### PR TITLE
More reliable in getting the user name

### DIFF
--- a/NuKeeper/Configuration/CommandLineParser.cs
+++ b/NuKeeper/Configuration/CommandLineParser.cs
@@ -51,7 +51,7 @@ namespace NuKeeper.Configuration
             {
                 GithubUri = settings.GithubRepositoryUri,
                 GithubToken = settings.GithubToken,
-                GithubApiBase = settings.GithubApiEndpoint,
+                GithubApiBase = EnsureTrailingSlash(settings.GithubApiEndpoint),
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner,
                 MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
@@ -66,11 +66,28 @@ namespace NuKeeper.Configuration
 
             return new OrganisationModeSettings
             {
-                GithubApiBase = githubHost,
+                GithubApiBase = EnsureTrailingSlash(githubHost),
                 GithubToken = githubToken,
                 OrganisationName = githubOrganisationName,
                 MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
             };
+        }
+
+        private static Uri EnsureTrailingSlash(Uri uri)
+        {
+            if (uri == null)
+            {
+                return null;
+            }
+
+            var path = uri.ToString();
+
+            if (path.EndsWith("/"))
+            {
+                return uri;
+            }
+
+            return new Uri(path + "/");
         }
     }
 }

--- a/NuKeeper/Github/GithubClient.cs
+++ b/NuKeeper/Github/GithubClient.cs
@@ -48,8 +48,13 @@ namespace NuKeeper.Github
             var request = _requestBuilder.ConstructRequestMessage(requestUri, HttpMethod.Get);
 
             var response = await _client.SendAsync(request);
-
             var content = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Get failed: {response.StatusCode} {content}");
+            }
+
             return GithubSerialization.DeserializeObject<T>(content);
         }
 
@@ -62,10 +67,10 @@ namespace NuKeeper.Github
 
         public async Task<string> GetCurrentUser()
         {
-            var path = "/user";
+            var path = "user";
             var response = await GetAsync<GithubOwner>(path);
 
-            return response.Login;
+            return response?.Login;
         }
 
         public async Task<OpenPullRequestResult> OpenPullRequest(OpenPullRequestRequest request)

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -46,6 +46,8 @@ namespace NuKeeper
             string githubToken)
         {
             var githubUser = await github.GetCurrentUser();
+            Console.WriteLine($"Read github user '{githubUser}'");
+
             var git = new LibGit2SharpDriver(tempDir, githubUser, githubToken);
 
             var repositories = await repositoryDiscovery.GetRepositories();


### PR DESCRIPTION
More reliable in getting the user name from github using the token.

It seem that building the url from 2 parts only works just right if the first part ends with a trailing `/` and the second one doesn't start with one.

if the second part starts with a slash, it is taken as an absolute path, .i.e. `https://github.myco.com/api/v3` and `/user` is `https://github.myco.com/user` which is wrong.

it is unfortunate that we don't have integration tests on `GithubClient`, but that would require committing a github api token, which github disallows.