### PR TITLE
Update to the release of the NUnit3TestAdapter

### DIFF
--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0"></PackageReference>
 	<PackageReference Include="NUnit" Version="3.7.1"></PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update `NUnit3TestAdapter` to `3.8.0` from `3.8.0-alpha1`
Nukeeper didn't pick this up as an update, so do it manually  :/