### PR TITLE
Rework RepositoryScanner

### DIFF
--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -13,10 +13,10 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
     [TestFixture]
     public class RepositoryScannerTests
     {
-        const string SinglePackageinFile =
+        const string SinglePackageInFile =
             @"<?xml version=""1.0"" encoding=""utf-8""?>
 <packages>
-  <package id=""foo"" version=""1.2.3.4"" targetFramework=""net45"" />
+  <package id=""foo"" version=""1.2.3"" targetFramework=""net45"" />
 </packages>";
 
         const string Vs2017ProjectFileTemplateWithPackages =
@@ -43,7 +43,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             var scanner = MakeScanner();
 
             var temporaryPath = GetUniqueTempFolder();
-            WriteFile(temporaryPath, "packages.config", SinglePackageinFile);
+            WriteFile(temporaryPath, "packages.config", SinglePackageInFile);
 
             var results = scanner.FindAllNuGetPackages(temporaryPath);
 
@@ -56,7 +56,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             var scanner = MakeScanner();
 
             var temporaryPath = GetUniqueTempFolder();
-            WriteFile(temporaryPath, "packages.config", SinglePackageinFile);
+            WriteFile(temporaryPath, "packages.config", SinglePackageInFile);
 
             var results = scanner.FindAllNuGetPackages(temporaryPath);
 

--- a/NuKeeper.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
@@ -1,4 +1,5 @@
-﻿using NuKeeper.RepositoryInspection;
+﻿using System.IO;
+using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
 
 namespace NuKeeper.Tests.RepositoryInspection
@@ -6,23 +7,26 @@ namespace NuKeeper.Tests.RepositoryInspection
     [TestFixture]
     public class DirectoryExclusionsTests
     {
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\NuKeeper.csproj")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\GitHub\\IGithub.cs")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\dustbin.cs")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\objections.cs")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\Packages.cs")]
-        public void ShouldBeIncluded(string path)
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}NuKeeper.csproj")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}GitHub{sep}IGithub.cs")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}dustbin.cs")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}objections.cs")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}Packages.cs")]
+        public void ShouldBeIncluded(string pathTemplate)
         {
+            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}");
             var actual = DirectoryExclusions.PathIsExcluded(path);
             Assert.That(actual, Is.False);
         }
 
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\bin\\debug\\net461\\config.json")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\obj\\debug\\net461\\config.json")]
-        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\packages\\foo.text")]
-        [TestCase("C:\\Code\\NuKeeper\\.git\\config")]
-        public void ShouldBeExcluded(string path)
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}bin{sep}debug{sep}net461{sep}config.json")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}obj{sep}debug{sep}net461{sep}config.json")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}packages{sep}foo.text")]
+        [TestCase("C:{sep}Code{sep}NuKeeper{sep}.git{sep}config")]
+        public void ShouldBeExcluded(string pathTemplate)
         {
+            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}");
+
             var actual = DirectoryExclusions.PathIsExcluded(path);
             Assert.That(actual, Is.True);
         }

--- a/NuKeeper.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
@@ -1,0 +1,30 @@
+﻿using NuKeeper.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class DirectoryExclusionsTests
+    {
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\NuKeeper.csproj")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\GitHub\\IGithub.cs")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\dustbin.cs")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\objections.cs")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\Packages.cs")]
+        public void ShouldBeIncluded(string path)
+        {
+            var actual = DirectoryExclusions.PathIsExcluded(path);
+            Assert.That(actual, Is.False);
+        }
+
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\bin\\debug\\net461\\config.json")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\obj\\debug\\net461\\config.json")]
+        [TestCase("C:\\Code\\NuKeeper\\NuKeeper\\packages\\foo.text")]
+        [TestCase("C:\\Code\\NuKeeper\\.git\\config")]
+        public void ShouldBeExcluded(string path)
+        {
+            var actual = DirectoryExclusions.PathIsExcluded(path);
+            Assert.That(actual, Is.True);
+        }
+    }
+}

--- a/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace NuKeeper.RepositoryInspection
@@ -9,14 +8,17 @@ namespace NuKeeper.RepositoryInspection
     {
         public static bool PathIsExcluded(string path)
         {
-            // subDir is a full path, check the last part
-            var dirName = new DirectoryInfo(path).Name;
-            return IsExcluded(dirName);
+            // subDir is a full path, check all parts
+            return ExcludedDirNames.Any(s => StringContains(path, s));
         }
 
-        private static bool IsExcluded(string dirName)
+        private static bool StringContains(string fullPath, string test)
         {
-            return ExcludedDirNames.Any(s => string.Equals(s, dirName, StringComparison.OrdinalIgnoreCase));
+            var testInPath = "\\" + test + "\\";
+
+            return 
+                !string.IsNullOrEmpty(fullPath) &&
+                 (fullPath.IndexOf(testInPath, StringComparison.InvariantCultureIgnoreCase) >= 0);
         }
 
         private static readonly List<string> ExcludedDirNames = new List<string>

--- a/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
@@ -9,16 +9,16 @@ namespace NuKeeper.RepositoryInspection
         public static bool PathIsExcluded(string path)
         {
             // subDir is a full path, check all parts
-            return ExcludedDirNames.Any(s => StringContains(path, s));
+            return ExcludedDirNames.Any(s => PathContains(path, s));
         }
 
-        private static bool StringContains(string fullPath, string test)
+        private static bool PathContains(string fullPath, string dirName)
         {
-            var testInPath = "\\" + test + "\\";
+            var dirInPath = "\\" + dirName + "\\";
 
             return 
                 !string.IsNullOrEmpty(fullPath) &&
-                 (fullPath.IndexOf(testInPath, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                 (fullPath.IndexOf(dirInPath, StringComparison.InvariantCultureIgnoreCase) >= 0);
         }
 
         private static readonly List<string> ExcludedDirNames = new List<string>

--- a/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper/RepositoryInspection/DirectoryExclusions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace NuKeeper.RepositoryInspection
@@ -14,7 +15,7 @@ namespace NuKeeper.RepositoryInspection
 
         private static bool PathContains(string fullPath, string dirName)
         {
-            var dirInPath = "\\" + dirName + "\\";
+            var dirInPath = Path.DirectorySeparatorChar + dirName + Path.DirectorySeparatorChar;
 
             return 
                 !string.IsNullOrEmpty(fullPath) &&

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -20,7 +20,8 @@ namespace NuKeeper.RepositoryInspection
 
             return 
                 PackageFiles(workingFolder)
-                .Concat(ProjectFiles(workingFolder));
+                .Concat(ProjectFiles(workingFolder))
+                .ToList();
         }
 
         private IEnumerable<PackageInProject> PackageFiles(IFolder workingFolder)
@@ -49,7 +50,7 @@ namespace NuKeeper.RepositoryInspection
 
             foreach (var projectFile in projectFiles)
             {
-                var path = MakePackagePath(workingFolder.FullPath, projectFile.FullName, PackageReferenceType.PackagesConfig);
+                var path = MakePackagePath(workingFolder.FullPath, projectFile.FullName, PackageReferenceType.ProjectFile);
                 var packages = _projectFileReader.ReadFile(path);
                 results.AddRange(packages);
             }


### PR DESCRIPTION
Rework `RepositoryScanner` to use the `IFolder.Find()` abstraction over the framework file and folder classes.

So it's not recursive any more.

And `DirectoryExclusions` has to work differently, and is brought under test.

`RepositoryScanner`  _should_ be unit tested and _will_ be unit tested, real soon. But not in this PR. We do have more integration tests though.