### PR TITLE
Refactor to engine

### DIFF
--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -29,7 +29,9 @@ namespace NuKeeper
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();
 
+            container.Register<GithubEngine>();
             container.Register<IRepositoryUpdater, RepositoryUpdater>();
+            container.Register<IPackageUpdater, PackageUpdater>();
 
             return container;
         }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -29,6 +29,8 @@ namespace NuKeeper
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();
 
+            container.Register<IRepositoryUpdater, RepositoryUpdater>();
+
             return container;
         }
     }

--- a/NuKeeper/Engine/GithubEngine.cs
+++ b/NuKeeper/Engine/GithubEngine.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
-using NuKeeper.Engine;
 using NuKeeper.Files;
 using NuKeeper.Git;
 using NuKeeper.Github;
 using NuKeeper.Logging;
 
-namespace NuKeeper
+namespace NuKeeper.Engine
 {
     public class GithubEngine
     {

--- a/NuKeeper/Engine/IPackageUpdater.cs
+++ b/NuKeeper/Engine/IPackageUpdater.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using NuKeeper.Configuration;
+using NuKeeper.Git;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine
+{
+    public interface IPackageUpdater
+    {
+        Task UpdatePackageInProjects(
+            IGitDriver git,
+            PackageUpdateSet updateSet,
+            RepositoryModeSettings settings,
+            string defaultBranch);
+    }
+}

--- a/NuKeeper/Engine/IRepositoryUpdater.cs
+++ b/NuKeeper/Engine/IRepositoryUpdater.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using NuKeeper.Configuration;
+using NuKeeper.Git;
+
+namespace NuKeeper.Engine
+{
+    public interface IRepositoryUpdater
+    {
+        Task Run(IGitDriver git, RepositoryModeSettings settings);
+    }
+}

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Threading.Tasks;
+using NuKeeper.Configuration;
+using NuKeeper.Git;
+using NuKeeper.Github;
+using NuKeeper.Logging;
+using NuKeeper.NuGet.Process;
+using NuKeeper.RepositoryInspection;
+using Octokit;
+
+namespace NuKeeper.Engine
+{
+    public class PackageUpdater : IPackageUpdater
+    {
+        private readonly IGithub _github;
+        private readonly INuKeeperLogger _logger;
+
+        public PackageUpdater(
+            IGithub github,
+            INuKeeperLogger logger)
+        {
+            _github = github;
+            _logger = logger;
+        }
+
+        public async Task UpdatePackageInProjects(
+            IGitDriver git,
+            PackageUpdateSet updateSet,
+            RepositoryModeSettings settings,
+            string defaultBranch)
+        {
+            try
+            {
+                _logger.Terse(EngineReport.OldVersionsToBeUpdated(updateSet));
+
+                git.Checkout(defaultBranch);
+
+                // branch
+                var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+                git.CheckoutNewBranch(branchName);
+
+                await UpdateAllCurrentUsages(updateSet);
+
+                var commitMessage = CommitReport.MakeCommitMessage(updateSet);
+                git.Commit(commitMessage);
+
+                git.Push("origin", branchName);
+
+                var prTitle = CommitReport.MakePullRequestTitle(updateSet);
+                await MakeGitHubPullRequest(updateSet, settings, prTitle, branchName, defaultBranch);
+
+                git.Checkout(defaultBranch);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Update failed", ex);
+            }
+        }
+
+        private async Task UpdateAllCurrentUsages(PackageUpdateSet updateSet)
+        {
+            foreach (var current in updateSet.CurrentPackages)
+            {
+                var updateCommand = GetUpdateCommand(current.Path.PackageReferenceType);
+                await updateCommand.Invoke(updateSet.NewVersion, current);
+            }
+        }
+
+        private IUpdatePackageCommand GetUpdateCommand(PackageReferenceType packageReferenceType)
+        {
+            if (packageReferenceType == PackageReferenceType.ProjectFile)
+            {
+                return new DotNetUpdatePackageCommand(_logger);
+            }
+
+            return new NuGetUpdatePackageCommand(_logger);
+        }
+
+        private async Task MakeGitHubPullRequest(
+            PackageUpdateSet updates,
+            RepositoryModeSettings settings,
+            string title, string headBranch, string baseBranch)
+        {
+            var pr = new NewPullRequest(title, headBranch, baseBranch)
+            {
+                Body = CommitReport.MakeCommitDetails(updates)
+            };
+
+            await _github.OpenPullRequest(settings.RepositoryOwner, settings.RepositoryName, pr);
+        }
+
+    }
+}

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
-using NuKeeper.Files;
 using NuKeeper.Git;
 using NuKeeper.Github;
 using NuKeeper.Logging;
@@ -13,43 +12,33 @@ using Octokit;
 
 namespace NuKeeper.Engine
 {
-    public class RepositoryUpdater
+    public class RepositoryUpdater : IRepositoryUpdater
     {   
         private readonly IPackageUpdatesLookup _packageLookup;
-        private readonly RepositoryModeSettings _settings;
-        private readonly IFolder _tempFolder;
         private readonly IGithub _github;
-        private readonly IGitDriver _git;
         private readonly IPackageUpdateSelection _updateSelection;
         private readonly INuKeeperLogger _logger;
 
         public RepositoryUpdater(
             IGithub github, 
-            IGitDriver git, 
             IPackageUpdatesLookup packageLookup, 
             IPackageUpdateSelection updateSelection, 
-            IFolder tempFolder, 
-            INuKeeperLogger logger, 
-            RepositoryModeSettings settings)
+            INuKeeperLogger logger)
         {
-            _packageLookup = packageLookup;
             _github = github;
-            _git = git;
-            _logger = logger;
-
-            _tempFolder = tempFolder;
+            _packageLookup = packageLookup;
             _updateSelection = updateSelection;
-            _settings = settings;
+            _logger = logger;
         }
 
-        public async Task Run()
+        public async Task Run(IGitDriver git, RepositoryModeSettings settings)
         {
-            _git.Clone(_settings.GithubUri);
-            var defaultBranch = _git.GetCurrentHead();
+            git.Clone(settings.GithubUri);
+            var defaultBranch = git.GetCurrentHead();
 
             // scan for nuget packages
             var repoScanner = new RepositoryScanner();
-            var packages = repoScanner.FindAllNuGetPackages(_tempFolder.FullPath)
+            var packages = repoScanner.FindAllNuGetPackages(git.WorkingFolder.FullPath)
                 .ToList();
 
             _logger.Log(EngineReport.PackagesFound(packages));
@@ -68,37 +57,39 @@ namespace NuKeeper.Engine
 
             foreach (var updateSet in targetUpdates)
             {
-                await UpdatePackageInProjects(updateSet, defaultBranch);
+                await UpdatePackageInProjects(git, updateSet, settings, defaultBranch);
             }
 
-            // delete the temp folder
-            _tempFolder.TryDelete();
             _logger.Info("Done");
         }
 
-        private async Task UpdatePackageInProjects(PackageUpdateSet updateSet, string defaultBranch)
+        private async Task UpdatePackageInProjects(
+            IGitDriver git,
+            PackageUpdateSet updateSet,
+            RepositoryModeSettings settings,
+            string defaultBranch)
         {
             try
             {
                 _logger.Terse(EngineReport.OldVersionsToBeUpdated(updateSet));
 
-                _git.Checkout(defaultBranch);
+                git.Checkout(defaultBranch);
 
                 // branch
                 var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
-                 _git.CheckoutNewBranch(branchName);
+                git.CheckoutNewBranch(branchName);
 
                 await UpdateAllCurrentUsages(updateSet);
 
                 var commitMessage = CommitReport.MakeCommitMessage(updateSet);
-                _git.Commit(commitMessage);
+                git.Commit(commitMessage);
 
-                _git.Push("origin", branchName);
+                git.Push("origin", branchName);
 
                 var prTitle = CommitReport.MakePullRequestTitle(updateSet);
-                await MakeGitHubPullRequest(updateSet, prTitle, branchName, defaultBranch);
+                await MakeGitHubPullRequest(updateSet, settings, prTitle, branchName, defaultBranch);
 
-                _git.Checkout(defaultBranch);
+                git.Checkout(defaultBranch);
             }
             catch (Exception ex)
             {
@@ -125,14 +116,17 @@ namespace NuKeeper.Engine
             return new NuGetUpdatePackageCommand(_logger);
         }
 
-        private async Task MakeGitHubPullRequest(PackageUpdateSet updates, string title, string headBranch, string baseBranch)
+        private async Task MakeGitHubPullRequest(
+            PackageUpdateSet updates, 
+            RepositoryModeSettings settings, 
+            string title, string headBranch, string baseBranch)
         {
             var pr = new NewPullRequest(title, headBranch, baseBranch)
                 {
                     Body = CommitReport.MakeCommitDetails(updates)
                 };
 
-            await _github.OpenPullRequest(_settings.RepositoryOwner, _settings.RepositoryName, pr);
+            await _github.OpenPullRequest(settings.RepositoryOwner, settings.RepositoryName, pr);
         }
     }
 }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -1,33 +1,30 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Git;
-using NuKeeper.Github;
 using NuKeeper.Logging;
 using NuKeeper.NuGet.Api;
-using NuKeeper.NuGet.Process;
 using NuKeeper.RepositoryInspection;
-using Octokit;
 
 namespace NuKeeper.Engine
 {
     public class RepositoryUpdater : IRepositoryUpdater
     {   
         private readonly IPackageUpdatesLookup _packageLookup;
-        private readonly IGithub _github;
         private readonly IPackageUpdateSelection _updateSelection;
+        private readonly IPackageUpdater _packageUpdater;
         private readonly INuKeeperLogger _logger;
 
         public RepositoryUpdater(
-            IGithub github, 
             IPackageUpdatesLookup packageLookup, 
-            IPackageUpdateSelection updateSelection, 
+            IPackageUpdateSelection updateSelection,
+            IPackageUpdater packageUpdater,
             INuKeeperLogger logger)
         {
-            _github = github;
             _packageLookup = packageLookup;
             _updateSelection = updateSelection;
+            _packageUpdater = packageUpdater;
             _logger = logger;
         }
 
@@ -36,6 +33,23 @@ namespace NuKeeper.Engine
             git.Clone(settings.GithubUri);
             var defaultBranch = git.GetCurrentHead();
 
+            var updates = await FindPackageUpdateSets(git);
+
+            if (updates.Count == 0)
+            {
+                _logger.Terse("No potential updates found. Well done. Exiting.");
+                return;
+            }
+
+            var targetUpdates = _updateSelection.SelectTargets(updates);
+
+            await UpdateAllTargets(git, settings, targetUpdates, defaultBranch);
+
+            _logger.Info($"Done {targetUpdates.Count} Updates");
+        }
+
+        private async Task<List<PackageUpdateSet>> FindPackageUpdateSets(IGitDriver git)
+        {
             // scan for nuget packages
             var repoScanner = new RepositoryScanner();
             var packages = repoScanner.FindAllNuGetPackages(git.WorkingFolder.FullPath)
@@ -46,87 +60,15 @@ namespace NuKeeper.Engine
             // look for package updates
             var updates = await _packageLookup.FindUpdatesForPackages(packages);
             _logger.Log(EngineReport.UpdatesFound(updates));
+            return updates;
+        }
 
-            if (updates.Count == 0)
-            {
-                _logger.Terse("No potential updates found. Well done. Exiting.");
-                return;
-            }
-
-            var targetUpdates = _updateSelection.SelectTargets(updates);
-
+        private async Task UpdateAllTargets(IGitDriver git, RepositoryModeSettings settings, List<PackageUpdateSet> targetUpdates, string defaultBranch)
+        {
             foreach (var updateSet in targetUpdates)
             {
-                await UpdatePackageInProjects(git, updateSet, settings, defaultBranch);
+                await _packageUpdater.UpdatePackageInProjects(git, updateSet, settings, defaultBranch);
             }
-
-            _logger.Info("Done");
-        }
-
-        private async Task UpdatePackageInProjects(
-            IGitDriver git,
-            PackageUpdateSet updateSet,
-            RepositoryModeSettings settings,
-            string defaultBranch)
-        {
-            try
-            {
-                _logger.Terse(EngineReport.OldVersionsToBeUpdated(updateSet));
-
-                git.Checkout(defaultBranch);
-
-                // branch
-                var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
-                git.CheckoutNewBranch(branchName);
-
-                await UpdateAllCurrentUsages(updateSet);
-
-                var commitMessage = CommitReport.MakeCommitMessage(updateSet);
-                git.Commit(commitMessage);
-
-                git.Push("origin", branchName);
-
-                var prTitle = CommitReport.MakePullRequestTitle(updateSet);
-                await MakeGitHubPullRequest(updateSet, settings, prTitle, branchName, defaultBranch);
-
-                git.Checkout(defaultBranch);
-            }
-            catch (Exception ex)
-            {
-                _logger.Error("Update failed", ex);
-            }
-        }
-
-        private async Task UpdateAllCurrentUsages(PackageUpdateSet updateSet)
-        {
-            foreach (var current in updateSet.CurrentPackages)
-            {
-                var updateCommand = GetUpdateCommand(current.Path.PackageReferenceType);
-                await updateCommand.Invoke(updateSet.NewVersion, current);
-            }
-        }
-
-        private IUpdatePackageCommand GetUpdateCommand(PackageReferenceType packageReferenceType)
-        {
-            if (packageReferenceType == PackageReferenceType.ProjectFile)
-            {
-                return new DotNetUpdatePackageCommand(_logger);
-            }
-
-            return new NuGetUpdatePackageCommand(_logger);
-        }
-
-        private async Task MakeGitHubPullRequest(
-            PackageUpdateSet updates, 
-            RepositoryModeSettings settings, 
-            string title, string headBranch, string baseBranch)
-        {
-            var pr = new NewPullRequest(title, headBranch, baseBranch)
-                {
-                    Body = CommitReport.MakeCommitDetails(updates)
-                };
-
-            await _github.OpenPullRequest(settings.RepositoryOwner, settings.RepositoryName, pr);
         }
     }
 }

--- a/NuKeeper/Git/IGitDriver.cs
+++ b/NuKeeper/Git/IGitDriver.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using NuKeeper.Files;
 
 namespace NuKeeper.Git
 {
     public interface IGitDriver
     {
+        IFolder WorkingFolder { get; }
+
         void Clone(Uri pullEndpoint);
 
         void Checkout(string branchName);

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -9,12 +9,13 @@ namespace NuKeeper.Git
     public class LibGit2SharpDriver : IGitDriver
     {
         private readonly INuKeeperLogger _logger;
-        private readonly IFolder _tempFolder;
         private readonly string _githubUser;
         private readonly string _githubToken;
 
+        public IFolder WorkingFolder { get; }
+
         public LibGit2SharpDriver(INuKeeperLogger logger,  
-            IFolder tempFolder, string githubUser, string githubToken)
+            IFolder workingFolder, string githubUser, string githubToken)
         {
             if (string.IsNullOrWhiteSpace(githubUser))
             {
@@ -27,15 +28,15 @@ namespace NuKeeper.Git
             }
 
             _logger = logger;
-            _tempFolder = tempFolder;
+            WorkingFolder = workingFolder;
             _githubUser = githubUser;
             _githubToken = githubToken;
         }
         public void Clone(Uri pullEndpoint)
         {
-            _logger.Verbose($"Git clone {pullEndpoint} to {_tempFolder.FullPath}");
+            _logger.Verbose($"Git clone {pullEndpoint} to {WorkingFolder.FullPath}");
 
-            Repository.Clone(pullEndpoint.ToString(), _tempFolder.FullPath,
+            Repository.Clone(pullEndpoint.ToString(), WorkingFolder.FullPath,
                 new CloneOptions
                 {
                     CredentialsProvider = UsernamePasswordCredentials
@@ -104,7 +105,7 @@ namespace NuKeeper.Git
 
         private Repository MakeRepo()
         {
-            return new Repository(_tempFolder.FullPath);
+            return new Repository(WorkingFolder.FullPath);
         }
 
         private UsernamePasswordCredentials UsernamePasswordCredentials(

--- a/NuKeeper/GithubEngine.cs
+++ b/NuKeeper/GithubEngine.cs
@@ -6,33 +6,29 @@ using NuKeeper.Files;
 using NuKeeper.Git;
 using NuKeeper.Github;
 using NuKeeper.Logging;
-using NuKeeper.NuGet.Api;
 
 namespace NuKeeper
 {
     public class GithubEngine
     {
         private readonly IGithubRepositoryDiscovery _repositoryDiscovery;
-        private readonly IPackageUpdatesLookup _updatesLookup;
-        private readonly IPackageUpdateSelection _updateSelection;
         private readonly IGithub _github;
+        private readonly IRepositoryUpdater _repositoryUpdater;
         private readonly INuKeeperLogger _logger;
         private readonly IFolderFactory _folderFactory;
         private readonly string _githubToken;
 
         public GithubEngine(
             IGithubRepositoryDiscovery repositoryDiscovery, 
-            IPackageUpdatesLookup updatesLookup, 
-            IPackageUpdateSelection updateSelection, 
             IGithub github,
+            IRepositoryUpdater repositoryUpdater,
             INuKeeperLogger logger,
             IFolderFactory folderFactory,
             Settings settings)
         {
             _repositoryDiscovery = repositoryDiscovery;
-            _updatesLookup = updatesLookup;
-            _updateSelection = updateSelection;
             _github = github;
+            _repositoryUpdater = repositoryUpdater;
             _logger = logger;
             _folderFactory = folderFactory;
             _githubToken = settings.GithubToken;
@@ -56,13 +52,9 @@ namespace NuKeeper
                 var tempFolder = _folderFactory.UniqueTemporaryFolder();
                 var git = new LibGit2SharpDriver(_logger, tempFolder, githubUser, _githubToken);
 
-                var repositoryUpdater = new RepositoryUpdater(
-                    _github, git,
-                    _updatesLookup, _updateSelection,
-                    tempFolder, _logger,
-                    repository);
+                await _repositoryUpdater.Run(git, repository);
 
-                await repositoryUpdater.Run();
+                tempFolder.TryDelete();
             }
             catch (Exception ex)
             {

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NuKeeper.Configuration;
+using NuKeeper.Engine;
 using NuKeeper.Files;
 
 namespace NuKeeper


### PR DESCRIPTION
refactor to the engine,  use the container more.
Github engine goes in the engine folder.
Extract package updater from repo updater
It's now a 3-level process: 
`GithubEngine` identifies target repo(s) 
`RepositoryUpdater` identifies target package updates for a repo 
`PackageUpdater` applies a package update

 I'm not totally done with the refactoring to IoC PRs yet - still looking for ways to consolidate and inject data rather than carry it around. But I feel that this PR puts it over the hump. 

