### PR TITLE
Change NuGet capitalisation to how main project prefers it

### DIFF
--- a/NuKeeper.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -14,7 +14,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         {
             var scanner = new RepositoryScanner();
 
-            Assert.Throws<Exception>(() => scanner.FindAllNugetPackages("fish"));
+            Assert.Throws<Exception>(() => scanner.FindAllNuGetPackages("fish"));
         }
 
         [Test]
@@ -22,7 +22,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         {
             var scanner = new RepositoryScanner();
 
-            var results = scanner.FindAllNugetPackages(TempFiles.MakeUniqueTemporaryPath());
+            var results = scanner.FindAllNuGetPackages(TempFiles.MakeUniqueTemporaryPath());
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -35,7 +35,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 
             var scanner = new RepositoryScanner();
 
-            var results = scanner.FindAllNugetPackages(basePath);
+            var results = scanner.FindAllNuGetPackages(basePath);
 
             Assert.That(results, Is.Not.Null, "in folder" + basePath);
             Assert.That(results, Is.Not.Empty, "in folder" + basePath);

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using NuKeeper.Nuget.Api;
+using NuKeeper.NuGet.Api;
 
 namespace NuKeeper.Engine
 {

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -5,8 +5,8 @@ using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Git;
 using NuKeeper.Github;
-using NuKeeper.Nuget.Api;
-using NuKeeper.Nuget.Process;
+using NuKeeper.NuGet.Api;
+using NuKeeper.NuGet.Process;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
@@ -42,7 +42,7 @@ namespace NuKeeper.Engine
 
             // scan for nuget packages
             var repoScanner = new RepositoryScanner();
-            var packages = repoScanner.FindAllNugetPackages(_tempDir)
+            var packages = repoScanner.FindAllNuGetPackages(_tempDir)
                 .ToList();
 
             var packageNames = string.Join(",", packages.Take(10).Select(p => p.Id));
@@ -98,7 +98,7 @@ namespace NuKeeper.Engine
 
             Console.WriteLine($"Using branch '{branchName}'");
 
-            var nugetUpdater = new NugetUpdater();
+            var nugetUpdater = new NuGetUpdater();
 
             foreach (var update in updates)
             {

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -7,7 +7,7 @@ using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public class ApiPackageLookup : IApiPackageLookup
     {

--- a/NuKeeper/NuGet/Api/ConsoleLogger.cs
+++ b/NuKeeper/NuGet/Api/ConsoleLogger.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NuGet.Common;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public class ConsoleLogger : ILogger
     {

--- a/NuKeeper/NuGet/Api/IApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IApiPackageLookup.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public interface IApiPackageLookup
     {

--- a/NuKeeper/NuGet/Api/IPackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/IPackageUpdatesLookup.cs
@@ -2,10 +2,10 @@
 using System.Threading.Tasks;
 using NuKeeper.RepositoryInspection;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public interface IPackageUpdatesLookup
     {
-        Task<List<PackageUpdate>> FindUpdatesForPackages(List<NugetPackage> packages);
+        Task<List<PackageUpdate>> FindUpdatesForPackages(List<NuGetPackage> packages);
     }
 }

--- a/NuKeeper/NuGet/Api/PackageUpdate.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdate.cs
@@ -2,17 +2,17 @@
 using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public class PackageUpdate
     {
-        public PackageUpdate(NugetPackage currentPackage, PackageIdentity newPackageIdentity)
+        public PackageUpdate(NuGetPackage currentPackage, PackageIdentity newPackageIdentity)
         {
             CurrentPackage = currentPackage;
             NewPackageIdentity = newPackageIdentity;
         }
 
-        public NugetPackage CurrentPackage { get; }
+        public NuGetPackage CurrentPackage { get; }
         public PackageIdentity NewPackageIdentity { get; }
 
         public string PackageId => CurrentPackage.Id;

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
 using NuKeeper.RepositoryInspection;
 
-namespace NuKeeper.Nuget.Api
+namespace NuKeeper.NuGet.Api
 {
     public class PackageUpdatesLookup : IPackageUpdatesLookup
     {
@@ -15,7 +15,7 @@ namespace NuKeeper.Nuget.Api
             _packageLookup = packageLookup;
         }
 
-        public async Task<List<PackageUpdate>> FindUpdatesForPackages(List<NugetPackage> packages)
+        public async Task<List<PackageUpdate>> FindUpdatesForPackages(List<NuGetPackage> packages)
         {
             var result = new List<PackageUpdate>();
 
@@ -34,7 +34,7 @@ namespace NuKeeper.Nuget.Api
             return result;
         }
 
-        private async Task<Dictionary<string, IPackageSearchMetadata>> BuildVersionsDictionary(IEnumerable<NugetPackage> packages)
+        private async Task<Dictionary<string, IPackageSearchMetadata>> BuildVersionsDictionary(IEnumerable<NuGetPackage> packages)
         {
             var result = new Dictionary<string, IPackageSearchMetadata>();
 

--- a/NuKeeper/NuGet/Process/INuGetUpdater.cs
+++ b/NuKeeper/NuGet/Process/INuGetUpdater.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading.Tasks;
-using NuKeeper.Nuget.Api;
+using NuKeeper.NuGet.Api;
 
-namespace NuKeeper.Nuget.Process
+namespace NuKeeper.NuGet.Process
 {
-    public interface INugetUpdater
+    public interface INuGetUpdater
     {
         Task UpdatePackage(PackageUpdate update);
     }

--- a/NuKeeper/NuGet/Process/NuGetUpdater.cs
+++ b/NuKeeper/NuGet/Process/NuGetUpdater.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using NuKeeper.Nuget.Api;
+using NuKeeper.NuGet.Api;
 using NuKeeper.ProcessRunner;
-using NuKeeper.RepositoryInspection;
 
-namespace NuKeeper.Nuget.Process
+namespace NuKeeper.NuGet.Process
 {
-    public class NugetUpdater : INugetUpdater
+    public class NuGetUpdater : INuGetUpdater
     {
         private readonly IExternalProcess _externalProcess;
 
-        public NugetUpdater(IExternalProcess externalProcess = null)
+        public NuGetUpdater(IExternalProcess externalProcess = null)
         {
             _externalProcess = externalProcess ?? new ExternalProcess();
         }

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Github;
-using NuKeeper.Nuget.Api;
+using NuKeeper.NuGet.Api;
 
 namespace NuKeeper
 {

--- a/NuKeeper/RepositoryInspection/IRepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/IRepositoryScanner.cs
@@ -4,6 +4,6 @@ namespace NuKeeper.RepositoryInspection
 {
     public interface IRepositoryScanner
     {
-        IEnumerable<NugetPackage> FindAllNugetPackages(string rootDirectory);
+        IEnumerable<NuGetPackage> FindAllNuGetPackages(string rootDirectory);
     }
 }

--- a/NuKeeper/RepositoryInspection/NuGetPackage.cs
+++ b/NuKeeper/RepositoryInspection/NuGetPackage.cs
@@ -2,15 +2,15 @@
 
 namespace NuKeeper.RepositoryInspection
 {
-    public class NugetPackage
+    public class NuGetPackage
     {
-        public NugetPackage(string id, NuGetVersion version)
+        public NuGetPackage(string id, NuGetVersion version)
         {
             Id = id;
             Version = version;
         }
 
-        public NugetPackage(string id, string version) : this(id, new NuGetVersion(version))
+        public NuGetPackage(string id, string version) : this(id, new NuGetVersion(version))
         {
         }
 

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -7,20 +7,20 @@ namespace NuKeeper.RepositoryInspection
 {
     public static class PackagesFileReader
     {
-        public static IEnumerable<NugetPackage> ReadFile(string fileName)
+        public static IEnumerable<NuGetPackage> ReadFile(string fileName)
         {
             var fileContents = File.ReadAllText(fileName);
             return Read(fileContents);
         }
 
-        public static IEnumerable<NugetPackage> Read(string fileContents)
+        public static IEnumerable<NuGetPackage> Read(string fileContents)
         {
             var xml = XDocument.Parse(fileContents);
 
             var packagesNode = xml.Element("packages");
             if (packagesNode == null)
             {
-                return Enumerable.Empty<NugetPackage>();
+                return Enumerable.Empty<NuGetPackage>();
             }
 
             var packageNodeList = packagesNode.Elements()
@@ -29,12 +29,12 @@ namespace NuKeeper.RepositoryInspection
             return packageNodeList.Select(XmlToPackage).ToList();
         }
 
-        private static NugetPackage XmlToPackage(XElement el)
+        private static NuGetPackage XmlToPackage(XElement el)
         {
             var id = el.Attribute("id")?.Value;
             var version = el.Attribute("version")?.Value;
 
-            return new NugetPackage(id, version);
+            return new NuGetPackage(id, version);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -7,20 +7,20 @@ namespace NuKeeper.RepositoryInspection
 {
     public static class ProjectFileReader
     {
-        public static IEnumerable<NugetPackage> ReadFile(string fileName)
+        public static IEnumerable<NuGetPackage> ReadFile(string fileName)
         {
             var fileContents = File.ReadAllText(fileName);
             return Read(fileContents);
         }
 
-        public static IEnumerable<NugetPackage> Read(string fileContents)
+        public static IEnumerable<NuGetPackage> Read(string fileContents)
         {
             var xml = XDocument.Parse(fileContents);
             var project = xml.Element("Project");
 
             if (project == null)
             {
-                return Enumerable.Empty<NugetPackage>();
+                return Enumerable.Empty<NuGetPackage>();
             }
 
             var itemGroups = project.Elements("ItemGroup");
@@ -31,12 +31,12 @@ namespace NuKeeper.RepositoryInspection
                 .ToList();
         }
 
-        private static NugetPackage XmlToPackage(XElement el)
+        private static NuGetPackage XmlToPackage(XElement el)
         {
             var id = el.Attribute("Include")?.Value;
             var version = el.Attribute("Version")?.Value;
 
-            return new NugetPackage(id, version);
+            return new NuGetPackage(id, version);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -7,19 +7,19 @@ namespace NuKeeper.RepositoryInspection
 {
     public class RepositoryScanner: IRepositoryScanner
     {
-        public IEnumerable<NugetPackage> FindAllNugetPackages(string rootDirectory)
+        public IEnumerable<NuGetPackage> FindAllNuGetPackages(string rootDirectory)
         {
             if (!Directory.Exists(rootDirectory))
             {
               throw new Exception($"No such directory: '{rootDirectory}'");
             }
 
-            return FindNugetPackagesInDirRecursive(rootDirectory);
+            return FindNuGetPackagesInDirRecursive(rootDirectory);
         }
 
-        private IEnumerable<NugetPackage> FindNugetPackagesInDirRecursive(string dir)
+        private IEnumerable<NuGetPackage> FindNuGetPackagesInDirRecursive(string dir)
         {
-            var current = ScanForNugetPackages(dir);
+            var current = ScanForNuGetPackages(dir);
 
             var subDirs = Directory.EnumerateDirectories(dir);
                 
@@ -29,7 +29,7 @@ namespace NuKeeper.RepositoryInspection
                 var dirName = new DirectoryInfo(subDir).Name;
                 if (!IsExcluded(dirName))
                 {
-                    var subdirPackages = FindNugetPackagesInDirRecursive(subDir);
+                    var subdirPackages = FindNuGetPackagesInDirRecursive(subDir);
                     current.AddRange(subdirPackages);
                 }
             }
@@ -52,9 +52,9 @@ namespace NuKeeper.RepositoryInspection
             return _excludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
         }
 
-        private List<NugetPackage> ScanForNugetPackages(string dir)
+        private List<NuGetPackage> ScanForNuGetPackages(string dir)
         {
-            var result = new List<NugetPackage>();
+            var result = new List<NuGetPackage>();
             var files = Directory.EnumerateFiles(dir);
 
             foreach (var fileName in files)
@@ -77,7 +77,7 @@ namespace NuKeeper.RepositoryInspection
             return result;
         }
 
-        private void SetSourceFilePath(IEnumerable<NugetPackage> packages, string sourceFilePath)
+        private void SetSourceFilePath(IEnumerable<NuGetPackage> packages, string sourceFilePath)
         {
             foreach (var package in packages)
             {


### PR DESCRIPTION
This one is a tad pedantic, so I won't be offended if you decide it's not worth it.

Only changes are updating the spelling to NuGet, how the projects spells it officially.