### PR TITLE
Package path

### DIFF
--- a/NuKeeper.Tests/RepositoryInspection/PackagePathTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackagePathTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class PackagePathTests
+    {
+        [Test]
+        public void ConstructorShouldProduceExpectedSimpleProps()
+        {
+            var path = new PackagePath("c:\\temp\\somefolder", "\\checkout1\\src\\myproj.csproj");
+
+            Assert.That(path.BaseDirectory, Is.EqualTo("c:\\temp\\somefolder"));
+            Assert.That(path.RelativePath, Is.EqualTo("checkout1\\src\\myproj.csproj"));
+        }
+
+        [Test]
+        public void ConstructorShouldProduceExpectedCalculatedProps()
+        {
+            var path = new PackagePath("c:\\temp\\somefolder", "checkout1\\src\\myproj.csproj");
+
+
+            Assert.That(path.FullDirectory, Is.EqualTo("c:\\temp\\somefolder\\checkout1\\src"));
+            Assert.That(path.FullPath, Is.EqualTo("c:\\temp\\somefolder\\checkout1\\src\\myproj.csproj"));
+            Assert.That(path.FileName, Is.EqualTo("myproj.csproj"));
+        }
+
+        [Test]
+        public void ConstructorShouldProduceExpectedCalculatedPropsWithExtraSlash()
+        {
+            var path = new PackagePath("c:\\temp\\somefolder", "\\checkout1\\src\\myproj.csproj");
+
+
+            Assert.That(path.BaseDirectory, Is.EqualTo("c:\\temp\\somefolder"));
+            Assert.That(path.RelativePath, Is.EqualTo("checkout1\\src\\myproj.csproj"));
+            Assert.That(path.FullDirectory, Is.EqualTo("c:\\temp\\somefolder\\checkout1\\src"));
+            Assert.That(path.FullPath, Is.EqualTo("c:\\temp\\somefolder\\checkout1\\src\\myproj.csproj"));
+            Assert.That(path.FileName, Is.EqualTo("myproj.csproj"));
+        }
+    }
+}

--- a/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 <packages>
 </packages>";
 
-            var packages = PackagesFileReader.Read(emptyContents);
+            var packages = PackagesFileReader.Read(emptyContents, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -37,7 +37,7 @@ namespace NuKeeper.Tests.RepositoryInspection
   <package id=""foo"" version=""1.2.3.4"" targetFramework=""net45"" />
 </packages>";
 
-            var packages = PackagesFileReader.Read(singlePackage);
+            var packages = PackagesFileReader.Read(singlePackage, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Not.Empty);
@@ -52,7 +52,7 @@ namespace NuKeeper.Tests.RepositoryInspection
   <package id=""foo"" version=""1.2.3.4"" targetFramework=""net45"" />
 </packages>";
 
-            var packages = PackagesFileReader.Read(singlePackage);
+            var packages = PackagesFileReader.Read(singlePackage, TempPath());
 
             var package = packages.FirstOrDefault();
             Assert.That(package, Is.Not.Null);
@@ -63,7 +63,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void TwoPackagesShouldBeRead()
         {
-            var packages = PackagesFileReader.Read(PackagesFileWithPackages)
+            var packages = PackagesFileReader.Read(PackagesFileWithPackages, TempPath())
                 .ToList();
 
             Assert.That(packages, Is.Not.Null);
@@ -75,16 +75,21 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void ResultIsReiterable()
         {
-            const string marker = "marker";
+            var path = TempPath();
 
-            var packages = PackagesFileReader.Read(PackagesFileWithPackages);
+            var packages = PackagesFileReader.Read(PackagesFileWithPackages, path);
 
             foreach (var package in packages)
             {
-                package.SourceFilePath = marker;
+                Assert.That(package, Is.Not.Null);
             }
 
-            Assert.That(packages.Select(p => p.SourceFilePath), Is.All.EqualTo(marker));
+            Assert.That(packages.Select(p => p.Path), Is.All.EqualTo(path));
+        }
+
+        private PackagePath TempPath()
+        {
+            return new PackagePath("c:\\temp\\somewhere", "src\\packages.config");
         }
     }
 }

--- a/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 <foo>
 </foo>";
 
-            var packages = ProjectFileReader.Read(NoProject);
+            var packages = ProjectFileReader.Read(NoProject, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -53,7 +53,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 <Project>
 </Project>";
 
-            var packages = ProjectFileReader.Read(NoProject);
+            var packages = ProjectFileReader.Read(NoProject, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -62,7 +62,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void ProjectWithoutPackageListCanBeRead()
         {
-            var packages = ProjectFileReader.Read(Vs2017ProjectFileTemplateWithoutPackages);
+            var packages = ProjectFileReader.Read(Vs2017ProjectFileTemplateWithoutPackages, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -73,7 +73,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         {
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", "");
 
-            var packages = ProjectFileReader.Read(projectFile);
+            var packages = ProjectFileReader.Read(projectFile, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -86,7 +86,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
-            var packages = ProjectFileReader.Read(projectFile);
+            var packages = ProjectFileReader.Read(projectFile, TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Not.Empty);
@@ -99,7 +99,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
-            var packages = ProjectFileReader.Read(projectFile);
+            var packages = ProjectFileReader.Read(projectFile, TempPath());
 
             var package = packages.FirstOrDefault();
 
@@ -117,7 +117,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
-            var packages = ProjectFileReader.Read(projectFile)
+            var packages = ProjectFileReader.Read(projectFile, TempPath())
                 .ToList();
 
             Assert.That(packages, Is.Not.Null);
@@ -129,16 +129,21 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void ResultIsReiterable()
         {
-            const string marker = "marker";
+            var path = TempPath();
 
-            var packages = ProjectFileReader.Read(Vs2017ProjectFileTemplateWithPackages);
+            var packages = ProjectFileReader.Read(Vs2017ProjectFileTemplateWithPackages, path);
 
             foreach (var package in packages)
             {
-                package.SourceFilePath = marker;
+                Assert.That(package, Is.Not.Null);
             }
 
-            Assert.That(packages.Select(p=>p.SourceFilePath), Is.All.EqualTo(marker));
+            Assert.That(packages.Select(p=>p.Path), Is.All.EqualTo(path));
+        }
+
+        private PackagePath TempPath()
+        {
+            return new PackagePath("c:\\temp\\somewhere", "src\\packages.config");
         }
     }
 }

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -5,14 +5,14 @@ using NuKeeper.NuGet.Api;
 
 namespace NuKeeper.Engine
 {
-    public class CommitReport
+    public static class CommitReport
     { 
-        public string MakeCommitMessage(List<PackageUpdate> updates)
+        public static string MakeCommitMessage(List<PackageUpdate> updates)
         {
             return $"Automatic update of {updates[0].PackageId} to {updates[0].NewVersion}";
         }
 
-        public string MakeCommitDetails(List<PackageUpdate> updates)
+        public static string MakeCommitDetails(List<PackageUpdate> updates)
         {
             var oldVersions = updates
                 .Select(u => CodeQuote(u.OldVersion.ToString()))

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NuKeeper.Nuget.Api;
@@ -7,14 +6,7 @@ using NuKeeper.Nuget.Api;
 namespace NuKeeper.Engine
 {
     public class CommitReport
-    {
-        private readonly string _baseDir;
-
-        public CommitReport(string baseDir)
-        {
-            _baseDir = baseDir;
-        }
-
+    { 
         public string MakeCommitMessage(List<PackageUpdate> updates)
         {
             return $"Automatic update of {updates[0].PackageId} to {updates[0].NewVersion}";
@@ -52,8 +44,7 @@ namespace NuKeeper.Engine
 
             foreach (var update in updates)
             {
-                var relativePath = update.CurrentPackage.SourceFilePath.Replace(_baseDir, String.Empty);
-                var line = $"Updated {CodeQuote(relativePath)} to {packageId} {CodeQuote(update.NewVersion.ToString())} from {CodeQuote(update.OldVersion.ToString())}";
+                var line = $"Updated {CodeQuote(update.CurrentPackage.Path.RelativePath)} to {packageId} {CodeQuote(update.NewVersion.ToString())} from {CodeQuote(update.OldVersion.ToString())}";
 
                 builder.AppendLine(line);
             }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -107,8 +107,7 @@ namespace NuKeeper.Engine
 
             Console.WriteLine("Commiting");
 
-            var reporter = new CommitReport();
-            var commitMessage = reporter.MakeCommitMessage(updates);
+            var commitMessage = CommitReport.MakeCommitMessage(updates);
             await _git.Commit(commitMessage);
 
             Console.WriteLine($"Pushing branch '{branchName}'");
@@ -122,7 +121,7 @@ namespace NuKeeper.Engine
                 Data = new PullRequestData
                 {
                     Title = commitMessage,
-                    Body = reporter.MakeCommitDetails(updates),
+                    Body = CommitReport.MakeCommitDetails(updates),
                     Base = "master",
                     Head = branchName
                 },

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -107,7 +107,7 @@ namespace NuKeeper.Engine
 
             Console.WriteLine("Commiting");
 
-            var reporter = new CommitReport(_tempDir);
+            var reporter = new CommitReport();
             var commitMessage = reporter.MakeCommitMessage(updates);
             await _git.Commit(commitMessage);
 

--- a/NuKeeper/Github/GithubClient.cs
+++ b/NuKeeper/Github/GithubClient.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NuKeeper.Configuration;
 
 namespace NuKeeper.Github

--- a/NuKeeper/Github/GithubRepository.cs
+++ b/NuKeeper/Github/GithubRepository.cs
@@ -1,6 +1,4 @@
-﻿using NuKeeper.Configuration;
-
-namespace NuKeeper.Github
+﻿namespace NuKeeper.Github
 {
     public class GithubRepository
     {

--- a/NuKeeper/Nuget/Process/NugetUpdater.cs
+++ b/NuKeeper/Nuget/Process/NugetUpdater.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.Threading.Tasks;
 using NuKeeper.Nuget.Api;
 using NuKeeper.ProcessRunner;
-using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Nuget.Process
 {

--- a/NuKeeper/Nuget/Process/NugetUpdater.cs
+++ b/NuKeeper/Nuget/Process/NugetUpdater.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Nuget.Process
 
         public async Task UpdatePackage(PackageUpdate update)
         {
-            var dirName = Path.GetDirectoryName(update.CurrentPackage.SourceFilePath);
+            var dirName = update.CurrentPackage.Path.FullDirectory;
             var updateCommand = $"cd {dirName} & dotnet add package {update.PackageId} -v {update.NewVersion}";
             Console.WriteLine(updateCommand);
             await RunExternalCommand(updateCommand);

--- a/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace NuKeeper.RepositoryInspection
+{
+    public static class DirectoryExclusions
+    {
+        private static readonly List<string> _excludedDirNames = new List<string>
+        {
+            ".git",
+            ".vs",
+            "obj",
+            "bin",
+            "node_modules",
+            "packages"
+        };
+
+        public static bool PathIsExcluded(string path)
+        {
+            // subDir is a full path, check the last part
+            var dirName = new DirectoryInfo(path).Name;
+            return IsExcluded(dirName);
+        }
+
+        public static bool IsExcluded(string dirName)
+        {
+            return _excludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
@@ -7,6 +7,18 @@ namespace NuKeeper.RepositoryInspection
 {
     public static class DirectoryExclusions
     {
+        public static bool PathIsExcluded(string path)
+        {
+            // subDir is a full path, check the last part
+            var dirName = new DirectoryInfo(path).Name;
+            return IsExcluded(dirName);
+        }
+
+        private static bool IsExcluded(string dirName)
+        {
+            return _excludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
+        }
+
         private static readonly List<string> _excludedDirNames = new List<string>
         {
             ".git",
@@ -16,17 +28,5 @@ namespace NuKeeper.RepositoryInspection
             "node_modules",
             "packages"
         };
-
-        public static bool PathIsExcluded(string path)
-        {
-            // subDir is a full path, check the last part
-            var dirName = new DirectoryInfo(path).Name;
-            return IsExcluded(dirName);
-        }
-
-        public static bool IsExcluded(string dirName)
-        {
-            return _excludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
-        }
     }
 }

--- a/NuKeeper/RepositoryInspection/NugetPackage.cs
+++ b/NuKeeper/RepositoryInspection/NugetPackage.cs
@@ -4,18 +4,20 @@ namespace NuKeeper.RepositoryInspection
 {
     public class NugetPackage
     {
-        public NugetPackage(string id, NuGetVersion version)
+        public NugetPackage(string id, NuGetVersion version, PackagePath packagePath)
         {
             Id = id;
             Version = version;
+            Path = packagePath;
         }
 
-        public NugetPackage(string id, string version) : this(id, new NuGetVersion(version))
+        public NugetPackage(string id, string version, PackagePath packagePath) 
+            : this(id, new NuGetVersion(version), packagePath)
         {
         }
 
         public string Id { get; }
         public NuGetVersion Version { get; }
-        public string SourceFilePath { get; set; }
+        public PackagePath Path { get; }
     }
 }

--- a/NuKeeper/RepositoryInspection/PackagePath.cs
+++ b/NuKeeper/RepositoryInspection/PackagePath.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+
+namespace NuKeeper.RepositoryInspection
+{
+    public class PackagePath
+    {
+        public PackagePath(string baseDirectory, string relativePath)
+        {
+            if (string.IsNullOrWhiteSpace(baseDirectory))
+            {
+                throw new ArgumentException(nameof(baseDirectory));
+            }
+
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                throw new ArgumentException(nameof(relativePath));
+            }
+
+            if (relativePath[0] == Path.DirectorySeparatorChar)
+            {
+                relativePath = relativePath.Substring(1);
+            }
+
+            BaseDirectory = baseDirectory;
+            RelativePath = relativePath;
+
+            FileName = Path.GetFileName(relativePath);
+
+            FullPath = Path.Combine(baseDirectory, relativePath);
+            FullDirectory = Path.GetDirectoryName(FullPath);
+        }
+
+        /// <summary>
+        /// The working directory at the root of all the files
+        /// </summary>
+        public string BaseDirectory { get; }
+
+        /// <summary>
+        /// The full directory path to the file, without file name
+        /// </summary>
+        public string FullDirectory { get; }
+
+        /// <summary>
+        /// Path from BaseDirectory to the file, includes file name
+        /// </summary>
+        public string RelativePath { get; }
+
+        /// <summary>
+        /// Just the file name
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Full path to the file
+        /// </summary>
+        public string FullPath { get; }
+    }
+}

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -7,13 +7,13 @@ namespace NuKeeper.RepositoryInspection
 {
     public static class PackagesFileReader
     {
-        public static IEnumerable<NugetPackage> ReadFile(string fileName)
+        public static IEnumerable<NugetPackage> ReadFile(PackagePath path)
         {
-            var fileContents = File.ReadAllText(fileName);
-            return Read(fileContents);
+            var fileContents = File.ReadAllText(path.FullPath);
+            return Read(fileContents, path);
         }
 
-        public static IEnumerable<NugetPackage> Read(string fileContents)
+        public static IEnumerable<NugetPackage> Read(string fileContents, PackagePath path)
         {
             var xml = XDocument.Parse(fileContents);
 
@@ -26,15 +26,17 @@ namespace NuKeeper.RepositoryInspection
             var packageNodeList = packagesNode.Elements()
                 .Where(x => x.Name == "package");
 
-            return packageNodeList.Select(XmlToPackage).ToList();
+            return packageNodeList
+                .Select(el => XmlToPackage(el, path))
+                .ToList();
         }
 
-        private static NugetPackage XmlToPackage(XElement el)
+        private static NugetPackage XmlToPackage(XElement el, PackagePath path)
         {
             var id = el.Attribute("id")?.Value;
             var version = el.Attribute("version")?.Value;
 
-            return new NugetPackage(id, version);
+            return new NugetPackage(id, version, path);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -7,13 +8,13 @@ namespace NuKeeper.RepositoryInspection
 {
     public static class ProjectFileReader
     {
-        public static IEnumerable<NugetPackage> ReadFile(string fileName)
+        public static IEnumerable<NugetPackage> ReadFile(PackagePath path)
         {
-            var fileContents = File.ReadAllText(fileName);
-            return Read(fileContents);
+            var fileContents = File.ReadAllText(path.FullPath);
+            return Read(fileContents, path);
         }
 
-        public static IEnumerable<NugetPackage> Read(string fileContents)
+        public static IEnumerable<NugetPackage> Read(string fileContents, PackagePath path)
         {
             var xml = XDocument.Parse(fileContents);
             var project = xml.Element("Project");
@@ -27,16 +28,16 @@ namespace NuKeeper.RepositoryInspection
             var packageRefs = itemGroups.SelectMany(ig => ig.Elements("PackageReference"));
 
             return packageRefs
-                .Select(XmlToPackage)
+                .Select(el => XmlToPackage(el, path))
                 .ToList();
         }
 
-        private static NugetPackage XmlToPackage(XElement el)
+        private static NugetPackage XmlToPackage(XElement el, PackagePath path)
         {
             var id = el.Attribute("Include")?.Value;
             var version = el.Attribute("Version")?.Value;
 
-            return new NugetPackage(id, version);
+            return new NugetPackage(id, version, path);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace NuKeeper.RepositoryInspection
 {
@@ -14,22 +13,20 @@ namespace NuKeeper.RepositoryInspection
               throw new Exception($"No such directory: '{rootDirectory}'");
             }
 
-            return FindNugetPackagesInDirRecursive(rootDirectory);
+            return FindNugetPackagesInDirRecursive(rootDirectory, rootDirectory);
         }
 
-        private IEnumerable<NugetPackage> FindNugetPackagesInDirRecursive(string dir)
+        private IEnumerable<NugetPackage> FindNugetPackagesInDirRecursive(string rootDir, string dir)
         {
-            var current = ScanForNugetPackages(dir);
+            var current = ScanForNugetPackages(rootDir, dir);
 
             var subDirs = Directory.EnumerateDirectories(dir);
                 
             foreach (var subDir in subDirs)
             {
-                // subDir is a full path, check the last part
-                var dirName = new DirectoryInfo(subDir).Name;
-                if (!IsExcluded(dirName))
+                if (!DirectoryExclusions.PathIsExcluded(subDir))
                 {
-                    var subdirPackages = FindNugetPackagesInDirRecursive(subDir);
+                    var subdirPackages = FindNugetPackagesInDirRecursive(rootDir, subDir);
                     current.AddRange(subdirPackages);
                 }
             }
@@ -37,22 +34,7 @@ namespace NuKeeper.RepositoryInspection
             return current;
         }
 
-        private readonly List<string> _excludedDirNames = new List<string>
-        {
-            ".git",
-            ".vs",
-            "obj",
-            "bin",
-            "node_modules",
-            "packages"
-        };
-
-        private bool IsExcluded(string dirName)
-        {
-            return _excludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private List<NugetPackage> ScanForNugetPackages(string dir)
+        private List<NugetPackage> ScanForNugetPackages(string rootDir, string dir)
         {
             var result = new List<NugetPackage>();
             var files = Directory.EnumerateFiles(dir);
@@ -60,16 +42,17 @@ namespace NuKeeper.RepositoryInspection
             foreach (var fileName in files)
             {
                 var fileNameWithoutPath = Path.GetFileName(fileName);
+
                 if (string.Equals(fileNameWithoutPath, "packages.config"))
                 {
-                    var packages = PackagesFileReader.ReadFile(fileName);
-                    SetSourceFilePath(packages, fileName);
+                    var path = MakePackagePath(rootDir, fileName);
+                    var packages = PackagesFileReader.ReadFile(path);
                     result.AddRange(packages);
                 }
                 else if (fileName.EndsWith(".csproj"))
                 {
-                    var packages = ProjectFileReader.ReadFile(fileName);
-                    SetSourceFilePath(packages, fileName);
+                    var path = MakePackagePath(rootDir, fileName);
+                    var packages = ProjectFileReader.ReadFile(path);
                     result.AddRange(packages);
                 }
             }
@@ -77,12 +60,10 @@ namespace NuKeeper.RepositoryInspection
             return result;
         }
 
-        private void SetSourceFilePath(IEnumerable<NugetPackage> packages, string sourceFilePath)
+        private PackagePath MakePackagePath(string rootDir, string fileName)
         {
-            foreach (var package in packages)
-            {
-                package.SourceFilePath = sourceFilePath;
-            }
+            var relativeFileName = fileName.Replace(rootDir, string.Empty);
+            return new PackagePath(rootDir, relativeFileName);
         }
     }
 }


### PR DESCRIPTION
Following up from Dan on Friday, commenting that the `NugetPackage` (i.e. data about a package used in a project) should know about the file path, including the base dir, so that the `CommitReport` doesn't have to be given the base path and do this work.

Made an object `PackagePath` to hold all of that, and a `NugetPackage` has one. 
Calculate all the path parts upfront.

Upside is that every package read from the same file will share one.

also extracted the `DirectoryExclusions` class - this needs a test now.