### PR TITLE
Refactoring lookups

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -12,7 +12,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task AmbigousPackageName_ShouldReturnCorrectResult()
         {
-            IApiPackageLookup lookup = new ApiPackageLookup(new NullNuGetLogger(), BuildDefaultSettings());
+            var lookup = BuildPackageLookup();
 
             var package = await lookup.LookupLatest("AWSSDK");
 
@@ -24,7 +24,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task UnknownPackageName_ShouldNotReturnResult()
         {
-            IApiPackageLookup lookup = new ApiPackageLookup(new NullNuGetLogger(), BuildDefaultSettings());
+            var lookup = BuildPackageLookup();
 
             var package = await lookup.LookupLatest(Guid.NewGuid().ToString());
 
@@ -34,7 +34,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task WellKnownPackageName_ShouldReturnResult()
         {
-            IApiPackageLookup lookup = new ApiPackageLookup(new NullNuGetLogger(), BuildDefaultSettings());
+            var lookup = BuildPackageLookup();
 
             var package = await lookup.LookupLatest("Newtonsoft.Json");
 
@@ -49,6 +49,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             {
                 NuGetSources = new[] {"https://api.nuget.org/v3/index.json"}
             };
+        }
+
+        private IApiPackageLookup BuildPackageLookup()
+        {
+            return new ApiPackageLookup(
+                new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -91,8 +91,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
         private static BulkPackageLookup BuildBulkPackageLookup()
         {
-            return new BulkPackageLookup(new ApiPackageLookup(new NullNuGetLogger(), BuildDefaultSettings()),
-                new NullNuKeeperLogger());
+            var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
+            return new BulkPackageLookup(lookup, new NullNuKeeperLogger());
         }
 
         private static Settings BuildDefaultSettings()

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -24,22 +24,6 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
             Assert.That(packageList[0].Identity.Id, Is.EqualTo("Newtonsoft.Json"));
         }
 
-        [Test]
-        public async Task WellKnownPackageName_ShouldReturnSortedResults()
-        {
-            var lookup = BuildPackageLookup();
-
-            var packages = await lookup.Lookup("Newtonsoft.Json");
-
-            Assert.That(packages, Is.Not.Null);
-
-            var versionList = packages
-                .Select(p => p.Identity.Version)
-                .ToList();
-
-            Assert.That(versionList, Is.Ordered.Descending);
-        }
-
         private IPackageVersionsLookup BuildPackageLookup()
         {
             return new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings());

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NuKeeper.Configuration;
+using NuKeeper.Integration.Tests.NuGet.Api;
+using NuKeeper.NuGet.Api;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.Nuget.Api
+{
+    [TestFixture]
+    public class PackageVersionsLookupTests
+    {
+        [Test]
+        public async Task WellKnownPackageName_ShouldReturnResults()
+        {
+            var lookup = BuildPackageLookup();
+
+            var packages = await lookup.Lookup("Newtonsoft.Json");
+
+            Assert.That(packages, Is.Not.Null);
+
+            var packageList = packages.ToList();
+            Assert.That(packageList, Is.Not.Empty);
+            Assert.That(packageList[0].Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+        }
+
+        [Test]
+        public async Task WellKnownPackageName_ShouldReturnSortedResults()
+        {
+            var lookup = BuildPackageLookup();
+
+            var packages = await lookup.Lookup("Newtonsoft.Json");
+
+            Assert.That(packages, Is.Not.Null);
+
+            var versionList = packages
+                .Select(p => p.Identity.Version)
+                .ToList();
+
+            Assert.That(versionList, Is.Ordered.Descending);
+        }
+
+        private IPackageVersionsLookup BuildPackageLookup()
+        {
+            return new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings());
+        }
+
+        private static Settings BuildDefaultSettings()
+        {
+            return new Settings((RepositoryModeSettings)null)
+            {
+                NuGetSources = new[] { "https://api.nuget.org/v3/index.json" }
+            };
+        }
+    }
+}

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using NuKeeper.NuGet.Api;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.NuGet.Api
+{
+    [TestFixture]
+    public class ApiPackageLookupTests
+    {
+        [Test]
+        public async Task WhenNoPackagesAreFound()
+        {
+            var allVersionsLookup = MockVersionLookup(new List<PackageSearchMedatadataWithSource>());
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var package = await lookup.LookupLatest("TestPackage");
+
+            Assert.That(package, Is.Null);
+        }
+
+        [Test]
+        public async Task WhenThereIsOnlyOneVersion()
+        {
+            var resultPackages = new List<PackageSearchMedatadataWithSource>
+            {
+                BuildMetadata("TestPackage", 2, 3, 4)
+            };
+
+            var allVersionsLookup = MockVersionLookup(resultPackages);
+
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var package = await lookup.LookupLatest("TestPackage");
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Identity, Is.Not.Null);
+            Assert.That(package.Identity.Id, Is.EqualTo("TestPackage"));
+            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
+        }
+
+        [Test]
+        public async Task ShouldPickLatestFromMultipleVersions()
+        {
+            var resultPackages = new List<PackageSearchMedatadataWithSource>
+            {
+                BuildMetadata("TestPackage", 2,3,4),
+                BuildMetadata("TestPackage", 1,23,55),
+                BuildMetadata("TestPackage", 8, 0,8),
+                BuildMetadata("TestPackage", 0,1,904)
+            };
+
+            var allVersionsLookup = MockVersionLookup(resultPackages);
+
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var package = await lookup.LookupLatest("TestPackage");
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Identity, Is.Not.Null);
+            Assert.That(package.Identity.Id, Is.EqualTo("TestPackage"));
+            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(8, 0, 8)));
+        }
+
+        private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadataWithSource> actualResults)
+        {
+            var allVersions = Substitute.For<IPackageVersionsLookup>();
+            allVersions.Lookup(Arg.Any<string>())
+                .Returns(actualResults);
+            return allVersions;
+        }
+
+        private static PackageSearchMedatadataWithSource BuildMetadata(string source, int major, int minor, int patch)
+        {
+            var version = new NuGetVersion(major, minor, patch);
+            var metadata = MetadataWithVersion(source, version);
+            return new PackageSearchMedatadataWithSource(source, metadata);
+        }
+
+        private static IPackageSearchMetadata MetadataWithVersion(string id, NuGetVersion version)
+        {
+            var metadata = Substitute.For<IPackageSearchMetadata>();
+            var identity = new PackageIdentity(id, version);
+            metadata.Identity.Returns(identity);
+            return metadata;
+        }
+    }
+}

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -32,6 +32,7 @@ namespace NuKeeper
             container.Register<IPackageUpdateSelection, PackageUpdateSelection>();
             container.Register<IPackageUpdatesLookup, PackageUpdatesLookup>();
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
+            container.Register<IPackageVersionsLookup, PackageVersionsLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();
             container.Register<IRepositoryScanner, RepositoryScanner>();
 

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -1,64 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+﻿using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
-using Settings = NuKeeper.Configuration.Settings;
 
 namespace NuKeeper.NuGet.Api
 {
     public class ApiPackageLookup : IApiPackageLookup
     {
-        private readonly ILogger _logger;
-        private readonly string[] _sources;
+        private readonly IPackageVersionsLookup _packageVersionsLookup;
 
-        public ApiPackageLookup(ILogger logger, Settings settings)
+        public ApiPackageLookup(IPackageVersionsLookup packageVersionsLookup)
         {
-            _logger = logger;
-            _sources = settings.NuGetSources;
+            _packageVersionsLookup = packageVersionsLookup;
         }
 
         public async Task<PackageSearchMedatadataWithSource> LookupLatest(string packageName)
         {
-            var versions = await Lookup(packageName);
-            return versions
-                .OrderByDescending(p => p?.Identity?.Version)
-                .FirstOrDefault();
-        }
-
-        private async Task<IEnumerable<PackageSearchMedatadataWithSource>> Lookup(string packageName)
-        {
-            var results = await Task.WhenAll(_sources.Select(source => RunFinderForSource(packageName, source)));
-            return results.SelectMany(r => r);
-        }
-
-        private async Task<IEnumerable<PackageSearchMedatadataWithSource>> RunFinderForSource(string packageName, string source)
-        {
-            var sourceRepository = BuildSourceRepository(source);
-            var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
-            var metadatas = await FindPackage(metadataResource, packageName);
-            return metadatas.Select(m => new PackageSearchMedatadataWithSource(source, m));
-        }
-
-        private static SourceRepository BuildSourceRepository(string source)
-        {
-            var packageSource = new PackageSource(source);
-
-            var providers = new List<Lazy<INuGetResourceProvider>>();
-            providers.AddRange(Repository.Provider.GetCoreV3()); // Add v3 API support
-
-            return new SourceRepository(packageSource, providers);
-        }
-
-        private async Task<IEnumerable<IPackageSearchMetadata>> FindPackage(
-            PackageMetadataResource metadataResource, string packageName)
-        {
-            return await metadataResource
-                .GetMetadataAsync(packageName, false, false, _logger, CancellationToken.None);
+            var versions = await _packageVersionsLookup.Lookup(packageName);
+            return versions.FirstOrDefault();
         }
     }
 }

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -15,7 +15,9 @@ namespace NuKeeper.NuGet.Api
         public async Task<PackageSearchMedatadataWithSource> LookupLatest(string packageName)
         {
             var versions = await _packageVersionsLookup.Lookup(packageName);
-            return versions.FirstOrDefault();
+            return versions
+                .OrderByDescending(p => p.Identity.Version)
+                .FirstOrDefault();
         }
     }
 }

--- a/NuKeeper/NuGet/Api/IPackageVersionsLookup.cs
+++ b/NuKeeper/NuGet/Api/IPackageVersionsLookup.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuKeeper.NuGet.Api
+{
+    public interface IPackageVersionsLookup
+    {
+        Task<IEnumerable<PackageSearchMedatadataWithSource>> Lookup(string packageName);
+    }
+}

--- a/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
@@ -27,8 +27,7 @@ namespace NuKeeper.NuGet.Api
             var results = await Task.WhenAll(_sources.Select(source => RunFinderForSource(packageName, source)));
             return results
                 .SelectMany(r => r)
-                .Where(p => p?.Identity?.Version != null)
-                .OrderByDescending(p => p.Identity.Version);
+                .Where(p => p?.Identity?.Version != null);
         }
 
         private async Task<IEnumerable<PackageSearchMedatadataWithSource>> RunFinderForSource(string packageName, string source)

--- a/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using Settings = NuKeeper.Configuration.Settings;
+
+namespace NuKeeper.NuGet.Api
+{
+    public class PackageVersionsLookup : IPackageVersionsLookup
+    {
+        private readonly ILogger _logger;
+        private readonly string[] _sources;
+
+        public PackageVersionsLookup(ILogger logger, Settings settings)
+        {
+            _logger = logger;
+            _sources = settings.NuGetSources;
+        }
+
+        public async Task<IEnumerable<PackageSearchMedatadataWithSource>> Lookup(string packageName)
+        {
+            var results = await Task.WhenAll(_sources.Select(source => RunFinderForSource(packageName, source)));
+            return results
+                .SelectMany(r => r)
+                .Where(p => p?.Identity?.Version != null)
+                .OrderByDescending(p => p.Identity.Version);
+        }
+
+        private async Task<IEnumerable<PackageSearchMedatadataWithSource>> RunFinderForSource(string packageName, string source)
+        {
+            var sourceRepository = BuildSourceRepository(source);
+            var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
+            var metadatas = await FindPackage(metadataResource, packageName);
+            return metadatas.Select(m => new PackageSearchMedatadataWithSource(source, m));
+        }
+
+        private static SourceRepository BuildSourceRepository(string source)
+        {
+            var packageSource = new PackageSource(source);
+
+            var providers = new List<Lazy<INuGetResourceProvider>>();
+            providers.AddRange(Repository.Provider.GetCoreV3()); // Add v3 API support
+
+            return new SourceRepository(packageSource, providers);
+        }
+
+        private async Task<IEnumerable<IPackageSearchMetadata>> FindPackage(
+            PackageMetadataResource metadataResource, string packageName)
+        {
+            return await metadataResource
+                .GetMetadataAsync(packageName, false, false, _logger, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Split up `ApiPackageLookup`, to put the parts under test (Integration and unit) and to make it easier to do something else besides the globally latest version (e.g. only minor version update)


