### PR TITLE
Automatic update of EasyConfig.Net.Core to 1.0.6

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>NuKeeper</RootNamespace>
     <AssemblyName>NuKeeper</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="EasyConfig.Net.Core" Version="1.0.4" />
+    <PackageReference Include="EasyConfig.Net.Core" Version="1.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.0.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
NuKeeper has generated an update of `EasyConfig.Net.Core` from `1.0.4` to `1.0.6`
One project update:
Updated `NuKeeper\NuKeeper.csproj` to `EasyConfig.Net.Core` `1.0.6` from `1.0.4`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
