### PR TITLE
Async main, yo!

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -5,6 +5,9 @@
     <RootNamespace>NuKeeper</RootNamespace>
     <AssemblyName>NuKeeper</AssemblyName>
   </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="2.0.60" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Files;
@@ -7,7 +8,7 @@ namespace NuKeeper
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             TempFiles.DeleteExistingTempDirs();
                 
@@ -22,8 +23,7 @@ namespace NuKeeper
             var container = ContainerRegistration.Init(settings);
 
             var engine = container.GetInstance<GithubEngine>();
-            engine.Run()
-                .GetAwaiter().GetResult();
+            await engine.Run();
 
             return 0;
         }


### PR DESCRIPTION
Main can now be async - 
actually the compiler just generates the same boilerplate `GetAwaiter().GetResult()` for us
This requires C#7.1 to be enabled
And VS 2017, release 15.3
We're so bleeding edge 😎 