### PR TITLE
Compound log data

### DIFF
--- a/NuKeeper/Engine/EngineReport.cs
+++ b/NuKeeper/Engine/EngineReport.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NuKeeper.Logging;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
 {
     public static class EngineReport
     {
-        public static string PackagesFoundSummary(List<PackageInProject> packages)
+        public static LogData PackagesFound(List<PackageInProject> packages)
         {
             var projectPathCount = packages
                 .Select(p => p.Path)
@@ -15,41 +16,37 @@ namespace NuKeeper.Engine
                 .Count();
 
             var packageIds = packages
-                .Select(p => p.Id)
-                .Distinct();
-
-            return $"Found {packages.Count} packages in use, {packageIds.Count()} distinct, in {projectPathCount} projects.";
-        }
-
-        public static string PackagesFoundDetails(List<PackageInProject> packages)
-        {
-            var packageIds = packages
                 .OrderBy(p => p.Id)
                 .Select(p => p.Id)
                 .Distinct()
                 .ToList();
 
-            return packageIds.JoinWithCommas();
+            var headline = $"Found {packages.Count} packages in use, {packageIds.Count} distinct, in {projectPathCount} projects.";
+
+            return new LogData
+            {
+                Terse = headline,
+                Info = packageIds.JoinWithCommas()
+            };
         }
 
-        public static string UpdatesFoundSummary(List<PackageUpdateSet> updates)
+        public static LogData UpdatesFound(List<PackageUpdateSet> updates)
         {
-            return $"Found {updates.Count} possible updates";
-        }
-
-        public static string UpdatesFoundDetails(List<PackageUpdateSet> updates)
-        {
-            StringBuilder result = new StringBuilder();
+            var headline = $"Found {updates.Count} possible updates";
+            var details = new StringBuilder();
 
             foreach (var updateSet in updates)
             {
                 foreach (var current in updateSet.CurrentPackages)
                 {
-                    result.AppendLine($"{updateSet.PackageId} from {current.Version} to {updateSet.NewVersion} in {current.Path.RelativePath}");
+                    details.AppendLine($"{updateSet.PackageId} from {current.Version} to {updateSet.NewVersion} in {current.Path.RelativePath}");
                 }
             }
-
-            return result.ToString();
+            return new LogData
+            {
+                Terse = headline,
+                Info = details.ToString()
+            };
         }
 
         public static string OldVersionsToBeUpdated(PackageUpdateSet updateSet)

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -51,13 +51,11 @@ namespace NuKeeper.Engine
             var packages = repoScanner.FindAllNuGetPackages(_tempDir)
                 .ToList();
 
-            _logger.Terse(EngineReport.PackagesFoundSummary(packages));
-            _logger.Info(EngineReport.PackagesFoundDetails(packages));
+            _logger.Log(EngineReport.PackagesFound(packages));
 
             // look for package updates
             var updates = await _packageLookup.FindUpdatesForPackages(packages);
-            _logger.Terse(EngineReport.UpdatesFoundSummary(updates));
-            _logger.Info(EngineReport.UpdatesFoundDetails(updates));
+            _logger.Log(EngineReport.UpdatesFound(updates));
 
             if (updates.Count == 0)
             {

--- a/NuKeeper/Logging/LogData.cs
+++ b/NuKeeper/Logging/LogData.cs
@@ -1,0 +1,25 @@
+namespace NuKeeper.Logging
+{
+    public class LogData
+    {
+        public string Terse { get; set; }
+        public string Info { get; set; }
+    }
+
+    public static class LoggerExtensions
+    {
+        public static void Log(this INuKeeperLogger logger, LogData data)
+        {
+            if (!string.IsNullOrWhiteSpace(data.Terse))
+            {
+                logger.Terse(data.Terse);
+            }
+
+            if (!string.IsNullOrWhiteSpace(data.Info))
+            {
+                logger.Info(data.Info);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Allows the `EngineReport` methods with different log levels to be folded back together again
And an extension method to log them both
`LogData` is totally not a tuple