### PR TITLE
Two versions

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -19,8 +19,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             var package = await lookup.FindVersionUpdate(Current("AWSSDK"), VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
-            Assert.That(package.Identity, Is.Not.Null);
-            Assert.That(package.Identity.Id, Is.EqualTo("AWSSDK"));
+            Assert.That(package.Highest, Is.Not.Null);
+            Assert.That(package.HighestMatch, Is.Not.Null);
+            Assert.That(package.HighestMatch.Identity, Is.Not.Null);
+            Assert.That(package.HighestMatch.Identity.Id, Is.EqualTo("AWSSDK"));
         }
 
         [Test]
@@ -32,7 +34,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 Current(Guid.NewGuid().ToString()), 
                 VersionChange.Major);
 
-            Assert.That(package, Is.Null);
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Highest, Is.Null);
+            Assert.That(package.HighestMatch, Is.Null);
         }
 
         [Test]
@@ -45,8 +49,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
-            Assert.That(package.Identity, Is.Not.Null);
-            Assert.That(package.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+            Assert.That(package.Highest, Is.Not.Null);
+            Assert.That(package.HighestMatch, Is.Not.Null);
+            Assert.That(package.HighestMatch.Identity, Is.Not.Null);
+            Assert.That(package.HighestMatch.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
         }
 
         private static Settings BuildDefaultSettings()

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -20,9 +20,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Highest, Is.Not.Null);
-            Assert.That(package.HighestMatch, Is.Not.Null);
-            Assert.That(package.HighestMatch.Identity, Is.Not.Null);
-            Assert.That(package.HighestMatch.Identity.Id, Is.EqualTo("AWSSDK"));
+            Assert.That(package.Match, Is.Not.Null);
+            Assert.That(package.Match.Identity, Is.Not.Null);
+            Assert.That(package.Match.Identity.Id, Is.EqualTo("AWSSDK"));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Highest, Is.Null);
-            Assert.That(package.HighestMatch, Is.Null);
+            Assert.That(package.Match, Is.Null);
         }
 
         [Test]
@@ -50,9 +50,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Highest, Is.Not.Null);
-            Assert.That(package.HighestMatch, Is.Not.Null);
-            Assert.That(package.HighestMatch.Identity, Is.Not.Null);
-            Assert.That(package.HighestMatch.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+            Assert.That(package.Match, Is.Not.Null);
+            Assert.That(package.Match.Identity, Is.Not.Null);
+            Assert.That(package.Match.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
         }
 
         private static Settings BuildDefaultSettings()

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -96,8 +96,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
         private static BulkPackageLookup BuildBulkPackageLookup()
         {
+            var nuKeeperLogger = new NullNuKeeperLogger();
             var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
-            return new BulkPackageLookup(lookup, new NullNuKeeperLogger());
+            return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger), nuKeeperLogger);
         }
 
         private static Settings BuildDefaultSettings()

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -122,7 +122,7 @@ namespace NuKeeper.Tests.NuGet.Api
             return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
         }
 
-        private static void AssertPackagesIdentityIs(VersionUpdate packages, string id)
+        private static void AssertPackagesIdentityIs(PackageLookupResult packages, string id)
         {
             Assert.That(packages, Is.Not.Null);
             AssertPackageIdentityIs(packages.Highest, id);

--- a/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -19,7 +19,9 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var package = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), VersionChange.Major);
 
-            Assert.That(package, Is.Null);
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Highest, Is.Null);
+            Assert.That(package.HighestMatch, Is.Null);
         }
 
         [Test]
@@ -34,10 +36,14 @@ namespace NuKeeper.Tests.NuGet.Api
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var package = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), VersionChange.Major);
+            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), VersionChange.Major);
 
-            AssertPackageIdentityIs(package, "TestPackage");
-            Assert.That(package.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
+            Assert.That(updates, Is.Not.Null);
+
+            AssertPackageIdentityIs(updates.Highest, "TestPackage");
+            AssertPackageIdentityIs(updates.HighestMatch, "TestPackage");
+            Assert.That(updates.Highest.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
+            Assert.That(updates.HighestMatch.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4)));
         }
 
         [TestCase(VersionChange.Major, 2, 3, 4)]
@@ -56,8 +62,11 @@ namespace NuKeeper.Tests.NuGet.Api
             var package = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), 
                 VersionChange.Major);
 
-            AssertPackageIdentityIs(package, "TestPackage");
-            Assert.That(package.Identity.Version, Is.EqualTo(expectedUpdate));
+            AssertPackageIdentityIs(package.Highest, "TestPackage");
+            AssertPackageIdentityIs(package.HighestMatch, "TestPackage");
+
+            Assert.That(package.Highest.Identity.Version, Is.GreaterThanOrEqualTo(package.HighestMatch.Identity));
+            Assert.That(package.HighestMatch.Identity.Version, Is.EqualTo(expectedUpdate));
         }
 
         [TestCase(VersionChange.Major, 1, 3, 1)]
@@ -76,8 +85,10 @@ namespace NuKeeper.Tests.NuGet.Api
             var package = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"),
                 VersionChange.Minor);
 
-            AssertPackageIdentityIs(package, "TestPackage");
-            Assert.That(package.Identity.Version, Is.EqualTo(expectedUpdate));
+            AssertPackageIdentityIs(package.Highest, "TestPackage");
+            AssertPackageIdentityIs(package.HighestMatch, "TestPackage");
+            Assert.That(package.Highest.Identity.Version, Is.GreaterThanOrEqualTo(package.HighestMatch.Identity));
+            Assert.That(package.HighestMatch.Identity.Version, Is.EqualTo(expectedUpdate));
         }
 
         [TestCase(VersionChange.Major, 1, 2, 5)]
@@ -96,8 +107,10 @@ namespace NuKeeper.Tests.NuGet.Api
             var package = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"),
                 VersionChange.Patch);
 
-            AssertPackageIdentityIs(package, "TestPackage");
-            Assert.That(package.Identity.Version, Is.EqualTo(expectedUpdate));
+            AssertPackageIdentityIs(package.Highest, "TestPackage");
+            AssertPackageIdentityIs(package.HighestMatch, "TestPackage");
+            Assert.That(package.Highest.Identity.Version, Is.GreaterThanOrEqualTo(package.HighestMatch.Identity));
+            Assert.That(package.HighestMatch.Identity.Version, Is.EqualTo(expectedUpdate));
         }
 
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadataWithSource> actualResults)

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.Tests.NuGet.Api
         public async Task CanLookupEmptyList()
         {
             var apiLookup = Substitute.For<IApiPackageLookup>();
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var results = await bulkLookup.LatestVersions(Enumerable.Empty<PackageIdentity>());
 
@@ -34,7 +34,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             ApiHasNewVersionForPackage(apiLookup, "foo");
 
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var queries = new List<PackageIdentity>
             {
@@ -56,7 +56,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             ApiHasNewVersionForPackage(apiLookup, "foo");
 
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var queries = new List<PackageIdentity>
             {
@@ -76,7 +76,7 @@ namespace NuKeeper.Tests.NuGet.Api
             ApiHasNewVersionForPackage(apiLookup, "foo");
             ApiHasNewVersionForPackage(apiLookup, "bar");
 
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var queries = new List<PackageIdentity>
             {
@@ -100,7 +100,7 @@ namespace NuKeeper.Tests.NuGet.Api
             ApiHasNewVersionForPackage(apiLookup, "foo");
             ApiHasNewVersionForPackage(apiLookup, "bar");
 
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var queries = new List<PackageIdentity>
             {
@@ -121,7 +121,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             ApiHasNewVersionForPackage(apiLookup, "foo");
 
-            var bulkLookup = new BulkPackageLookup(apiLookup, new NullNuKeeperLogger());
+            var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
             var queries = new List<PackageIdentity>
             {
@@ -154,11 +154,19 @@ namespace NuKeeper.Tests.NuGet.Api
                 "test", MetadataWithVersion(packageName, new NuGetVersion(2, 3, 4)));
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
-                .Returns(new VersionUpdate
+                .Returns(new PackageLookupResult
                     {
+                        AllowedChange = VersionChange.Major,
                         Highest = responseMetaData,
                         Match = responseMetaData
                     });
+        }
+
+        private static BulkPackageLookup BuildBulkPackageLookup(IApiPackageLookup apiLookup)
+        {
+            var logger = new NullNuKeeperLogger();
+            return new BulkPackageLookup(apiLookup, new PackageLookupResultReporter(logger), logger);
+        }
+
     }
-}
 }

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -154,7 +154,11 @@ namespace NuKeeper.Tests.NuGet.Api
                 "test", MetadataWithVersion(packageName, new NuGetVersion(2, 3, 4)));
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
-                .Returns(responseMetaData);
+                .Returns(new VersionUpdate
+                    {
+                        Highest = responseMetaData,
+                        HighestMatch = responseMetaData
+                    });
     }
 }
 }

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -157,7 +157,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 .Returns(new VersionUpdate
                     {
                         Highest = responseMetaData,
-                        HighestMatch = responseMetaData
+                        Match = responseMetaData
                     });
     }
 }

--- a/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
@@ -46,10 +46,10 @@ namespace NuKeeper.Tests.NuGet.Api
             reporter.Report(data);
 
             logger.Received()
-                .Info("Selected update of package foo to highest version, 2.3.4.");
+                .Verbose("Selected update of package foo to highest version, 2.3.4.");
             logger.DidNotReceive().Error(Arg.Any<string>());
             logger.DidNotReceive().Terse(Arg.Any<string>());
-            logger.DidNotReceive().Verbose(Arg.Any<string>());
+            logger.DidNotReceive().Info(Arg.Any<string>());
         }
 
         [Test]
@@ -69,11 +69,12 @@ namespace NuKeeper.Tests.NuGet.Api
 
             reporter.Report(data);
 
+            logger.Received()
+                .Verbose("Selected update of package foo to highest version, 2.3.4. Allowing Minor version updates.");
+
             logger.DidNotReceive().Error(Arg.Any<string>());
             logger.DidNotReceive().Terse(Arg.Any<string>());
-            logger.DidNotReceive().Verbose(Arg.Any<string>());
-            logger.Received()
-                .Info("Selected update of package foo to highest version, 2.3.4. Allowing Minor version updates.");
+            logger.DidNotReceive().Info(Arg.Any<string>());
         }
 
         [Test]

--- a/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
@@ -21,7 +21,10 @@ namespace NuKeeper.Tests.NuGet.Api
 
             reporter.Report(data);
 
+            logger.DidNotReceive().Error(Arg.Any<string>());
+            logger.DidNotReceive().Terse(Arg.Any<string>());
             logger.DidNotReceive().Info(Arg.Any<string>());
+            logger.DidNotReceive().Verbose(Arg.Any<string>());
         }
 
 
@@ -43,7 +46,10 @@ namespace NuKeeper.Tests.NuGet.Api
             reporter.Report(data);
 
             logger.Received()
-                .Info("Selected update to highest version, 2.3.4.");
+                .Info("Selected update of package foo to highest version, 2.3.4.");
+            logger.DidNotReceive().Error(Arg.Any<string>());
+            logger.DidNotReceive().Terse(Arg.Any<string>());
+            logger.DidNotReceive().Verbose(Arg.Any<string>());
         }
 
         [Test]
@@ -63,8 +69,11 @@ namespace NuKeeper.Tests.NuGet.Api
 
             reporter.Report(data);
 
+            logger.DidNotReceive().Error(Arg.Any<string>());
+            logger.DidNotReceive().Terse(Arg.Any<string>());
+            logger.DidNotReceive().Verbose(Arg.Any<string>());
             logger.Received()
-                .Info("Selected update to highest version, 2.3.4. Allowing Minor version updates.");
+                .Info("Selected update of package foo to highest version, 2.3.4. Allowing Minor version updates.");
         }
 
         [Test]
@@ -86,7 +95,10 @@ namespace NuKeeper.Tests.NuGet.Api
             reporter.Report(data);
 
             logger.Received()
-                .Info("Selected update to version 2.3.4, but version 3.0.0 is also available. Allowing Minor version updates.");
+                .Info("Selected update of package foo to version 2.3.4, but version 3.0.0 is also available. Allowing Minor version updates.");
+            logger.DidNotReceive().Error(Arg.Any<string>());
+            logger.DidNotReceive().Terse(Arg.Any<string>());
+            logger.DidNotReceive().Verbose(Arg.Any<string>());
         }
 
         [Test]
@@ -107,7 +119,10 @@ namespace NuKeeper.Tests.NuGet.Api
             reporter.Report(data);
 
             logger.Received()
-                .Info("Version 3.0.0 is available but is not allowed. Allowing Minor version updates.");
+                .Info("Package foo version 3.0.0 is available but is not allowed. Allowing Minor version updates.");
+            logger.DidNotReceive().Error(Arg.Any<string>());
+            logger.DidNotReceive().Terse(Arg.Any<string>());
+            logger.DidNotReceive().Verbose(Arg.Any<string>());
         }
 
 

--- a/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
@@ -1,0 +1,122 @@
+﻿using NSubstitute;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using NuKeeper.Logging;
+using NuKeeper.NuGet.Api;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.NuGet.Api
+{
+    [TestFixture]
+    public class PackageLookupResultReporterTests
+    {
+        [Test]
+        public void CanCopeWithEmptyData()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var reporter = new PackageLookupResultReporter(logger);
+
+            var data = new PackageLookupResult();
+
+            reporter.Report(data);
+
+            logger.DidNotReceive().Info(Arg.Any<string>());
+        }
+
+
+        [Test]
+        public void WhenThereIsAMajorUpdate()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var reporter = new PackageLookupResultReporter(logger);
+
+            var fooMetadata = new PackageSearchMedatadataWithSource("foo", MetadataWithVersion("foo", new NuGetVersion(2, 3, 4)));
+
+            var data = new PackageLookupResult
+            {
+                AllowedChange = VersionChange.Major,
+                Match = fooMetadata,
+                Highest = fooMetadata
+            };
+
+            reporter.Report(data);
+
+            logger.Received()
+                .Info("Selected update to highest version, 2.3.4.");
+        }
+
+        [Test]
+        public void WhenThereIsAMinorUpdate()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var reporter = new PackageLookupResultReporter(logger);
+
+            var fooMetadata = new PackageSearchMedatadataWithSource("foo", MetadataWithVersion("foo", new NuGetVersion(2, 3, 4)));
+
+            var data = new PackageLookupResult
+            {
+                AllowedChange = VersionChange.Minor,
+                Match = fooMetadata,
+                Highest = fooMetadata
+            };
+
+            reporter.Report(data);
+
+            logger.Received()
+                .Info("Selected update to highest version, 2.3.4. Allowing Minor version updates.");
+        }
+
+        [Test]
+        public void WhenThereIsAMajorAndAMinorUpdate()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var reporter = new PackageLookupResultReporter(logger);
+
+            var fooMajor = new PackageSearchMedatadataWithSource("foo", MetadataWithVersion("foo", new NuGetVersion(3, 0, 0)));
+            var fooMinor = new PackageSearchMedatadataWithSource("foo", MetadataWithVersion("foo", new NuGetVersion(2, 3, 4)));
+
+            var data = new PackageLookupResult
+            {
+                AllowedChange = VersionChange.Minor,
+                Match = fooMinor,
+                Highest = fooMajor
+            };
+
+            reporter.Report(data);
+
+            logger.Received()
+                .Info("Selected update to version 2.3.4, but version 3.0.0 is also available. Allowing Minor version updates.");
+        }
+
+        [Test]
+        public void WhenThereIsAMajorUpdateThatCannotBeUsed()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var reporter = new PackageLookupResultReporter(logger);
+
+            var fooMajor = new PackageSearchMedatadataWithSource("foo", MetadataWithVersion("foo", new NuGetVersion(3, 0, 0)));
+
+            var data = new PackageLookupResult
+            {
+                AllowedChange = VersionChange.Minor,
+                Match = null,
+                Highest = fooMajor
+            };
+
+            reporter.Report(data);
+
+            logger.Received()
+                .Info("Version 3.0.0 is available but is not allowed. Allowing Minor version updates.");
+        }
+
+
+        private static IPackageSearchMetadata MetadataWithVersion(string id, NuGetVersion version)
+        {
+            var metadata = Substitute.For<IPackageSearchMetadata>();
+            var identity = new PackageIdentity(id, version);
+            metadata.Identity.Returns(identity);
+            return metadata;
+        }
+    }
+}

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -19,17 +19,18 @@ namespace NuKeeper.NuGet.Api
             var filter = VersionChangeFilter.FilterFor(allowedChange);
 
             var versions = await _packageVersionsLookup.Lookup(package.Id);
-            var ordered = versions
+            var orderedByVersion = versions
                 .OrderByDescending(p => p.Identity.Version)
                 .ToList();
 
-            var highestVersion = ordered.FirstOrDefault();
-            var highestMatch = ordered.FirstOrDefault(p => filter(package.Version, p.Identity.Version));
+            var highest = orderedByVersion.FirstOrDefault();
+            var highestThatMatchesFilter = orderedByVersion
+                .FirstOrDefault(p => filter(package.Version, p.Identity.Version));
             
             return new VersionUpdate
             {
-                Highest = highestVersion,
-                HighestMatch = highestMatch
+                Highest = highest,
+                Match = highestThatMatchesFilter
             };
         }
     }

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -13,15 +13,24 @@ namespace NuKeeper.NuGet.Api
             _packageVersionsLookup = packageVersionsLookup;
         }
 
-        public async Task<PackageSearchMedatadataWithSource> FindVersionUpdate(
+        public async Task<VersionUpdate> FindVersionUpdate(
             PackageIdentity package, VersionChange allowedChange)
         {
             var filter = VersionChangeFilter.FilterFor(allowedChange);
 
             var versions = await _packageVersionsLookup.Lookup(package.Id);
-            return versions
+            var ordered = versions
                 .OrderByDescending(p => p.Identity.Version)
-                .FirstOrDefault(p => filter(package.Version, p.Identity.Version));
+                .ToList();
+
+            var highestVersion = ordered.FirstOrDefault();
+            var highestMatch = ordered.FirstOrDefault(p => filter(package.Version, p.Identity.Version));
+            
+            return new VersionUpdate
+            {
+                Highest = highestVersion,
+                HighestMatch = highestMatch
+            };
         }
     }
 }

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -13,7 +13,7 @@ namespace NuKeeper.NuGet.Api
             _packageVersionsLookup = packageVersionsLookup;
         }
 
-        public async Task<VersionUpdate> FindVersionUpdate(
+        public async Task<PackageLookupResult> FindVersionUpdate(
             PackageIdentity package, VersionChange allowedChange)
         {
             var filter = VersionChangeFilter.FilterFor(allowedChange);
@@ -27,8 +27,9 @@ namespace NuKeeper.NuGet.Api
             var highestThatMatchesFilter = orderedByVersion
                 .FirstOrDefault(p => filter(package.Version, p.Identity.Version));
             
-            return new VersionUpdate
+            return new PackageLookupResult
             {
+                AllowedChange = allowedChange,
                 Highest = highest,
                 Match = highestThatMatchesFilter
             };

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -33,12 +33,14 @@ namespace NuKeeper.NuGet.Api
 
             foreach (var lookupTask in lookupTasks)
             {
-                var serverVersion = lookupTask.Result;
-                if (serverVersion?.Identity?.Version != null)
+                var serverVersions = lookupTask.Result;
+                var matchingVersion = serverVersions.HighestMatch;
+
+                if (matchingVersion?.Identity?.Version != null)
                 {
-                    var packageId = serverVersion.Identity.Id;
-                    _logger.Verbose($"Found latest version of {packageId}: {serverVersion.Identity.Version}");
-                    result.Add(packageId, serverVersion);
+                    var packageId = matchingVersion.Identity.Id;
+                    _logger.Verbose($"Found an updated version of {packageId}: {matchingVersion.Identity.Version}");
+                    result.Add(packageId, matchingVersion);
                 }
             }
 

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -34,7 +34,7 @@ namespace NuKeeper.NuGet.Api
             foreach (var lookupTask in lookupTasks)
             {
                 var serverVersions = lookupTask.Result;
-                var matchingVersion = serverVersions.HighestMatch;
+                var matchingVersion = serverVersions.Match;
 
                 if (matchingVersion?.Identity?.Version != null)
                 {

--- a/NuKeeper/NuGet/Api/IApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IApiPackageLookup.cs
@@ -5,7 +5,6 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IApiPackageLookup
     {
-        Task<PackageSearchMedatadataWithSource> FindVersionUpdate(
-            PackageIdentity package, VersionChange allowedChange);
+        Task<VersionUpdate> FindVersionUpdate(PackageIdentity package, VersionChange allowedChange);
     }
 }

--- a/NuKeeper/NuGet/Api/IApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IApiPackageLookup.cs
@@ -5,6 +5,6 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IApiPackageLookup
     {
-        Task<VersionUpdate> FindVersionUpdate(PackageIdentity package, VersionChange allowedChange);
+        Task<PackageLookupResult> FindVersionUpdate(PackageIdentity package, VersionChange allowedChange);
     }
 }

--- a/NuKeeper/NuGet/Api/PackageLookupResult.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResult.cs
@@ -1,7 +1,9 @@
 ﻿namespace NuKeeper.NuGet.Api
 {
-    public class VersionUpdate
+    public class PackageLookupResult
     {
+        public VersionChange AllowedChange { get; set; }
+
         public PackageSearchMedatadataWithSource Highest { get; set; }
         public PackageSearchMedatadataWithSource Match { get; set; }
     }

--- a/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
@@ -14,29 +14,32 @@ namespace NuKeeper.NuGet.Api
         public void Report(PackageLookupResult lookupResult)
         {
             var highestVersion = lookupResult.Highest?.Identity?.Version;
-            var highestMatchVersion = lookupResult.Match?.Identity?.Version;
+            if (highestVersion == null)
+            {
+                return;
+            }
 
             var allowing = lookupResult.AllowedChange == VersionChange.Major
                 ? string.Empty
                 : $" Allowing {lookupResult.AllowedChange} version updates.";
 
-            if (highestVersion != null)
+            var highestMatchVersion = lookupResult.Match?.Identity?.Version;
+
+            var packageId = lookupResult.Highest.Identity.Id;
+
+            if (highestMatchVersion == null)
             {
-                if (highestMatchVersion != null)
-                {
-                    if (highestVersion > highestMatchVersion)
-                    {
-                        _logger.Info($"Selected update to version {highestMatchVersion}, but version {highestVersion} is also available.{allowing}");
-                    }
-                    else
-                    {
-                       _logger.Info($"Selected update to highest version, {highestMatchVersion}.{allowing}");
-                    }
-                }
-                else
-                {
-                    _logger.Info($"Version {highestVersion} is available but is not allowed.{allowing}");
-                }
+                _logger.Info($"Package {packageId} version {highestVersion} is available but is not allowed.{allowing}");
+                return;
+            }
+
+            if (highestVersion > highestMatchVersion)
+            {
+                _logger.Info($"Selected update of package {packageId} to version {highestMatchVersion}, but version {highestVersion} is also available.{allowing}");
+            }
+            else
+            {
+                _logger.Info($"Selected update of package {packageId} to highest version, {highestMatchVersion}.{allowing}");
             }
         }
     }

--- a/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
@@ -14,7 +14,11 @@ namespace NuKeeper.NuGet.Api
         public void Report(PackageLookupResult lookupResult)
         {
             var highestVersion = lookupResult.Highest?.Identity?.Version;
-            var highestMatchVersion = lookupResult.Highest?.Identity?.Version;
+            var highestMatchVersion = lookupResult.Match?.Identity?.Version;
+
+            var allowing = lookupResult.AllowedChange == VersionChange.Major
+                ? string.Empty
+                : $" Allowing {lookupResult.AllowedChange} version updates.";
 
             if (highestVersion != null)
             {
@@ -22,18 +26,16 @@ namespace NuKeeper.NuGet.Api
                 {
                     if (highestVersion > highestMatchVersion)
                     {
-                        _logger.Info($"Allowing {lookupResult.AllowedChange} updates, selected update to version {highestMatchVersion}, but version {highestVersion} is also available.");
+                        _logger.Info($"Selected update to version {highestMatchVersion}, but version {highestVersion} is also available.{allowing}");
                     }
                     else
                     {
-                        _logger.Info($"Allowing {lookupResult.AllowedChange} updates, selected update to higest version {highestMatchVersion}.");
-
+                       _logger.Info($"Selected update to highest version, {highestMatchVersion}.{allowing}");
                     }
                 }
                 else
                 {
-                    // There is a highest version but no match
-                    _logger.Info($"Allowing {lookupResult.AllowedChange} updates, there is no matching update, but  {highestVersion} is also available.");
+                    _logger.Info($"Version {highestVersion} is available but is not allowed.{allowing}");
                 }
             }
         }

--- a/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
@@ -1,0 +1,41 @@
+﻿using NuKeeper.Logging;
+
+namespace NuKeeper.NuGet.Api
+{
+    public class PackageLookupResultReporter
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public PackageLookupResultReporter(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Report(PackageLookupResult lookupResult)
+        {
+            var highestVersion = lookupResult.Highest?.Identity?.Version;
+            var highestMatchVersion = lookupResult.Highest?.Identity?.Version;
+
+            if (highestVersion != null)
+            {
+                if (highestMatchVersion != null)
+                {
+                    if (highestVersion > highestMatchVersion)
+                    {
+                        _logger.Info($"Allowing {lookupResult.AllowedChange} updates, selected update to version {highestMatchVersion}, but version {highestVersion} is also available.");
+                    }
+                    else
+                    {
+                        _logger.Info($"Allowing {lookupResult.AllowedChange} updates, selected update to higest version {highestMatchVersion}.");
+
+                    }
+                }
+                else
+                {
+                    // There is a highest version but no match
+                    _logger.Info($"Allowing {lookupResult.AllowedChange} updates, there is no matching update, but  {highestVersion} is also available.");
+                }
+            }
+        }
+    }
+}

--- a/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResultReporter.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.NuGet.Api
             }
             else
             {
-                _logger.Info($"Selected update of package {packageId} to highest version, {highestMatchVersion}.{allowing}");
+                _logger.Verbose($"Selected update of package {packageId} to highest version, {highestMatchVersion}.{allowing}");
             }
         }
     }

--- a/NuKeeper/NuGet/Api/VersionUpdate.cs
+++ b/NuKeeper/NuGet/Api/VersionUpdate.cs
@@ -3,6 +3,6 @@
     public class VersionUpdate
     {
         public PackageSearchMedatadataWithSource Highest { get; set; }
-        public PackageSearchMedatadataWithSource HighestMatch { get; set; }
+        public PackageSearchMedatadataWithSource Match { get; set; }
     }
 }

--- a/NuKeeper/NuGet/Api/VersionUpdate.cs
+++ b/NuKeeper/NuGet/Api/VersionUpdate.cs
@@ -1,0 +1,8 @@
+﻿namespace NuKeeper.NuGet.Api
+{
+    public class VersionUpdate
+    {
+        public PackageSearchMedatadataWithSource Highest { get; set; }
+        public PackageSearchMedatadataWithSource HighestMatch { get; set; }
+    }
+}


### PR DESCRIPTION
`ApiPackageLookup` must return more info, i.e. a `PackageLookupResult` containing two package versions: the overall highest version of the package, and the highest that matches the allowed change.

So that the caller can report on e.g. "here's your highest version allowed as a `Patch` update, but a new major version is also available" and other variations on this. The class `PackageLookupResultReporter` does that. It has tests.