### PR TITLE
Automatic update of NuGet.Protocol.Core.v3 to 4.2.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="1.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.0.0" />
+    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated an update of `NuGet.Protocol.Core.v3` to `4.2.0` from `4.0.0`
1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.Protocol.Core.v3` `4.2.0` from `4.0.0`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
