### PR TITLE
Clean-up previous runs at startup

### DIFF
--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -12,6 +12,8 @@ namespace NuKeeper
     {
         public static int Main(string[] args)
         {
+            TempFiles.DeleteExistingTempDirs();
+                
             var settings = CommandLineParser.ReadSettings(args);
 
             if (settings == null)

--- a/NuKeeper/TempFiles.cs
+++ b/NuKeeper/TempFiles.cs
@@ -5,10 +5,24 @@ namespace NuKeeper
 {
     public static class TempFiles
     {
+        private static string NuKeeperTempFilesPath()
+        {
+            return Path.Combine(Path.GetTempPath(), "NuKeeper");
+        }
+
+        public static void DeleteExistingTempDirs()
+        {
+            var dirs = Directory.EnumerateDirectories(NuKeeperTempFilesPath());
+            foreach (var dir in dirs)
+            {
+                TryDelete(dir);
+            }
+        }
+
         public static string GetUniqueTemporaryPath()
         {
             var uniqueName = Guid.NewGuid().ToString("N");
-            return Path.Combine(Path.GetTempPath(), "NuKeeper", uniqueName);
+            return Path.Combine(NuKeeperTempFilesPath(), uniqueName);
         }
 
         public static string MakeUniqueTemporaryPath()


### PR DESCRIPTION
Clean-up previous runs at startup
This works, to an extent. It deletes old files that aren't locked.