### PR TITLE
Extract the nuget path logic and put a test around it

### DIFF
--- a/NuKeeper.Integration.Tests/Nuget/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Api/BulkPackageLookupTests.cs
@@ -55,7 +55,20 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         }
 
         [Test]
-        public async Task IsNotBrokenByInvalidPackages()
+        public async Task InvalidPackageIsIgnored()
+        {
+            var packages = new List<string> { Guid.NewGuid().ToString() };
+
+            var lookup = new BulkPackageLookup(new ApiPackageLookup());
+
+            var results = await lookup.LatestVersions(packages);
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results, Is.Empty);
+        }
+
+        [Test]
+        public async Task ValidPackagesWorkDespiteInvalidPackages()
         {
             var packages = new List<string>
             {
@@ -71,6 +84,8 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
+            Assert.That(results, Does.ContainKey("Moq"));
+            Assert.That(results, Does.ContainKey("Newtonsoft.Json"));
         }
     }
 }

--- a/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.Nuget.Process
 {
-    [TestFixture]
+    [TestFixture, Ignore("Windows only for now")]
     public class NugetPathTests
     {
         [Test]

--- a/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
@@ -11,6 +11,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Process
         {
             var nugetPath = NugetPath.Find();
 
+            Assert.That(nugetPath, Is.Not.Empty);
             FileAssert.Exists(nugetPath);
         }
     }

--- a/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
@@ -1,7 +1,7 @@
-﻿using NuKeeper.Nuget.Process;
+﻿using NuKeeper.NuGet.Process;
 using NUnit.Framework;
 
-namespace NuKeeper.Integration.Tests.Nuget.Process
+namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture, Ignore("Windows only for now")]
     public class NugetPathTests

--- a/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
@@ -1,0 +1,17 @@
+﻿using NuKeeper.Nuget.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.Nuget.Process
+{
+    [TestFixture]
+    public class NugetPathTests
+    {
+        [Test]
+        public void HasNugetPath()
+        {
+            var nugetPath = NugetPath.Find();
+
+            FileAssert.Exists(nugetPath);
+        }
+    }
+}

--- a/NuKeeper/NuGet/Process/NugetPath.cs
+++ b/NuKeeper/NuGet/Process/NugetPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 
 namespace NuKeeper.Nuget.Process
 {
@@ -8,14 +9,30 @@ namespace NuKeeper.Nuget.Process
         public static string Find()
         {
             var profile = Environment.GetEnvironmentVariable("userprofile");
-            var nugetDir = Path.Combine(profile, ".nuget\\packages\\nuget.commandline\\4.1.0\\tools");
 
-            if (!Directory.Exists(nugetDir))
+            if (string.IsNullOrWhiteSpace(profile))
             {
-                throw new Exception("Could not find nuget commandline path: " + nugetDir);
+                throw new Exception("Could not find user profile path");
             }
 
-            return Path.GetFullPath(Path.Combine(nugetDir, "NuGet.exe"));
+            var commandlinePackageDir = Path.Combine(profile, ".nuget\\packages\\nuget.commandline");
+
+            if (!Directory.Exists(commandlinePackageDir))
+            {
+                throw new Exception("Could not find nuget commandline path: " + commandlinePackageDir);
+            }
+
+            var highestVersion = Directory.GetDirectories(commandlinePackageDir)
+                .OrderByDescending(n => n)
+                .FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(highestVersion))
+            {
+                throw new Exception("Could not find a version of nuget.commandline");
+            }
+
+            var nugetProgramPath = Path.Combine(highestVersion, "tools\\NuGet.exe");
+            return Path.GetFullPath(nugetProgramPath);
         }
     }
 }

--- a/NuKeeper/NuGet/Process/NugetPath.cs
+++ b/NuKeeper/NuGet/Process/NugetPath.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 
-namespace NuKeeper.Nuget.Process
+namespace NuKeeper.NuGet.Process
 {
     public static class NugetPath
     {

--- a/NuKeeper/NuGet/Process/NugetPath.cs
+++ b/NuKeeper/NuGet/Process/NugetPath.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.IO;
+
+namespace NuKeeper.Nuget.Process
+{
+    public static class NugetPath
+    {
+        public static string Find()
+        {
+            var profile = Environment.GetEnvironmentVariable("userprofile");
+            var nugetDir = Path.Combine(profile, ".nuget\\packages\\nuget.commandline\\4.1.0\\tools");
+
+            if (!Directory.Exists(nugetDir))
+            {
+                throw new Exception("Could not find nuget commandline path: " + nugetDir);
+            }
+
+            return Path.GetFullPath(Path.Combine(nugetDir, "NuGet.exe"));
+        }
+    }
+}

--- a/NuKeeper/NuGet/Process/PackagesConfigUpdater.cs
+++ b/NuKeeper/NuGet/Process/PackagesConfigUpdater.cs
@@ -1,8 +1,8 @@
 ﻿using NuKeeper.ProcessRunner;
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using NuGet.Versioning;
+using NuKeeper.Nuget.Process;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.NuGet.Process
@@ -19,7 +19,7 @@ namespace NuKeeper.NuGet.Process
         public async Task UpdatePackage(NuGetVersion newVersion, PackageInProject currentPackage)
         {
             var dirName = currentPackage.Path.FullDirectory;
-            var nuget = GetNuGetPath();
+            var nuget = NugetPath.Find();
             var updateCommand = $"cd {dirName}"
                 + $" & {nuget} restore packages.config"
                 + $" & {nuget} update packages.config -Id {currentPackage.Id} -Version {newVersion}";
@@ -35,19 +35,6 @@ namespace NuKeeper.NuGet.Process
             {
                 throw new Exception($"Exit code: {result.ExitCode}\n\n{result.Output}\n\n{result.ErrorOutput}");
             }
-        }
-
-        private string GetNuGetPath()
-        {
-            var profile = Environment.GetEnvironmentVariable("userprofile");
-            var nugetDir = Path.Combine(profile, ".nuget\\packages\\nuget.commandline\\4.1.0\\tools");
-
-            if (!Directory.Exists(nugetDir))
-            {
-                throw new Exception("Could not find nuget commandline path: " + nugetDir);
-            }
-
-            return Path.GetFullPath(Path.Combine(nugetDir, "NuGet.exe"));
         }
     }
 }

--- a/NuKeeper/NuGet/Process/PackagesConfigUpdater.cs
+++ b/NuKeeper/NuGet/Process/PackagesConfigUpdater.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading.Tasks;
 using NuGet.Versioning;
-using NuKeeper.Nuget.Process;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.NuGet.Process


### PR DESCRIPTION
Extract the nuget path logic and put a test around it, because it's dodgy and needs something more.
The test won't work on linux but neither does the profile path. 

So we can only do `nuget.exe` updates on windows, but it's for old-style projects that only run on windows anyway


