### PR TITLE
don't guess the api url

### DIFF
--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -35,12 +35,9 @@ namespace NuKeeper.Configuration
 
         private static RepositoryModeSettings ReadSettingsForRepositoryMode(CommandLineArguments settings)
         {
-            var githubToken = settings.GithubToken;
-            var githubRepoUri = settings.GithubRepositoryUri;
-
             // general pattern is https://github.com/owner/reponame.git
-            var githubHost = "https://api." + githubRepoUri.Host;
-            var path = githubRepoUri.AbsolutePath;
+            // from this we extract owner and repo name
+            var path = settings.GithubRepositoryUri.AbsolutePath;
             var pathParts = path.Split('/')
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();
@@ -50,9 +47,9 @@ namespace NuKeeper.Configuration
 
             return new RepositoryModeSettings
             {
-                GithubUri = githubRepoUri,
-                GithubToken = githubToken,
-                GithubApiBase = new Uri(githubHost),
+                GithubUri = settings.GithubRepositoryUri,
+                GithubToken = settings.GithubToken,
+                GithubApiBase = settings.GithubApiEndpoint,
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner
             };


### PR DESCRIPTION
In repo mode, don't guess the api url from the repo url
Allow it to be set from the commandline
It comes from the settings -  It's either the default value for github.com or it's specified on the commandline as "github_api_endpoint"

replaces https://github.com/NuKeeperDotNet/NuKeeper/pull/40