### PR TITLE
Push down the branch name check

### DIFF
--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -82,8 +82,7 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var target =
-                new PackageUpdateSelection(
+            var target = new PackageUpdateSelection(
                     new Settings(new RepositoryModeSettings { MaxPullRequestsPerRepository = 10 })
                     {
                         PackageIncludes = new Regex("bar")
@@ -126,7 +125,7 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var target =new PackageUpdateSelection(
+            var target = new PackageUpdateSelection(
                     new Settings(new RepositoryModeSettings { MaxPullRequestsPerRepository = 10 })
                     {
                         PackageExcludes = new Regex("bar"),

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -104,8 +104,7 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var target =
-                new PackageUpdateSelection(
+            var target = new PackageUpdateSelection(
                     new Settings(new RepositoryModeSettings { MaxPullRequestsPerRepository = 10 })
                     {
                         PackageExcludes = new Regex("bar")
@@ -127,8 +126,7 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var target =
-                new PackageUpdateSelection(
+            var target =new PackageUpdateSelection(
                     new Settings(new RepositoryModeSettings { MaxPullRequestsPerRepository = 10 })
                     {
                         PackageExcludes = new Regex("bar"),
@@ -208,7 +206,7 @@ namespace NuKeeper.Tests.Engine
         private static IPackageUpdateSelection OneTargetSelection()
         {
             const int maxPullRequests = 1;
-            var settings = new Settings(new RepositoryModeSettings()
+            var settings = new Settings(new RepositoryModeSettings
             {
                 MaxPullRequestsPerRepository = maxPullRequests
             });

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -39,7 +39,8 @@ namespace NuKeeper.Engine
                 git.Checkout(defaultBranch);
 
                 // branch
-                var branchName = MakeBranchName(git, updateSet);
+                var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+                _logger.Verbose($"Using branch name: '{branchName}'");
                 git.CheckoutNewBranch(branchName);
 
                 await UpdateAllCurrentUsages(updateSet);
@@ -58,21 +59,6 @@ namespace NuKeeper.Engine
             {
                 _logger.Error("Update failed", ex);
             }
-        }
-
-        private string MakeBranchName(IGitDriver git, PackageUpdateSet updateSet)
-        {
-            var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
-            _logger.Verbose($"Using branch name: '{branchName}'");
-
-            var qualifiedBranchName = "origin/" + branchName;
-
-            if (git.BranchExists(qualifiedBranchName))
-            {
-                throw new Exception($"A Git branch named '{qualifiedBranchName}' already exists");
-            }
-
-            return branchName;
         }
 
         private async Task UpdateAllCurrentUsages(PackageUpdateSet updateSet)

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -50,6 +50,12 @@ namespace NuKeeper.Git
 
         public void CheckoutNewBranch(string branchName)
         {
+            var qualifiedBranchName = "origin/" + branchName;
+            if (BranchExists(qualifiedBranchName))
+            {
+                throw new Exception($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+            }
+
             _logger.Verbose($"Git checkout new branch '{branchName}'");
             using (var repo = MakeRepo())
             {


### PR DESCRIPTION
Push the check on duplicate branch name down into the git driver
Salvaged from #118 
The rest of that will be refactored into in a separate PR (with tests), after which the duplicate branch names won't happen regularly any more