### PR TITLE
Updater for packages.config files

### DIFF
--- a/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -58,6 +58,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Id, Is.EqualTo("foo"));
             Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.PackageType, Is.EqualTo(PackageType.PackagesConfig));
         }
 
         [Test]

--- a/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -106,6 +106,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Id, Is.EqualTo("foo"));
             Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3")));
+            Assert.That(package.PackageType, Is.EqualTo(PackageType.ProjectFileReference));
         }
 
         [Test]

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -98,11 +98,13 @@ namespace NuKeeper.Engine
 
             Console.WriteLine($"Using branch '{branchName}'");
 
-            var nugetUpdater = new NuGetUpdater();
-
             foreach (var update in updates)
             {
-                await nugetUpdater.UpdatePackage(update);
+                var updater = update.CurrentPackage.PackageType == PackageType.ProjectFileReference
+                    ? (INuGetUpdater) new NuGetUpdater()
+                    : new PackagesConfigUpdater();
+
+                await updater.UpdatePackage(update);
             }
 
             Console.WriteLine("Commiting");

--- a/NuKeeper/NuGet/Process/NuGetUpdater.cs
+++ b/NuKeeper/NuGet/Process/NuGetUpdater.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.NuGet.Process
 
             if (!result.Success)
             {
-                throw new Exception($"Exit code: {result.ExitCode}\n\n{result.Output}");
+                throw new Exception($"Exit code: {result.ExitCode}\n\n{result.Output}\n\n{result.ErrorOutput}");
             }
         }
     }

--- a/NuKeeper/ProcessRunner/ExternalProcess.cs
+++ b/NuKeeper/ProcessRunner/ExternalProcess.cs
@@ -10,17 +10,20 @@ namespace NuKeeper.ProcessRunner
             var processInfo = new ProcessStartInfo("cmd.exe", "/C " + command)
             {
                 CreateNoWindow = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
 
             var process = Process.Start(processInfo);
 
             var textOut = await process.StandardOutput.ReadToEndAsync();
+            var errorOut = await process.StandardError.ReadToEndAsync();
+
             process.WaitForExit();
 
             var exitCode = process.ExitCode;
 
-            return new ProcessOutput(textOut, exitCode);
+            return new ProcessOutput(textOut, errorOut, exitCode);
         }
     }
 }

--- a/NuKeeper/ProcessRunner/ProcessOutput.cs
+++ b/NuKeeper/ProcessRunner/ProcessOutput.cs
@@ -2,13 +2,15 @@
 {
     public class ProcessOutput
     {
-        public ProcessOutput(string output, int exitCode)
+        public ProcessOutput(string output, string errorOutput, int exitCode)
         {
             Output = output;
+            ErrorOutput = errorOutput;
             ExitCode = exitCode;
         }
 
         public string Output { get; }
+        public string ErrorOutput { get; }
         public int ExitCode { get; }
 
         public bool Success => ExitCode == 0;

--- a/NuKeeper/RepositoryInspection/NuGetPackage.cs
+++ b/NuKeeper/RepositoryInspection/NuGetPackage.cs
@@ -4,18 +4,20 @@ namespace NuKeeper.RepositoryInspection
 {
     public class NuGetPackage
     {
-        public NuGetPackage(string id, NuGetVersion version, PackagePath path)
+        public NuGetPackage(string id, NuGetVersion version, PackagePath path, PackageType packageType)
         {
             Id = id;
             Version = version;
-			Path = path;
+            Path = path;
+            PackageType = packageType;
         }
 
-        public NuGetPackage(string id, string version,PackagePath path): 
-		  this(id, new NuGetVersion(version), path)
+        public NuGetPackage(string id, string version, PackagePath path, PackageType packageType) :
+            this(id, new NuGetVersion(version), path, packageType)
         {
         }
 
+        public PackageType PackageType { get; }
         public string Id { get; }
         public NuGetVersion Version { get; }
         public PackagePath Path { get; }

--- a/NuKeeper/RepositoryInspection/PackageType.cs
+++ b/NuKeeper/RepositoryInspection/PackageType.cs
@@ -1,0 +1,8 @@
+﻿namespace NuKeeper.RepositoryInspection
+{
+    public enum PackageType
+    {
+        PackagesConfig,
+        ProjectFileReference
+    }
+}

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -36,7 +36,7 @@ namespace NuKeeper.RepositoryInspection
             var id = el.Attribute("id")?.Value;
             var version = el.Attribute("version")?.Value;
 
-            return new NuGetPackage(id, version, path);
+            return new NuGetPackage(id, version, path, PackageType.PackagesConfig);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -36,7 +36,7 @@ namespace NuKeeper.RepositoryInspection
             var id = el.Attribute("Include")?.Value;
             var version = el.Attribute("Version")?.Value;
 
-            return new NuGetPackage(id, version, path);
+            return new NuGetPackage(id, version, path, PackageType.ProjectFileReference);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,5 +36,9 @@ Will discover repositories in that organisation and update them.
 C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> github_api_endpoint=https://api.github.com/ github_organisation_name=<OrgName>
 ```
 
+## Limitations
+
+For projects using `packages.config`, `NuGet.exe` no longer runs `install.ps1` and `uninstall.ps1` scripts from command line. Those are still executed from Visual Studio, resulting in different behaviour for packages relying on this functionality. An example of this is [StyleCop.Analyzers](https://www.nuget.org/packages/StyleCop.Analyzers/) which will not update the `<Analyzers>` node in the project file.
+
 Inspired by [Greenkeeper](https://greenkeeper.io/).
 


### PR DESCRIPTION
This follows on #30 change

Uses NuGet.exe installed as a package, however, there's a problem: behaviour of this tool is not the same as updating through Visual Studio UI. Main difference seems to be that install/uninstall PowerShell scripts aren't run.

Examples:
~https://www.nuget.org/packages/System.IO.Abstractions/ would add app.config assembly mappings, but command line doesn't do this~ for some reason this doesn't happen any more from UI either
https://www.nuget.org/packages/StyleCop.Analyzers/ would update analyzers in .csproj, but command line doesn't do this