### PR TITLE
Test the api package lookup

### DIFF
--- a/NuKeeper.Tests/Nuget/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/Nuget/Api/ApiPackageLookupTests.cs
@@ -30,7 +30,6 @@ namespace NuKeeper.Tests.Nuget.Api
             Assert.That(package.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
         }
 
-
         [Test]
         public async Task AmbigousPackageName_ShouldReturnCorrectResult()
         {

--- a/NuKeeper.Tests/Nuget/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/Nuget/Api/ApiPackageLookupTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using NuKeeper.NuGet.Api;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Nuget.Api
+{
+    [TestFixture]
+    public class ApiPackageLookupTests
+    {
+        [Test]
+        public async Task UnknownPackageName_ShouldNotReturnResult()
+        {
+            IApiPackageLookup lookup = new ApiPackageLookup();
+
+            var package = await lookup.LookupLatest(Guid.NewGuid().ToString());
+
+            Assert.That(package, Is.Null);
+        }
+
+        [Test]
+        public async Task WellKnownPackageName_ShouldReturnResult()
+        {
+            IApiPackageLookup lookup = new ApiPackageLookup();
+
+            var package = await lookup.LookupLatest("Newtonsoft.Json");
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Identity, Is.Not.Null);
+            Assert.That(package.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+        }
+
+
+        [Test]
+        public async Task AmbigousPackageName_ShouldReturnCorrectResult()
+        {
+            IApiPackageLookup lookup = new ApiPackageLookup();
+
+            var package = await lookup.LookupLatest("AWSSDK");
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Identity, Is.Not.Null);
+            Assert.That(package.Identity.Id, Is.EqualTo("AWSSDK"));
+        }
+    }
+}


### PR DESCRIPTION
Testing a failure that I saw this week
This is an integration test but we need it, as it fail predictably:   
`Expected: "AWSSDK"   But was:  "AWSSDK.Core`
Search result is not the same as exact name match.
There seems to be a suitable method as well.

