### PR TITLE
Supply creds when cloning

### DIFF
--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -108,7 +108,7 @@ namespace NuKeeper.Engine
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Update failed: {ex.Message}");
+                Console.WriteLine($"Update failed: {ex.GetType().Name} {ex.Message}");
             }
         }
 

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -17,7 +17,11 @@ namespace NuKeeper.Git
         }
         public void Clone(Uri pullEndpoint)
         {
-            Repository.Clone(pullEndpoint.ToString(), _repoStoragePath);
+            Repository.Clone(pullEndpoint.ToString(), _repoStoragePath,
+                new CloneOptions
+                {
+                    CredentialsProvider = UsernamePasswordCredentials
+                });
         }
 
         public void Checkout(string branchName)
@@ -60,14 +64,21 @@ namespace NuKeeper.Git
 
                 repo.Network.Push(localBranch, new PushOptions
                 {
-                    CredentialsProvider = (_, __, ___) => new UsernamePasswordCredentials
-                    {
-
-                        Username = _githubUser,
-                        Password = _githubToken
-                    }
+                    CredentialsProvider = UsernamePasswordCredentials
                 });
             }
+        }
+
+        private UsernamePasswordCredentials UsernamePasswordCredentials(
+            string url, string usernameFromUrl, 
+            SupportedCredentialTypes types)
+        {
+            return new UsernamePasswordCredentials
+            {
+
+                Username = _githubUser,
+                Password = _githubToken
+            };
         }
     }
 }

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -11,6 +11,21 @@ namespace NuKeeper.Git
 
         public LibGit2SharpDriver(string repoStoragePath, string githubUser, string githubToken)
         {
+            if (string.IsNullOrWhiteSpace(repoStoragePath))
+            {
+                throw new ArgumentNullException(nameof(repoStoragePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(githubUser))
+            {
+                throw new ArgumentNullException(nameof(githubUser));
+            }
+
+            if (string.IsNullOrWhiteSpace(githubToken))
+            {
+                throw new ArgumentNullException(nameof(githubToken));
+            }
+
             _repoStoragePath = repoStoragePath;
             _githubUser = githubUser;
             _githubToken = githubToken;

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -59,7 +59,7 @@ namespace NuKeeper
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
+                    Console.WriteLine($"Repo failed {e.GetType().Name}: {e.Message}");
                 }
             }
         }


### PR DESCRIPTION
In the git driver, Supply creds when cloning
as well as on the push
this fixes the "401" issue with some repos - #86 