### PR TITLE
Less parse noise in a common case

### DIFF
--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -57,6 +57,11 @@ namespace NuKeeper.Configuration
 
         private static Regex ParseRegex(string regex, string optionName)
         {
+            if (string.IsNullOrWhiteSpace(regex))
+            {
+                return null;
+            }
+
             try
             {
                 return new Regex(regex);


### PR DESCRIPTION
Less parse noise (no `Console.WriteLine`) in the default case when there's no Include / Exclude regex