### PR TITLE
Filter out existing branches

### DIFF
--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -121,7 +121,7 @@ namespace NuKeeper.Tests.Engine
         private static IPackageUpdateSelection OneTargetSelection()
         {
             const int maxPullRequests = 1;
-            var settings = new Settings(new RepositoryModeSettings()
+            var settings = new Settings(new RepositoryModeSettings
             {
                 MaxPullRequestsPerRepository = maxPullRequests
             });

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -26,6 +26,7 @@ namespace NuKeeper
             container.Register<IGithub, OctokitClient>();
             container.Register<IGithubRepositoryDiscovery, GithubRepositoryDiscovery>();
             container.Register<IPackageUpdateSelection, PackageUpdateSelection>();
+            container.Register<IExistingBranchFilter, ExistingBranchFilter>();
             container.Register<IPackageUpdatesLookup, PackageUpdatesLookup>();
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();

--- a/NuKeeper/Engine/BranchNamer.cs
+++ b/NuKeeper/Engine/BranchNamer.cs
@@ -1,0 +1,12 @@
+﻿using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine
+{
+    public static class BranchNamer
+    {
+        public static string MakeName(PackageUpdateSet updateSet)
+        {
+            return $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+        }
+    }
+}

--- a/NuKeeper/Engine/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/ExistingBranchFilter.cs
@@ -1,0 +1,14 @@
+using NuKeeper.Git;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine
+{
+    public class ExistingBranchFilter : IExistingBranchFilter
+    {
+        public bool Exists(IGitDriver git, PackageUpdateSet packageUpdateSet)
+        {
+            var branchName = BranchNamer.MakeName(packageUpdateSet);
+            return  git.BranchExists("origin/" + branchName);
+        }
+    }
+}

--- a/NuKeeper/Engine/IExistingBranchFilter.cs
+++ b/NuKeeper/Engine/IExistingBranchFilter.cs
@@ -1,0 +1,10 @@
+﻿using NuKeeper.Git;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine
+{
+    public interface IExistingBranchFilter
+    {
+        bool Exists(IGitDriver git, PackageUpdateSet packageUpdateSet);
+    }
+}

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -62,7 +62,7 @@ namespace NuKeeper.Engine
 
         private string MakeBranchName(IGitDriver git, PackageUpdateSet updateSet)
         {
-            var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+            var branchName = BranchNamer.MakeName(updateSet);
             _logger.Verbose($"Using branch name: '{branchName}'");
 
             var qualifiedBranchName = "origin/" + branchName;

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.Engine
                 git.Checkout(defaultBranch);
 
                 // branch
-                var branchName = MakeBranchName(git, updateSet);
+                var branchName = MakeBranchName(updateSet);
                 git.CheckoutNewBranch(branchName);
 
                 await UpdateAllCurrentUsages(updateSet);
@@ -60,18 +60,10 @@ namespace NuKeeper.Engine
             }
         }
 
-        private string MakeBranchName(IGitDriver git, PackageUpdateSet updateSet)
+        private string MakeBranchName(PackageUpdateSet updateSet)
         {
             var branchName = BranchNamer.MakeName(updateSet);
             _logger.Verbose($"Using branch name: '{branchName}'");
-
-            var qualifiedBranchName = "origin/" + branchName;
-
-            if (git.BranchExists(qualifiedBranchName))
-            {
-                throw new Exception($"A Git branch named '{qualifiedBranchName}' already exists");
-            }
-
             return branchName;
         }
 

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -50,7 +50,14 @@ namespace NuKeeper.Git
 
         public void CheckoutNewBranch(string branchName)
         {
+            var qualifiedBranchName = "origin/" + branchName;
+            if (BranchExists(qualifiedBranchName))
+            {
+                throw new Exception($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+            }
+
             _logger.Verbose($"Git checkout new branch '{branchName}'");
+
             using (var repo = MakeRepo())
             {
                 var branch = repo.CreateBranch(branchName);


### PR DESCRIPTION
As discussed here https://github.com/NuKeeperDotNet/NuKeeper/pull/117
You can't make the same branch twice, so it was failing on a second run.
Instead of trying the same update with a different branch name,  make a different update.
When running again, try to make different update PRs
based on noticing that the Update's PR branch already exists.
