### PR TITLE
Automatic update of EasyConfig.Net.Core to 2.0.58

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>NuKeeper</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EasyConfig.Net.Core" Version="1.0.48" />
+    <PackageReference Include="EasyConfig.Net.Core" Version="2.0.58" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />


### PR DESCRIPTION
NuKeeper has generated an update of `EasyConfig.Net.Core` to `2.0.58` from `1.0.48`
1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `EasyConfig.Net.Core` `2.0.58` from `1.0.48`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
