### PR TITLE
Fix args the simple way

### DIFF
--- a/NuKeeper/Configuration/CommandLineArguments.cs
+++ b/NuKeeper/Configuration/CommandLineArguments.cs
@@ -21,6 +21,6 @@ namespace NuKeeper.Configuration
         public Uri GithubApiEndpoint;
 
         [CommandLine("max_pull_requests_per_repository", "maxpr"), Default(3)]
-        public int MaxPullRequestsPerRepository { get; set; }
+        public int MaxPullRequestsPerRepository;
     }
 }


### PR DESCRIPTION
`MaxPullRequestsPerRepository` on `CommandLineArguments` needs to be a field not a property
Like the other ones
To fix the crash