### PR TITLE
Lookup new package versions on the nuget api in parallel

### DIFF
--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -48,7 +48,7 @@ namespace NuKeeper.NuGet.Api
                 .Distinct();
 
             var lookupTasks = packageIds
-                .Select(packageId => _packageLookup.LookupLatest(packageId))
+                .Select(id => _packageLookup.LookupLatest(id))
                 .ToList();
 
             await Task.WhenAll(lookupTasks);

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -47,11 +47,18 @@ namespace NuKeeper.NuGet.Api
                 .Select(p => p.Id)
                 .Distinct();
 
-            foreach (var packageId in packageIds)
+            var lookupTasks = packageIds
+                .Select(packageId => _packageLookup.LookupLatest(packageId))
+                .ToList();
+
+            await Task.WhenAll(lookupTasks);
+
+            foreach (var lookupTask in lookupTasks)
             {
-                var serverVersion = await _packageLookup.LookupLatest(packageId);
+                var serverVersion = lookupTask.Result;
                 if (serverVersion?.Identity != null)
                 {
+                    var packageId = serverVersion.Identity.Id;
                     result.Add(packageId, serverVersion);
                     Console.WriteLine($"Found latest version of {packageId}: {serverVersion.Identity.Id} {serverVersion.Identity.Version}");
                 }


### PR DESCRIPTION
Lookup new package versions on the nuget api in parallel
This api client is http under the hood, can parallelise with `await Task.WhenAll`
It's significantly faster, this was becoming a major part of the runtime for large projects