### PR TITLE
easyconfig configuration error handling to handle missing arguments

### DIFF
--- a/NuKeeper/Configuration/CommandLineArguments.cs
+++ b/NuKeeper/Configuration/CommandLineArguments.cs
@@ -5,7 +5,7 @@ namespace NuKeeper.Configuration
 {
     public class CommandLineArguments
     {
-        [CommandLine("mode")]
+        [CommandLine("mode"), Required]
         public string Mode;
 
         [CommandLine("github_token"), Required, SensitiveInformation]

--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -8,14 +8,8 @@ namespace NuKeeper.Configuration
     {
         public static Settings ReadSettings(string[] args)
         {
-            if (args.Length == 0)
-            {
-                Console.WriteLine("Please supply some command line arguments");
-                return null;
-            }
-
             var settings = Config.Populate<CommandLineArguments>(args);
-
+            
             Console.WriteLine($"Running NuKeeper in {settings.Mode} mode");
 
             switch (settings.Mode)

--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using EasyConfig;
-using EasyConfig.Exceptions;
 
 namespace NuKeeper.Configuration
 {
@@ -9,9 +8,10 @@ namespace NuKeeper.Configuration
     {
         public static Settings ReadSettings(string[] args)
         {
+            CommandLineArguments settings;
             try
             {
-                var settings = Config.Populate<CommandLineArguments>(args);
+                 settings = Config.Populate<CommandLineArguments>(args);
             }
             catch(Exception e)
             {

--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using EasyConfig;
+using EasyConfig.Exceptions;
 
 namespace NuKeeper.Configuration
 {
@@ -8,7 +9,15 @@ namespace NuKeeper.Configuration
     {
         public static Settings ReadSettings(string[] args)
         {
-            var settings = Config.Populate<CommandLineArguments>(args);
+            try
+            {
+                var settings = Config.Populate<CommandLineArguments>(args);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return null;
+            }
             
             Console.WriteLine($"Running NuKeeper in {settings.Mode} mode");
 

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -16,6 +16,7 @@ namespace NuKeeper
 
             if (settings == null)
             {
+                Console.WriteLine("Exiting early...");
                 return 1;
             }
 


### PR DESCRIPTION
The error handling will end up with a throw (and a dotnet core crash)

If that's acceptable to us, then easyconfig already has code in place for informative error handling (even if the elegance of it is questionable)

![example](https://user-images.githubusercontent.com/4104871/28066589-7e9451b2-6635-11e7-9340-8b0bc7041704.png)
