### PR TITLE
Control allowed Version change

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.FindVersionUpdate(Current("AWSSDK"));
+            var package = await lookup.FindVersionUpdate(Current("AWSSDK"), VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -28,7 +28,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.FindVersionUpdate(Current(Guid.NewGuid().ToString()));
+            var package = await lookup.FindVersionUpdate(
+                Current(Guid.NewGuid().ToString()), 
+                VersionChange.Major);
 
             Assert.That(package, Is.Null);
         }
@@ -38,7 +40,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.FindVersionUpdate(Current("Newtonsoft.Json"));
+            var package = await lookup.FindVersionUpdate(
+                Current("Newtonsoft.Json"), 
+                VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -37,22 +37,14 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Major);
 
-            Assert.That(package, Is.Not.Null);
-            Assert.That(package.Identity, Is.Not.Null);
-            Assert.That(package.Identity.Id, Is.EqualTo("TestPackage"));
+            AssertPackageIdentityIs(package, "TestPackage");
             Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
         }
 
         [Test]
-        public async Task ShouldPickLatestFromMultipleVersions()
+        public async Task ShouldPickLatestMajorFromMultipleVersions()
         {
-            var resultPackages = new List<PackageSearchMedatadataWithSource>
-            {
-                BuildMetadata("TestPackage", 2,3,4),
-                BuildMetadata("TestPackage", 1,23,55),
-                BuildMetadata("TestPackage", 8, 0,8),
-                BuildMetadata("TestPackage", 0,1,904)
-            };
+            var resultPackages = SeveralVersions();
 
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
@@ -60,10 +52,61 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Major);
 
-            Assert.That(package, Is.Not.Null);
-            Assert.That(package.Identity, Is.Not.Null);
-            Assert.That(package.Identity.Id, Is.EqualTo("TestPackage"));
-            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(8, 0, 8)));
+            AssertPackageIdentityIs(package, "TestPackage");
+            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
+        }
+
+        [Test]
+        public async Task ShouldPickLatestMinorFromMultipleVersions()
+        {
+            var resultPackages = SeveralVersions();
+
+            var allVersionsLookup = MockVersionLookup(resultPackages);
+
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Minor);
+
+            AssertPackageIdentityIs(package, "TestPackage");
+            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(1, 3, 1)));
+        }
+
+        [Test]
+        public async Task ShouldPickLatestPatchFromMultipleVersions()
+        {
+            var resultPackages = SeveralVersions();
+
+            var allVersionsLookup = MockVersionLookup(resultPackages);
+
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Minor);
+
+            AssertPackageIdentityIs(package, "TestPackage");
+            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 5)));
+        }
+
+
+        private static List<PackageSearchMedatadataWithSource> SeveralVersions()
+        {
+            return new List<PackageSearchMedatadataWithSource>
+            {
+                BuildMetadata("TestPackage", 2, 3, 4),
+                BuildMetadata("TestPackage", 2, 1, 1),
+                BuildMetadata("TestPackage", 2, 0, 0),
+
+                BuildMetadata("TestPackage", 1, 3, 1),
+                BuildMetadata("TestPackage", 1, 3, 0),
+
+                BuildMetadata("TestPackage", 1, 2, 5),
+                BuildMetadata("TestPackage", 1, 2, 4),
+                BuildMetadata("TestPackage", 1, 2, 3),
+                BuildMetadata("TestPackage", 1, 2, 2),
+                BuildMetadata("TestPackage", 1, 2, 1),
+
+                BuildMetadata("TestPackage", 1, 1, 0),
+                BuildMetadata("TestPackage", 1, 0, 0)
+            };
         }
 
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadataWithSource> actualResults)
@@ -92,6 +135,13 @@ namespace NuKeeper.Tests.NuGet.Api
         private PackageIdentity Current(string packageId)
         {
             return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
+        }
+
+        private static void AssertPackageIdentityIs(PackageSearchMedatadataWithSource package, string id)
+        {
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Identity, Is.Not.Null);
+            Assert.That(package.Identity.Id, Is.EqualTo(id));
         }
     }
 }

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var allVersionsLookup = MockVersionLookup(new List<PackageSearchMedatadataWithSource>());
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Major);
 
             Assert.That(package, Is.Null);
         }
@@ -35,7 +35,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
@@ -58,7 +58,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.FindVersionUpdate(Current("TestPackage"));
+            var package = await lookup.FindVersionUpdate(Current("TestPackage"), VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NSubstitute;
 using NuGet.Packaging.Core;
-using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using NuKeeper.NuGet.Api;
 using NUnit.Framework;
@@ -28,7 +27,7 @@ namespace NuKeeper.Tests.NuGet.Api
         {
             var resultPackages = new List<PackageSearchMedatadataWithSource>
             {
-                BuildMetadata("TestPackage", 2, 3, 4)
+                PackageVersionTestData.BuildMetadata("TestPackage", 2, 3, 4)
             };
 
             var allVersionsLookup = MockVersionLookup(resultPackages);
@@ -48,7 +47,7 @@ namespace NuKeeper.Tests.NuGet.Api
             int expectedMajor, int expectedMinor, int expectedPatch)
         {
             var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
-            var resultPackages = VersionsFor(dataRange);
+            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
@@ -67,7 +66,7 @@ namespace NuKeeper.Tests.NuGet.Api
             int expectedMajor, int expectedMinor, int expectedPatch)
         {
             var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
-            var resultPackages = VersionsFor(dataRange);
+            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
@@ -86,7 +85,7 @@ namespace NuKeeper.Tests.NuGet.Api
             int expectedMajor, int expectedMinor, int expectedPatch)
         {
             var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
-            var resultPackages = VersionsFor(dataRange);
+            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
@@ -98,101 +97,12 @@ namespace NuKeeper.Tests.NuGet.Api
             Assert.That(package.Identity.Version, Is.EqualTo(expectedUpdate));
         }
 
-        private static List<PackageSearchMedatadataWithSource> VersionsFor(VersionChange change)
-        {
-            switch (change)
-            {
-                case VersionChange.Major:
-                    return AllKindsOfVersions();
-
-                case VersionChange.Minor:
-                    return MinorVersions();
-
-                case VersionChange.Patch:
-                    return PatchVersions();
-
-                default:
-                    return new List<PackageSearchMedatadataWithSource>();
-            }
-        }
-
-
-        private static List<PackageSearchMedatadataWithSource> AllKindsOfVersions()
-        {
-            return new List<PackageSearchMedatadataWithSource>
-            {
-                BuildMetadata("TestPackage", 2, 3, 4),
-                BuildMetadata("TestPackage", 2, 1, 1),
-                BuildMetadata("TestPackage", 2, 0, 0),
-
-                BuildMetadata("TestPackage", 1, 3, 1),
-                BuildMetadata("TestPackage", 1, 3, 0),
-
-                BuildMetadata("TestPackage", 1, 2, 5),
-                BuildMetadata("TestPackage", 1, 2, 4),
-                BuildMetadata("TestPackage", 1, 2, 3),
-                BuildMetadata("TestPackage", 1, 2, 2),
-                BuildMetadata("TestPackage", 1, 2, 1),
-
-                BuildMetadata("TestPackage", 1, 1, 0),
-                BuildMetadata("TestPackage", 1, 0, 0)
-            };
-        }
-
-        private static List<PackageSearchMedatadataWithSource> MinorVersions()
-        {
-            return new List<PackageSearchMedatadataWithSource>
-            {
-                BuildMetadata("TestPackage", 1, 3, 1),
-                BuildMetadata("TestPackage", 1, 3, 0),
-
-                BuildMetadata("TestPackage", 1, 2, 5),
-                BuildMetadata("TestPackage", 1, 2, 4),
-                BuildMetadata("TestPackage", 1, 2, 3),
-                BuildMetadata("TestPackage", 1, 2, 2),
-                BuildMetadata("TestPackage", 1, 2, 1),
-
-                BuildMetadata("TestPackage", 1, 1, 0),
-                BuildMetadata("TestPackage", 1, 0, 0)
-            };
-        }
-
-        private static List<PackageSearchMedatadataWithSource> PatchVersions()
-        {
-            return new List<PackageSearchMedatadataWithSource>
-            {
-                BuildMetadata("TestPackage", 1, 2, 5),
-                BuildMetadata("TestPackage", 1, 2, 4),
-                BuildMetadata("TestPackage", 1, 2, 3),
-                BuildMetadata("TestPackage", 1, 2, 2),
-                BuildMetadata("TestPackage", 1, 2, 1),
-
-                BuildMetadata("TestPackage", 1, 1, 0),
-                BuildMetadata("TestPackage", 1, 0, 0)
-            };
-        }
-
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadataWithSource> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();
             allVersions.Lookup(Arg.Any<string>())
                 .Returns(actualResults);
             return allVersions;
-        }
-
-        private static PackageSearchMedatadataWithSource BuildMetadata(string source, int major, int minor, int patch)
-        {
-            var version = new NuGetVersion(major, minor, patch);
-            var metadata = MetadataWithVersion(source, version);
-            return new PackageSearchMedatadataWithSource(source, metadata);
-        }
-
-        private static IPackageSearchMetadata MetadataWithVersion(string id, NuGetVersion version)
-        {
-            var metadata = Substitute.For<IPackageSearchMetadata>();
-            var identity = new PackageIdentity(id, version);
-            metadata.Identity.Returns(identity);
-            return metadata;
         }
 
         private PackageIdentity CurrentVersion123(string packageId)

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -43,6 +43,7 @@ namespace NuKeeper.Tests.NuGet.Api
         [TestCase(VersionChange.Major, 2, 3, 4)]
         [TestCase(VersionChange.Minor, 1, 3, 1)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenMajorVersionChangesAreAllowed(VersionChange dataRange,
             int expectedMajor, int expectedMinor, int expectedPatch)
         {
@@ -62,6 +63,7 @@ namespace NuKeeper.Tests.NuGet.Api
         [TestCase(VersionChange.Major, 1, 3, 1)]
         [TestCase(VersionChange.Minor, 1, 3, 1)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenMinorVersionChangesAreAllowed(VersionChange dataRange,
             int expectedMajor, int expectedMinor, int expectedPatch)
         {
@@ -81,6 +83,7 @@ namespace NuKeeper.Tests.NuGet.Api
         [TestCase(VersionChange.Major, 1, 2, 5)]
         [TestCase(VersionChange.Minor, 1, 2, 5)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenPatchVersionChangesAreAllowed(VersionChange dataRange,
             int expectedMajor, int expectedMinor, int expectedPatch)
         {

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -24,7 +24,7 @@ namespace NuKeeper.Tests.NuGet.Api
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
 
-            await apiLookup.DidNotReceive().FindVersionUpdate(Arg.Any<PackageIdentity>());
+            await apiLookup.DidNotReceive().FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             await bulkLookup.LatestVersions(queries);
 
-            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>());
+            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             await bulkLookup.LatestVersions(queries);
 
-            await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>());
+            await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
 
 
@@ -131,9 +131,9 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var results = await bulkLookup.LatestVersions(queries);
 
-            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>());
+            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
             await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(
-                pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)));
+                pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)), Arg.Any<VersionChange>());
 
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results.ContainsKey("foo"), Is.True);
@@ -153,7 +153,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var responseMetaData = new PackageSearchMedatadataWithSource(
                 "test", MetadataWithVersion(packageName, new NuGetVersion(2, 3, 4)));
 
-            lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName))
+            lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
                 .Returns(responseMetaData);
     }
 }

--- a/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using NuKeeper.NuGet.Api;
+
+namespace NuKeeper.Tests.NuGet.Api
+{
+    public static class PackageVersionTestData
+    {
+        public static List<PackageSearchMedatadataWithSource> VersionsFor(VersionChange change)
+        {
+            switch (change)
+            {
+                case VersionChange.Major:
+                    return NewMajorVersion()
+                        .Concat(MinorVersions())
+                        .Concat(PatchVersions())
+                        .ToList();
+
+                case VersionChange.Minor:
+                    return MinorVersions()
+                        .Concat(PatchVersions())
+                        .ToList();
+
+                case VersionChange.Patch:
+                    return PatchVersions();
+
+                default:
+                    return new List<PackageSearchMedatadataWithSource>();
+            }
+        }
+
+
+        private static List<PackageSearchMedatadataWithSource> NewMajorVersion()
+        {
+            return new List<PackageSearchMedatadataWithSource>
+                {
+                    BuildMetadata("TestPackage", 2, 3, 4),
+                    BuildMetadata("TestPackage", 2, 3, 1),
+                    BuildMetadata("TestPackage", 2, 1, 1),
+                    BuildMetadata("TestPackage", 2, 1, 0),
+                    BuildMetadata("TestPackage", 2, 0, 1),
+                    BuildMetadata("TestPackage", 2, 0, 0)
+                };
+        }
+
+        private static List<PackageSearchMedatadataWithSource> MinorVersions()
+        {
+            return new List<PackageSearchMedatadataWithSource>
+                {
+                    BuildMetadata("TestPackage", 1, 3, 1),
+                    BuildMetadata("TestPackage", 1, 3, 0)
+                };
+        }
+
+        private static List<PackageSearchMedatadataWithSource> PatchVersions()
+        {
+            return new List<PackageSearchMedatadataWithSource>
+            {
+                BuildMetadata("TestPackage", 1, 2, 5),
+                BuildMetadata("TestPackage", 1, 2, 4),
+                BuildMetadata("TestPackage", 1, 2, 3),
+                BuildMetadata("TestPackage", 1, 2, 2),
+                BuildMetadata("TestPackage", 1, 2, 1),
+                BuildMetadata("TestPackage", 1, 2, 0),
+
+                BuildMetadata("TestPackage", 1, 1, 0),
+                BuildMetadata("TestPackage", 1, 0, 0)
+            };
+        }
+
+        public static PackageSearchMedatadataWithSource BuildMetadata(string source, int major, int minor, int patch)
+        {
+            var version = new NuGetVersion(major, minor, patch);
+            var metadata = MetadataWithVersion(source, version);
+            return new PackageSearchMedatadataWithSource(source, metadata);
+        }
+
+        private static IPackageSearchMetadata MetadataWithVersion(string id, NuGetVersion version)
+        {
+            var metadata = Substitute.For<IPackageSearchMetadata>();
+            var identity = new PackageIdentity(id, version);
+            metadata.Identity.Returns(identity);
+            return metadata;
+        }
+    }
+}

--- a/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NSubstitute;
 using NuGet.Packaging.Core;
@@ -28,11 +29,13 @@ namespace NuKeeper.Tests.NuGet.Api
                 case VersionChange.Patch:
                     return PatchVersions();
 
+                case VersionChange.None:
+                    return CurrentVersionOnly();
+
                 default:
-                    return new List<PackageSearchMedatadataWithSource>();
+                    throw new Exception($"Invalid version change {change}");
             }
         }
-
 
         private static List<PackageSearchMedatadataWithSource> NewMajorVersion()
         {
@@ -69,6 +72,14 @@ namespace NuKeeper.Tests.NuGet.Api
 
                 BuildMetadata("TestPackage", 1, 1, 0),
                 BuildMetadata("TestPackage", 1, 0, 0)
+            };
+        }
+
+        private static List<PackageSearchMedatadataWithSource> CurrentVersionOnly()
+        {
+            return new List<PackageSearchMedatadataWithSource>
+            {
+                BuildMetadata("TestPackage", 1, 2, 3)
             };
         }
 

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -16,10 +16,12 @@ namespace NuKeeper.NuGet.Api
         public async Task<PackageSearchMedatadataWithSource> FindVersionUpdate(
             PackageIdentity package, VersionChange allowedChange)
         {
+            var filter = VersionChangeFilter.FilterFor(allowedChange);
+
             var versions = await _packageVersionsLookup.Lookup(package.Id);
             return versions
                 .OrderByDescending(p => p.Identity.Version)
-                .FirstOrDefault();
+                .FirstOrDefault(p => filter(package.Version, p.Identity.Version));
         }
     }
 }

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -13,7 +13,8 @@ namespace NuKeeper.NuGet.Api
             _packageVersionsLookup = packageVersionsLookup;
         }
 
-        public async Task<PackageSearchMedatadataWithSource> FindVersionUpdate(PackageIdentity package)
+        public async Task<PackageSearchMedatadataWithSource> FindVersionUpdate(
+            PackageIdentity package, VersionChange allowedChange)
         {
             var versions = await _packageVersionsLookup.Lookup(package.Id);
             return versions

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -24,7 +24,7 @@ namespace NuKeeper.NuGet.Api
                 .Select(HighestVersion);
 
             var lookupTasks = latestOfEach
-                .Select(id => _packageLookup.FindVersionUpdate(id))
+                .Select(id => _packageLookup.FindVersionUpdate(id, VersionChange.Major))
                 .ToList();
 
             await Task.WhenAll(lookupTasks);

--- a/NuKeeper/NuGet/Api/IApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IApiPackageLookup.cs
@@ -5,6 +5,7 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IApiPackageLookup
     {
-        Task<PackageSearchMedatadataWithSource> FindVersionUpdate(PackageIdentity package);
+        Task<PackageSearchMedatadataWithSource> FindVersionUpdate(
+            PackageIdentity package, VersionChange allowedChange);
     }
 }

--- a/NuKeeper/NuGet/Api/VersionChange.cs
+++ b/NuKeeper/NuGet/Api/VersionChange.cs
@@ -3,8 +3,8 @@
     public enum VersionChange
     {
         None = 0,
-        Patch,
-        Minor,
-        Major
+        Patch = 1,
+        Minor = 2,
+        Major = 3
     };
 }

--- a/NuKeeper/NuGet/Api/VersionChange.cs
+++ b/NuKeeper/NuGet/Api/VersionChange.cs
@@ -1,0 +1,10 @@
+﻿namespace NuKeeper.NuGet.Api
+{
+    public enum VersionChange
+    {
+        None = 0,
+        Patch,
+        Minor,
+        Major
+    };
+}

--- a/NuKeeper/NuGet/Api/VersionChange.cs
+++ b/NuKeeper/NuGet/Api/VersionChange.cs
@@ -1,32 +1,5 @@
-﻿using System;
-using NuGet.Versioning;
-
-namespace NuKeeper.NuGet.Api
+﻿namespace NuKeeper.NuGet.Api
 {
-    public static class VersionChangeFilter
-    {
-        public static Func<NuGetVersion, NuGetVersion, bool> FilterFor(VersionChange allowedChange)
-        {
-            switch (allowedChange)
-            {
-                case VersionChange.Major:
-                    return (v1, v2) => true;
-
-                case VersionChange.Minor:
-                    return (v1, v2) => v1.Major == v2.Major;
-
-                case VersionChange.Patch:
-                    return (v1, v2) => (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
-
-                case VersionChange.None:
-                    return (v1, v2) => (v1 == v2);
-
-                default:
-                    throw new Exception($"Unknown version change {allowedChange}");
-            }
-        }
-    }
-
     public enum VersionChange
     {
         None = 0,

--- a/NuKeeper/NuGet/Api/VersionChange.cs
+++ b/NuKeeper/NuGet/Api/VersionChange.cs
@@ -1,5 +1,32 @@
-﻿namespace NuKeeper.NuGet.Api
+﻿using System;
+using NuGet.Versioning;
+
+namespace NuKeeper.NuGet.Api
 {
+    public static class VersionChangeFilter
+    {
+        public static Func<NuGetVersion, NuGetVersion, bool> FilterFor(VersionChange allowedChange)
+        {
+            switch (allowedChange)
+            {
+                case VersionChange.Major:
+                    return (v1, v2) => true;
+
+                case VersionChange.Minor:
+                    return (v1, v2) => v1.Major == v2.Major;
+
+                case VersionChange.Patch:
+                    return (v1, v2) => (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
+
+                case VersionChange.None:
+                    return (v1, v2) => (v1 == v2);
+
+                default:
+                    throw new Exception($"Unknown version change {allowedChange}");
+            }
+        }
+    }
+
     public enum VersionChange
     {
         None = 0,

--- a/NuKeeper/NuGet/Api/VersionChangeFilter.cs
+++ b/NuKeeper/NuGet/Api/VersionChangeFilter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using NuGet.Versioning;
+
+namespace NuKeeper.NuGet.Api
+{
+    public static class VersionChangeFilter
+    {
+        public static Func<NuGetVersion, NuGetVersion, bool> FilterFor(VersionChange allowedChange)
+        {
+            switch (allowedChange)
+            {
+                case VersionChange.Major:
+                    return (v1, v2) => true;
+
+                case VersionChange.Minor:
+                    return (v1, v2) => v1.Major == v2.Major;
+
+                case VersionChange.Patch:
+                    return (v1, v2) => (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
+
+                case VersionChange.None:
+                    return (v1, v2) => (v1 == v2);
+
+                default:
+                    throw new Exception($"Unknown version change {allowedChange}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The engine work  for #126 is in this PR. And tests.
Not yet surfaced in a commandline flag.

we have the ` enum VersionChange { None = 0, Patch, Minor, Major }` Which controls which level of update should be selected to be applied.  `ApiPackageLookup` applies this by using the `VersionChangeFilter`.
There are sufficient tests.

No way to use this from the commandline, yet. That can be a different PR.