### PR TITLE
Automatic update of EasyConfig.Net.Core to 1.0.9

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>NuKeeper</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EasyConfig.Net.Core" Version="1.0.8" />
+    <PackageReference Include="EasyConfig.Net.Core" Version="1.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated an update of `EasyConfig.Net.Core` to `1.0.9` from `1.0.8`
1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `EasyConfig.Net.Core` `1.0.9` from `1.0.8`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
