### PR TITLE
Test that the container can resolve

### DIFF
--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests
+{
+    [TestFixture]
+    public class ContainerRegistrationTests
+    {
+        [Test]
+        public void RootCanBeResolved()
+        {
+            var container = ContainerRegistration.Init(MakeValidSettings());
+
+            var engine = container.GetInstance<GithubEngine>();
+
+            Assert.That(engine, Is.Not.Null);
+        }
+
+        private static Settings MakeValidSettings()
+        {
+            var org = new OrganisationModeSettings
+            {
+                GithubApiBase = new Uri("https://github.com/NuKeeperDotNet"),
+                GithubToken = "abc123"
+            };
+            return new Settings(org);
+        }
+    }
+}


### PR DESCRIPTION
Test that the container can resolve the engine root object
Having this test would have saved some time recently
And if it fails, the error message tells you what needs registering