### PR TITLE
Category for tests instead of Ignore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ addons:
 script:
   - dotnet restore
   - dotnet build
-  - cd NuKeeper.Tests
-  - dotnet test
-  - cd ..
-  - cd NuKeeper.Integration.Tests
-  - dotnet test
+  - dotnet test NuKeeper.Tests/NuKeeper.Tests.csproj
+  - dotnet test NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"
 
  

--- a/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
+++ b/NuKeeper.Integration.Tests/Nuget/Process/NugetPathTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
-    [TestFixture, Ignore("Windows only for now")]
+    [TestFixture, Category("WindowsOnly")]
     public class NugetPathTests
     {
         [Test]

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.ProcessRunner
 {
-    [TestFixture, Ignore("Windows only for now")]
+    [TestFixture, Category("WindowsOnly")]
     public class ExternalProcessTests
     {
         [Test]


### PR DESCRIPTION
it is better to use a `[Category]` on tests that only work on windows instead of `[Ignore]`
So that they can be filtered out of the travis build only, and run them when working locally or on some other potential kind of build.

Works on travis: it runs 8 of the 11 integration tests.