### PR TITLE
Use PackageIdentity not name to lookup

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Configuration;
 using NuKeeper.NuGet.Api;
 using NUnit.Framework;
@@ -14,7 +16,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.LookupLatest("AWSSDK");
+            var package = await lookup.FindVersionUpdate(Current("AWSSDK"));
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -26,7 +28,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.LookupLatest(Guid.NewGuid().ToString());
+            var package = await lookup.FindVersionUpdate(Current(Guid.NewGuid().ToString()));
 
             Assert.That(package, Is.Null);
         }
@@ -36,7 +38,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.LookupLatest("Newtonsoft.Json");
+            var package = await lookup.FindVersionUpdate(Current("Newtonsoft.Json"));
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -55,6 +57,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             return new ApiPackageLookup(
                 new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
+        }
+
+        private PackageIdentity Current(string packageId)
+        {
+            return new PackageIdentity(packageId, new NuGetVersion(1,2,3));
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Configuration;
 using NuKeeper.NuGet.Api;
 using NUnit.Framework;
@@ -14,7 +16,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task CanFindUpdateForOneWellKnownPackage()
         {
-            var packages = new List<string> {"Moq"};
+            var packages = new List<PackageIdentity> { Current("Moq") };
 
             var lookup = BuildBulkPackageLookup();
 
@@ -28,10 +30,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task CanFindUpdateForTwoWellKnownPackages()
         {
-            var packages = new List<string>
+            var packages = new List<PackageIdentity>
             {
-                "Moq",
-                "Newtonsoft.Json"
+                Current("Moq"),
+                Current("Newtonsoft.Json")
             };
 
             var lookup = BuildBulkPackageLookup();
@@ -47,7 +49,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task InvalidPackageIsIgnored()
         {
-            var packages = new List<string> {Guid.NewGuid().ToString()};
+            var packages = new List<PackageIdentity>
+            {
+                Current(Guid.NewGuid().ToString())
+            };
 
             var lookup = BuildBulkPackageLookup();
 
@@ -62,7 +67,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(Enumerable.Empty<string>());
+            var results = await lookup.LatestVersions(Enumerable.Empty<PackageIdentity>());
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -71,12 +76,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         [Test]
         public async Task ValidPackagesWorkDespiteInvalidPackages()
         {
-            var packages = new List<string>
+            var packages = new List<PackageIdentity>
             {
-                "Moq",
-                Guid.NewGuid().ToString(),
-                "Newtonsoft.Json",
-                Guid.NewGuid().ToString()
+                Current("Moq"),
+                Current(Guid.NewGuid().ToString()),
+                Current("Newtonsoft.Json"),
+                Current(Guid.NewGuid().ToString())
             };
 
             var lookup = BuildBulkPackageLookup();
@@ -101,6 +106,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             {
                 NuGetSources = new[] {"https://api.nuget.org/v3/index.json"}
             };
+        }
+
+        private PackageIdentity Current(string packageId)
+        {
+            return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
         }
     }
 }

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var allVersionsLookup = MockVersionLookup(new List<PackageSearchMedatadataWithSource>());
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.LookupLatest("TestPackage");
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
 
             Assert.That(package, Is.Null);
         }
@@ -35,7 +35,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.LookupLatest("TestPackage");
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -58,7 +58,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.LookupLatest("TestPackage");
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -87,6 +87,11 @@ namespace NuKeeper.Tests.NuGet.Api
             var identity = new PackageIdentity(id, version);
             metadata.Identity.Returns(identity);
             return metadata;
+        }
+
+        private PackageIdentity Current(string packageId)
+        {
+            return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
         }
     }
 }

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -132,6 +132,8 @@ namespace NuKeeper.Tests.NuGet.Api
             var results = await bulkLookup.LatestVersions(queries);
 
             await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>());
+            await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(
+                pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)));
 
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results.ContainsKey("foo"), Is.True);

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -1,0 +1,158 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using NuKeeper.NuGet.Api;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.NuGet.Api
+{
+    [TestFixture]
+    public class BulkPackageLookupTests
+    {
+        [Test]
+        public async Task CanLookupEmptyList()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var results = await bulkLookup.LatestVersions(Enumerable.Empty<PackageIdentity>());
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results, Is.Empty);
+
+            await apiLookup.DidNotReceive().FindVersionUpdate(Arg.Any<PackageIdentity>());
+        }
+
+        [Test]
+        public async Task CanLookupOnePackage()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+
+            ApiHasNewVersionForPackage(apiLookup, "foo");
+
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var queries = new List<PackageIdentity>
+            {
+                new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
+            };
+
+            var results = await bulkLookup.LatestVersions(queries);
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results, Is.Not.Empty);
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.ContainsKey("foo"), Is.True);
+        }
+
+        [Test]
+        public async Task LookupOnePackageCallsApiOnce()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+
+            ApiHasNewVersionForPackage(apiLookup, "foo");
+
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var queries = new List<PackageIdentity>
+            {
+                new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
+            };
+
+            await bulkLookup.LatestVersions(queries);
+
+            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>());
+        }
+
+        [Test]
+        public async Task CanLookupTwoPackages()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+
+            ApiHasNewVersionForPackage(apiLookup, "foo");
+            ApiHasNewVersionForPackage(apiLookup, "bar");
+
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var queries = new List<PackageIdentity>
+            {
+                new PackageIdentity("foo", new NuGetVersion(1, 2, 3)),
+                new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
+            };
+
+            var results = await bulkLookup.LatestVersions(queries);
+
+            Assert.That(results.Count, Is.EqualTo(2));
+            Assert.That(results.ContainsKey("foo"), Is.True);
+            Assert.That(results.ContainsKey("bar"), Is.True);
+            Assert.That(results.ContainsKey("fish"), Is.False);
+        }
+
+        [Test]
+        public async Task LookupTwoPackagesCallsApiTwice()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+
+            ApiHasNewVersionForPackage(apiLookup, "foo");
+            ApiHasNewVersionForPackage(apiLookup, "bar");
+
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var queries = new List<PackageIdentity>
+            {
+                new PackageIdentity("foo", new NuGetVersion(1, 2, 3)),
+                new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
+            };
+
+            await bulkLookup.LatestVersions(queries);
+
+            await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>());
+        }
+
+
+        [Test]
+        public async Task WhenThereAreMultipleVersionOfTheSamePackage()
+        {
+            var apiLookup = Substitute.For<IApiPackageLookup>();
+
+            ApiHasNewVersionForPackage(apiLookup, "foo");
+
+            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+
+            var queries = new List<PackageIdentity>
+            {
+                new PackageIdentity("foo", new NuGetVersion(1, 2, 3)),
+                new PackageIdentity("foo", new NuGetVersion(1, 3, 4))
+            };
+
+            var results = await bulkLookup.LatestVersions(queries);
+
+            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>());
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.ContainsKey("foo"), Is.True);
+            Assert.That(results.ContainsKey("bar"), Is.False);
+        }
+
+        private static IPackageSearchMetadata MetadataWithVersion(string id, NuGetVersion version)
+        {
+            var metadata = Substitute.For<IPackageSearchMetadata>();
+            var identity = new PackageIdentity(id, version);
+            metadata.Identity.Returns(identity);
+            return metadata;
+        }
+
+        private static void ApiHasNewVersionForPackage(IApiPackageLookup lookup, string packageName)
+        {
+            var responseMetaData = new PackageSearchMedatadataWithSource(
+                "test", MetadataWithVersion(packageName, new NuGetVersion(2, 3, 4)));
+
+            lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName))
+                .Returns(responseMetaData);
+    }
+}
+}

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
 
 namespace NuKeeper.NuGet.Api
 {
@@ -12,9 +13,9 @@ namespace NuKeeper.NuGet.Api
             _packageVersionsLookup = packageVersionsLookup;
         }
 
-        public async Task<PackageSearchMedatadataWithSource> LookupLatest(string packageName)
+        public async Task<PackageSearchMedatadataWithSource> FindVersionUpdate(PackageIdentity package)
         {
-            var versions = await _packageVersionsLookup.Lookup(packageName);
+            var versions = await _packageVersionsLookup.Lookup(package.Id);
             return versions
                 .OrderByDescending(p => p.Identity.Version)
                 .FirstOrDefault();

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -1,8 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Protocol.Core.Types;
+using NuGet.Packaging.Core;
 using NuKeeper.Logging;
 
 namespace NuKeeper.NuGet.Api
@@ -18,10 +17,10 @@ namespace NuKeeper.NuGet.Api
             _logger = logger;
         }
 
-        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<string> packageIds)
+        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages)
         {
-            var lookupTasks = packageIds
-                .Select(id => _packageLookup.LookupLatest(id))
+            var lookupTasks = packages
+                .Select(id => _packageLookup.FindVersionUpdate(id))
                 .ToList();
 
             await Task.WhenAll(lookupTasks);

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -19,7 +19,11 @@ namespace NuKeeper.NuGet.Api
 
         public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages)
         {
-            var lookupTasks = packages
+            var latestOfEach = packages
+                .GroupBy(pi => pi.Id)
+                .Select(HighestVersion);
+
+            var lookupTasks = latestOfEach
                 .Select(id => _packageLookup.FindVersionUpdate(id))
                 .ToList();
 
@@ -39,6 +43,13 @@ namespace NuKeeper.NuGet.Api
             }
 
             return result;
+        }
+
+        private PackageIdentity HighestVersion(IEnumerable<PackageIdentity> packages)
+        {
+            return packages
+                .OrderByDescending(p => p.Version)
+                .FirstOrDefault();
         }
     }
 }

--- a/NuKeeper/NuGet/Api/IApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IApiPackageLookup.cs
@@ -1,9 +1,10 @@
 ﻿using System.Threading.Tasks;
+using NuGet.Packaging.Core;
 
 namespace NuKeeper.NuGet.Api
 {
     public interface IApiPackageLookup
     {
-        Task<PackageSearchMedatadataWithSource> LookupLatest(string packageName);
+        Task<PackageSearchMedatadataWithSource> FindVersionUpdate(PackageIdentity package);
     }
 }

--- a/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
 
 namespace NuKeeper.NuGet.Api
 {
     public interface IBulkPackageLookup
     {
-        Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<string> packageIds);
+        Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages);
     }
 }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.NuGet.Api
         public async Task<List<PackageUpdateSet>> FindUpdatesForPackages(IReadOnlyCollection<PackageInProject> packages)
         {
             var packageIds = packages
-                .Select(p => p.Id)
+                .Select(p => p.Identity)
                 .Distinct();
 
             var latestVersions = await _bulkPackageLookup.LatestVersions(packageIds);


### PR DESCRIPTION
As discussed in #126 , look up updates for a `PackageIdentity`  containing name and version rather than just a name. This is needed for later changes, but should not itself cause any functional changes.

