### PR TITLE
Simplify the LibGit2SharpDriver credentials

### DIFF
--- a/NuKeeper/Engine/GithubEngine.cs
+++ b/NuKeeper/Engine/GithubEngine.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using NuKeeper.Configuration;
 using NuKeeper.Files;
 using NuKeeper.Git;
@@ -36,20 +37,26 @@ namespace NuKeeper.Engine
         public async Task Run()
         {
             var githubUser = await _github.GetCurrentUser();
+            var gitCreds = new UsernamePasswordCredentials
+            {
+                Username = githubUser,
+                Password = _githubToken
+            };
+
             var repositories = await _repositoryDiscovery.GetRepositories();
 
             foreach (var repository in repositories)
             {
-                await RunRepo(githubUser, repository);
+                await RunRepo(repository, gitCreds);
             }
         }
 
-        private async Task RunRepo(string githubUser, RepositoryModeSettings repository)
+        private async Task RunRepo(RepositoryModeSettings repository, Credentials gitCreds)
         {
             try
             {
                 var tempFolder = _folderFactory.UniqueTemporaryFolder();
-                var git = new LibGit2SharpDriver(_logger, tempFolder, githubUser, _githubToken);
+                var git = new LibGit2SharpDriver(_logger, tempFolder, gitCreds);
 
                 await _repositoryUpdater.Run(git, repository);
 

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -9,28 +9,22 @@ namespace NuKeeper.Git
     public class LibGit2SharpDriver : IGitDriver
     {
         private readonly INuKeeperLogger _logger;
-        private readonly string _githubUser;
-        private readonly string _githubToken;
+        private readonly Credentials _gitCredentials;
 
         public IFolder WorkingFolder { get; }
 
         public LibGit2SharpDriver(INuKeeperLogger logger,  
-            IFolder workingFolder, string githubUser, string githubToken)
+            IFolder workingFolder, Credentials gitCredentials)
         {
-            if (string.IsNullOrWhiteSpace(githubUser))
+            if (gitCredentials == null)
             {
-                throw new ArgumentNullException(nameof(githubUser));
+                throw new ArgumentNullException(nameof(gitCredentials));
             }
 
-            if (string.IsNullOrWhiteSpace(githubToken))
-            {
-                throw new ArgumentNullException(nameof(githubToken));
-            }
 
             _logger = logger;
             WorkingFolder = workingFolder;
-            _githubUser = githubUser;
-            _githubToken = githubToken;
+            _gitCredentials = gitCredentials;
         }
         public void Clone(Uri pullEndpoint)
         {
@@ -108,15 +102,10 @@ namespace NuKeeper.Git
             return new Repository(WorkingFolder.FullPath);
         }
 
-        private UsernamePasswordCredentials UsernamePasswordCredentials(
-            string url, string usernameFromUrl, 
-            SupportedCredentialTypes types)
+        private Credentials UsernamePasswordCredentials(
+            string url, string usernameFromUrl, SupportedCredentialTypes types)
         {
-            return new UsernamePasswordCredentials
-            {
-                Username = _githubUser,
-                Password = _githubToken
-            };
+            return _gitCredentials;
         }
     }
 }


### PR DESCRIPTION
use a Credentials class in LibGit2Sharp
instead of user name and password.
2 string params become one strongly typed param
also since it's a base class other kinds of creds could be used, not user username / password