### PR TITLE
Allow a local version of NuGet.exe

### DIFF
--- a/NuKeeper/NuGet/Process/NuGetPath.cs
+++ b/NuKeeper/NuGet/Process/NuGetPath.cs
@@ -8,6 +8,31 @@ namespace NuKeeper.NuGet.Process
     {
         public static string FindExecutable()
         {
+            var localNugetPath = FindLocalNuget();
+
+            if (!string.IsNullOrEmpty(localNugetPath))
+            {
+                return localNugetPath;
+            }
+
+
+            return FindNugetInPackagesUnderProfile();
+        }
+
+        private static string FindLocalNuget()
+        {
+            var appDir = AppDomain.CurrentDomain.BaseDirectory;
+            var fullPath = Path.Combine(appDir, "NuGet.exe");
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+
+            return string.Empty;
+        }
+
+        private static string FindNugetInPackagesUnderProfile()
+        {
             var profile = Environment.GetEnvironmentVariable("userprofile");
 
             if (string.IsNullOrWhiteSpace(profile))


### PR DESCRIPTION
Use a local copy of `NuGet.exe` if it's present.

My thinking is that if/when we make builds of NuKeeper for people who want to use it but not develop it, then it can be useful to use a copy of `NuGet.exe` in the same folder, as the other mechanism may fail if the package is not present on that machine.