### PR TITLE
Allow the max prs per repo to vary

### DIFF
--- a/NuKeeper/Configuration/CommandLineArguments.cs
+++ b/NuKeeper/Configuration/CommandLineArguments.cs
@@ -19,5 +19,8 @@ namespace NuKeeper.Configuration
 
         [CommandLine("github_api_endpoint", "api"), Default("https://api.github.com")]
         public Uri GithubApiEndpoint;
+
+        [CommandLine("max_pull_requests_per_repository", "max"), Default(3)]
+        public int MaxPullRequestsPerRepository { get; set; }
     }
 }

--- a/NuKeeper/Configuration/CommandLineArguments.cs
+++ b/NuKeeper/Configuration/CommandLineArguments.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Configuration
         [CommandLine("github_api_endpoint", "api"), Default("https://api.github.com")]
         public Uri GithubApiEndpoint;
 
-        [CommandLine("max_pull_requests_per_repository", "max"), Default(3)]
+        [CommandLine("max_pull_requests_per_repository", "maxpr"), Default(3)]
         public int MaxPullRequestsPerRepository { get; set; }
     }
 }

--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -52,7 +52,8 @@ namespace NuKeeper.Configuration
                 GithubToken = settings.GithubToken,
                 GithubApiBase = settings.GithubApiEndpoint,
                 RepositoryName = repoName,
-                RepositoryOwner = repoOwner
+                RepositoryOwner = repoOwner,
+                MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
             };
         }
 
@@ -66,7 +67,8 @@ namespace NuKeeper.Configuration
             {
                 GithubApiBase = githubHost,
                 GithubToken = githubToken,
-                OrganisationName = githubOrganisationName
+                OrganisationName = githubOrganisationName,
+                MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
             };
         }
     }

--- a/NuKeeper/Configuration/OrganisationModeSettings.cs
+++ b/NuKeeper/Configuration/OrganisationModeSettings.cs
@@ -7,5 +7,6 @@ namespace NuKeeper.Configuration
         public Uri GithubApiBase { get; set; }
         public string OrganisationName { get; set; }
         public string GithubToken { get; set; }
+        public int MaxPullRequestsPerRepository { get; set;  }
     }
 }

--- a/NuKeeper/Configuration/RepositoryModeSettings.cs
+++ b/NuKeeper/Configuration/RepositoryModeSettings.cs
@@ -9,13 +9,15 @@ namespace NuKeeper.Configuration
         {
         }
 
-        public RepositoryModeSettings(GithubRepository repository, Uri githubApi, string githubToken)
+        public RepositoryModeSettings(GithubRepository repository, 
+            Uri githubApi, string githubToken, int maxPullRequestsPerRepository)
         {
             GithubApiBase = githubApi;
             GithubToken = githubToken;
             GithubUri = new Uri(repository.HtmlUrl);
             RepositoryOwner = repository.Owner.Login;
             RepositoryName = repository.Name;
+            MaxPullRequestsPerRepository = maxPullRequestsPerRepository;
         }
 
         public Uri GithubUri { get; set; }
@@ -25,5 +27,7 @@ namespace NuKeeper.Configuration
 
         public string RepositoryOwner { get; set; }
         public string RepositoryName { get; set; }
+
+        public int MaxPullRequestsPerRepository { get; set; }
     }
 }

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -21,7 +21,9 @@ namespace NuKeeper.Engine
         {
             var repositories = await _github.GetRepositoriesForOrganisation(organisation.OrganisationName);
 
-            return repositories.Select(r => new RepositoryModeSettings(r, _settings.GithubApiBase, _settings.GithubToken));
+            return repositories.Select(r => new RepositoryModeSettings(r, 
+                    _settings.GithubApiBase, _settings.GithubToken, 
+                    organisation.MaxPullRequestsPerRepository));
         }
 
         public async Task<IEnumerable<RepositoryModeSettings>> GetRepositories()

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -73,13 +73,12 @@ namespace NuKeeper.Engine
             Console.WriteLine("Git clone complete");
         }
 
-        private static IEnumerable<IGrouping<string, PackageUpdate>> GroupUpdatesByPackageId(List<PackageUpdate> updates)
+        private IEnumerable<IGrouping<string, PackageUpdate>> GroupUpdatesByPackageId(List<PackageUpdate> updates)
         {
             // All packages that need update
             var updatesByPackage = updates.GroupBy(p => p.PackageId);
 
-            // todo make this number config
-            return updatesByPackage.Take(2);
+            return updatesByPackage.Take(_settings.MaxPullRequestsPerRepository);
         }
 
         private async Task UpdatePackageInProjects(string packageId, List<PackageUpdate> updates)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> g
 
  * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.
  * *github_token* You will need to [create a github personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) to authorise access to your github server in order to raise PRs. Be sure to check the "repo" scope when creating the token.
- *  *github_api_endpoint* This defaults to `https://api.github.com`. If you are using an internal github server and not the public one, it will need to be set to the api url for your github server. The correct value will be something like `https://github.mycompany.com/api/v3`. This applies to all modes.
- * *github_repository_uri* The repository to scan in repository mode.
- * *github_organisation_name* the organisation to scan in organisation mode.
+ * *github_repository_uri* The repository to scan. Required in `repository` mode, not used `organisation` mode.
+ * *github_organisation_name* the organisation to scan. Required in `organisation` mode, not used `repository` mode.
+ *  *github_api_endpoint* This defaults to `https://api.github.com`. If you are using an internal github server and not the public one, you must set it to the api url for your github server. The value will be e.g. `https://github.mycompany.com/api/v3`. This applies to all modes.
  * *max_pull_requests_per_repository* The maximum number of pull requests to raise on any repository. The default value is 3.
 
 ## When to use NuKeeper

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> g
 
 ### Command-line arguments
 
-| Name                             | Abbreviation | Default value          |
-|----------------------------------|--------------|------------------------|
-| mode                             | m            |                        |
-| github_token                     | t            |                        |
-| github_repository_uri            | repo         |                        |
-| github_organisation_name         | org          |                        |
-| github_api_endpoint              | api          | https://api.github.com |
-| max_pull_requests_per_repository | maxpr        | 3                      |
+| Name                             | Alias | Default value          | Required |
+|----------------------------------|-------|------------------------|----------|
+| mode                             | m     |                        | Yes      |
+| github_token                     | t     |                        | Yes      |
+| github_repository_uri            | repo  |                        | No       |
+| github_organisation_name         | org   |                        | No       |
+| github_api_endpoint              | api   | https://api.github.com | No       |
+| max_pull_requests_per_repository | maxpr | 3                      | No       |
 
 
  * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> g
 ### Command-line arguments
 
 | Name                             | Alias | Default value          | Required |
-|----------------------------------|-------|------------------------|----------|
-| mode                             | m     |                        | Yes      |
-| github_token                     | t     |                        | Yes      |
-| github_repository_uri            | repo  |                        | No       |
-| github_organisation_name         | org   |                        | No       |
-| github_api_endpoint              | api   | https://api.github.com | No       |
-| max_pull_requests_per_repository | maxpr | 3                      | No       |
+|----------------------------------|-------|------------------------|-----------------|
+| mode                             | m     |                        | Yes             |
+| github_token                     | t     |                        | Yes             |
+| github_repository_uri            | repo  |                        | Depends on mode |
+| github_organisation_name         | org   |                        | Depends on mode |
+| github_api_endpoint              | api   | https://api.github.com | No              |
+| max_pull_requests_per_repository | maxpr | 3                      | No              |
 
 
  * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> g
 
 ### Command-line arguments
 
+| Name                             | Abbreviation | Default value          |
+|----------------------------------|--------------|------------------------|
+| mode                             | m            |                        |
+| github_token                     | t            |                        |
+| github_repository_uri            | repo         |                        |
+| github_organisation_name         | org          |                        |
+| github_api_endpoint              | api          | https://api.github.com |
+| max_pull_requests_per_repository | max          | 3                      |
+
+
  * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.
  * *github_token* You will need to [create a github personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) to authorise access to your github server in order to raise PRs. Be sure to check the "repo" scope when creating the token.
  *  *github_api_endpoint* This defaults to `https://api.github.com`. If you are using an internal github server and not the public one, it will need to be set to the api url for your github server. The correct value will be something like `https://github.mycompany.com/api/v3`. This applies to all modes.
  * *github_repository_uri* The repository to scan in repository mode.
  * *github_organisation_name* the organisation to scan in organisation mode.
+ * *max_pull_requests_per_repository* The maximum number of pull requests to raise on any repository. The default value is 3.
 
 ## When to use NuKeeper
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ C:\Code\NuKeeper\NuKeeper>dotnet run mode=organisation github_token=<GitToken> g
 | github_repository_uri            | repo         |                        |
 | github_organisation_name         | org          |                        |
 | github_api_endpoint              | api          | https://api.github.com |
-| max_pull_requests_per_repository | max          | 3                      |
+| max_pull_requests_per_repository | maxpr        | 3                      |
 
 
  * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.


### PR DESCRIPTION
Allow the maximum pull requests per repo to vary based on a commandline arg
And readme docs
Naming suggestions are welcome, `max_pull_requests_per_repository` is a mouthful.
Also default is 3 not 2 - a bit less cautious.