### PR TITLE
Scanning packages config

### DIFF
--- a/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -8,6 +8,12 @@ namespace NuKeeper.Tests.RepositoryInspection
     [TestFixture]
     public class PackagesFileReaderTests
     {
+        private const string PackagesFileWithPackages = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<packages>
+  <package id=""foo"" version=""1.2.3.4"" targetFramework=""net45"" />
+  <package id=""bar"" version=""2.3.4.5"" targetFramework=""net45"" />
+</packages>";
+
         [Test]
         public void EmptyPackagesListShouldBeParsed()
         {
@@ -57,20 +63,28 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void TwoPackagesShouldBeRead()
         {
-            const string packagesFile =
-                @"<?xml version=""1.0"" encoding=""utf-8""?>
-<packages>
-  <package id=""foo"" version=""1.2.3.4"" targetFramework=""net45"" />
-  <package id=""bar"" version=""2.3.4.5"" targetFramework=""net45"" />
-</packages>";
-
-            var packages = PackagesFileReader.Read(packagesFile)
+            var packages = PackagesFileReader.Read(PackagesFileWithPackages)
                 .ToList();
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages.Count, Is.EqualTo(2));
             Assert.That(packages[0].Id, Is.EqualTo("foo"));
             Assert.That(packages[1].Id, Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            const string marker = "marker";
+
+            var packages = PackagesFileReader.Read(PackagesFileWithPackages);
+
+            foreach (var package in packages)
+            {
+                package.SourceFilePath = marker;
+            }
+
+            Assert.That(packages.Select(p => p.SourceFilePath), Is.All.EqualTo(marker));
         }
     }
 }

--- a/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -125,5 +125,20 @@ namespace NuKeeper.Tests.RepositoryInspection
             Assert.That(packages[0].Id, Is.EqualTo("foo"));
             Assert.That(packages[1].Id, Is.EqualTo("bar"));
         }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            const string marker = "marker";
+
+            var packages = ProjectFileReader.Read(Vs2017ProjectFileTemplateWithPackages);
+
+            foreach (var package in packages)
+            {
+                package.SourceFilePath = marker;
+            }
+
+            Assert.That(packages.Select(p=>p.SourceFilePath), Is.All.EqualTo(marker));
+        }
     }
 }

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.RepositoryInspection
             var packageNodeList = packagesNode.Elements()
                 .Where(x => x.Name == "package");
 
-            return packageNodeList.Select(XmlToPackage);
+            return packageNodeList.Select(XmlToPackage).ToList();
         }
 
         private static NugetPackage XmlToPackage(XElement el)

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -59,18 +59,17 @@ namespace NuKeeper.RepositoryInspection
 
             foreach (var fileName in files)
             {
-                if (string.Equals(fileName, "packages.config"))
+                var fileNameWithoutPath = Path.GetFileName(fileName);
+                if (string.Equals(fileNameWithoutPath, "packages.config"))
                 {
-                    var packagesFullPath = Path.Combine(dir, fileName);
-                    var packages = PackagesFileReader.ReadFile(packagesFullPath);
-                    SetSourceFilePath(packages, packagesFullPath);
+                    var packages = PackagesFileReader.ReadFile(fileName);
+                    SetSourceFilePath(packages, fileName);
                     result.AddRange(packages);
                 }
                 else if (fileName.EndsWith(".csproj"))
                 {
-                    var csprojFullPath = Path.Combine(dir, fileName);
-                    var packages = ProjectFileReader.ReadFile(csprojFullPath);
-                    SetSourceFilePath(packages, csprojFullPath);
+                    var packages = ProjectFileReader.ReadFile(fileName);
+                    SetSourceFilePath(packages, fileName);
                     result.AddRange(packages);
                 }
             }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You will need [a github api token](https://github.com/blog/1509-personal-api-tok
 
 ## Repository mode
 
-Will PR a a single repository. Point it at the https url of a github repo, like this:
+Will PR a single repository. Point it at the https url of a github repo, like this:
 
 syntax:
 ```


### PR DESCRIPTION
This fixes scanning old style packages.config and improves performance by only contacting nuget.org once per package Id.

Unfortunately, this is not yet enough to work for old style projects (at least for me), as `dotnet add package` still fails for me with

```
error: Value cannot be null.
error: Parameter name: projectUniqueName
```