### PR TITLE
Split tests into unit and integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,7 @@ script:
   - dotnet build
   - cd NuKeeper.Tests
   - dotnet test
+  - cd NuKeeper.Integration.Tests
+  - dotnet test
 
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - dotnet build
   - cd NuKeeper.Tests
   - dotnet test
+  - cd ..
   - cd NuKeeper.Integration.Tests
   - dotnet test
 

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0"></PackageReference>
+	<PackageReference Include="NUnit" Version="3.7.1"></PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NuKeeper\NuKeeper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}"></Service>
+  </ItemGroup>
+</Project>

--- a/NuKeeper.Integration.Tests/Nuget/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Api/ApiPackageLookupTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using NuKeeper.NuGet.Api;
 using NUnit.Framework;
 
-namespace NuKeeper.Tests.Nuget.Api
+namespace NuKeeper.Integration.Tests.Nuget.Api
 {
     [TestFixture]
     public class ApiPackageLookupTests

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using NuKeeper.ProcessRunner;
 using NUnit.Framework;
 
-namespace NuKeeper.Tests.ProcessRunner
+namespace NuKeeper.Integration.Tests.ProcessRunner
 {
     [TestFixture, Ignore("Windows only for now")]
     public class ExternalProcessTests

--- a/NuKeeper.sln
+++ b/NuKeeper.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper", "NuKeeper\NuKeeper.csproj", "{DA701A15-52BE-4BFC-B9D1-08C94AA14A29}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Tests", "NuKeeper.Tests\NuKeeper.Tests.csproj", "{82E536CF-67B8-4373-AE7B-560B7C12BB0D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Tests", "NuKeeper.Tests\NuKeeper.Tests.csproj", "{82E536CF-67B8-4373-AE7B-560B7C12BB0D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Integration.Tests", "NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj", "{68B2FDA7-A728-4D4C-8B7F-4F824FD4E03C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{82E536CF-67B8-4373-AE7B-560B7C12BB0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82E536CF-67B8-4373-AE7B-560B7C12BB0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82E536CF-67B8-4373-AE7B-560B7C12BB0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68B2FDA7-A728-4D4C-8B7F-4F824FD4E03C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68B2FDA7-A728-4D4C-8B7F-4F824FD4E03C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68B2FDA7-A728-4D4C-8B7F-4F824FD4E03C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68B2FDA7-A728-4D4C-8B7F-4F824FD4E03C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -41,8 +41,6 @@ namespace NuKeeper.NuGet.Api
 
         private async Task<Dictionary<string, IPackageSearchMetadata>> BuildLatestVersionsDictionary(IEnumerable<PackageInProject> packages)
         {
-            var result = new Dictionary<string, IPackageSearchMetadata>();
-
             var packageIds = packages
                 .Select(p => p.Id)
                 .Distinct();
@@ -52,6 +50,8 @@ namespace NuKeeper.NuGet.Api
                 .ToList();
 
             await Task.WhenAll(lookupTasks);
+
+            var result = new Dictionary<string, IPackageSearchMetadata>();
 
             foreach (var lookupTask in lookupTasks)
             {


### PR DESCRIPTION
Split tests into unit and integration
because we need more tests
and we need both kinds
And a few tests already use external apis / file system and so are integration : package lookup, External process