### PR TITLE
Filter out existing branches

### DIFF
--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0"></PackageReference>
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
 	<PackageReference Include="NUnit" Version="3.7.1"></PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>

--- a/NuKeeper/Engine/BranchNamer.cs
+++ b/NuKeeper/Engine/BranchNamer.cs
@@ -1,0 +1,12 @@
+﻿using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine
+{
+    public static class BranchNamer
+    {
+        public static string MakeName(PackageUpdateSet updateSet)
+        {
+            return $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+        }
+    }
+}

--- a/NuKeeper/Engine/IPackageUpdateSelection.cs
+++ b/NuKeeper/Engine/IPackageUpdateSelection.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
+using NuKeeper.Git;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
 {
     public interface IPackageUpdateSelection
     {
-        List<PackageUpdateSet> SelectTargets(IEnumerable<PackageUpdateSet> potentialUpdates);
+        List<PackageUpdateSet> SelectTargets(
+            IGitDriver git,
+            IEnumerable<PackageUpdateSet> potentialUpdates);
     }
 }

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.Engine
                 git.Checkout(defaultBranch);
 
                 // branch
-                var branchName = $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+                var branchName = BranchNamer.MakeName(updateSet);
                 _logger.Verbose($"Using branch name: '{branchName}'");
                 git.CheckoutNewBranch(branchName);
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.Engine
                 return;
             }
 
-            var targetUpdates = _updateSelection.SelectTargets(updates);
+            var targetUpdates = _updateSelection.SelectTargets(git, updates);
 
             await UpdateAllTargets(git, settings, targetUpdates, defaultBranch);
 


### PR DESCRIPTION
As discussed here https://github.com/NuKeeperDotNet/NuKeeper/pull/117
You can't make the same branch twice, so it was failing on a second run.
Instead of trying the same update with a different branch name,  make a different update.
When running again, try to make different update PRs
based on noticing that the Update's PR branch already exists.

This PR replaces #118 , but has tests and drags in `NSubstitute` as a mocking framework in the unit tests.