### PR TITLE
Allowed version change visible on the commandline

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -38,7 +38,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
@@ -56,7 +56,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -67,7 +67,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -86,7 +86,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages);
+            var results = await lookup.LatestVersions(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -38,7 +38,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages);
+            var results = await lookup.LatestVersions(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
@@ -56,7 +56,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages);
+            var results = await lookup.LatestVersions(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -67,7 +67,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(Enumerable.Empty<PackageIdentity>());
+            var results = await lookup.LatestVersions(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -86,7 +86,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.LatestVersions(packages);
+            var results = await lookup.LatestVersions(packages, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -98,7 +98,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var nuKeeperLogger = new NullNuKeeperLogger();
             var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
-            return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger), nuKeeperLogger);
+            return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger));
         }
 
         private static Settings BuildDefaultSettings()

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var apiLookup = Substitute.For<IApiPackageLookup>();
             var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
-            var results = await bulkLookup.LatestVersions(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -41,7 +41,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Not.Empty);
@@ -63,7 +63,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.LatestVersions(queries, VersionChange.Major);
+            await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
@@ -84,7 +84,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
 
             Assert.That(results.Count, Is.EqualTo(2));
             Assert.That(results.ContainsKey("foo"), Is.True);
@@ -108,7 +108,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.LatestVersions(queries, VersionChange.Major);
+            await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
 
             await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
@@ -129,7 +129,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 3, 4))
             };
 
-            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
             await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var apiLookup = Substitute.For<IApiPackageLookup>();
             var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
-            var results = await bulkLookup.LatestVersions(Enumerable.Empty<PackageIdentity>());
+            var results = await bulkLookup.LatestVersions(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -41,7 +41,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.LatestVersions(queries);
+            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Not.Empty);
@@ -63,7 +63,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.LatestVersions(queries);
+            await bulkLookup.LatestVersions(queries, VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
@@ -84,7 +84,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.LatestVersions(queries);
+            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
 
             Assert.That(results.Count, Is.EqualTo(2));
             Assert.That(results.ContainsKey("foo"), Is.True);
@@ -108,7 +108,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.LatestVersions(queries);
+            await bulkLookup.LatestVersions(queries, VersionChange.Major);
 
             await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
         }
@@ -129,7 +129,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(1, 3, 4))
             };
 
-            var results = await bulkLookup.LatestVersions(queries);
+            var results = await bulkLookup.LatestVersions(queries, VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
             await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -165,7 +165,7 @@ namespace NuKeeper.Tests.NuGet.Api
         private static BulkPackageLookup BuildBulkPackageLookup(IApiPackageLookup apiLookup)
         {
             var logger = new NullNuKeeperLogger();
-            return new BulkPackageLookup(apiLookup, new PackageLookupResultReporter(logger), logger);
+            return new BulkPackageLookup(apiLookup, new PackageLookupResultReporter(logger));
         }
 
     }

--- a/NuKeeper/Configuration/EnumParser.cs
+++ b/NuKeeper/Configuration/EnumParser.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace NuKeeper.Configuration
+{
+    public static class EnumParser
+    {
+        public static T? Parse<T>(string value) where T: struct 
+        {
+            var success = Enum.TryParse(value, true, out T result);
+            if (success)
+            {
+                return result;
+            }
+            return null;
+        }
+    }
+}

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -40,5 +40,10 @@ namespace NuKeeper.Configuration
 
         [CommandLine("exclude", "e")]
         public string Exclude;
+
+        [JsonConfig("allowed_version_change"), Default("Major")]
+        [OverriddenBy(ConfigurationSources.CommandLine, "allowedChange")]
+        public string AllowedChange;
+
     }
 }

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -42,7 +42,7 @@ namespace NuKeeper.Configuration
         public string Exclude;
 
         [JsonConfig("allowed_version_change"), Default("Major")]
-        [OverriddenBy(ConfigurationSources.CommandLine, "allowedChange")]
+        [OverriddenBy(ConfigurationSources.CommandLine, "change")]
         public string AllowedChange;
 
     }

--- a/NuKeeper/Configuration/Settings.cs
+++ b/NuKeeper/Configuration/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using NuKeeper.Logging;
+using NuKeeper.NuGet.Api;
 
 namespace NuKeeper.Configuration
 {
@@ -34,6 +35,8 @@ namespace NuKeeper.Configuration
         public Uri GithubApiBase => Repository?.GithubApiBase ?? Organisation?.GithubApiBase;
 
         public int MaxPullRequestsPerRepository => Repository?.MaxPullRequestsPerRepository ?? Organisation?.MaxPullRequestsPerRepository ?? 0;
+
+        public VersionChange AllowedChange { get; set; }
 
         public string Mode { get; }
 

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -143,12 +143,10 @@ namespace NuKeeper.Configuration
 
         private static LogLevel? ParseLogLevel(string value)
         {
-            LogLevel result;
-            var success = Enum.TryParse(value, true, out result);
-            if (!success)
+            var result = EnumParser.Parse<LogLevel>(value);
+            if (!result.HasValue)
             {
                 Console.WriteLine($"Unknown log level '{value}'");
-                return null;
             }
 
             return result;
@@ -156,12 +154,10 @@ namespace NuKeeper.Configuration
 
         private static VersionChange? ParseVersionChange(string value)
         {
-            VersionChange result;
-            var success = Enum.TryParse(value, true, out result);
-            if (!success)
+            var result = EnumParser.Parse<VersionChange>(value);
+            if (!result.HasValue)
             {
                 Console.WriteLine($"Unknown version change '{value}'");
-                return null;
             }
 
             return result;

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using EasyConfig;
 using EasyConfig.Exceptions;
 using NuKeeper.Logging;
+using NuKeeper.NuGet.Api;
 
 namespace NuKeeper.Configuration
 {
@@ -31,6 +32,12 @@ namespace NuKeeper.Configuration
                 return null;
             }
 
+            var allowedChange = ParseVersionChange(settings.AllowedChange);
+            if (!allowedChange.HasValue)
+            {
+                return null;
+            }
+
             Settings result;
 
             switch (settings.Mode)
@@ -49,6 +56,8 @@ namespace NuKeeper.Configuration
             }
 
             result.LogLevel = logLevel.Value;
+            result.AllowedChange = allowedChange.Value;
+
             result.NuGetSources = ReadNuGetSources(settings);
             result.PackageIncludes = ParseRegex(settings.Include, nameof(settings.Include));
             result.PackageExcludes = ParseRegex(settings.Exclude, nameof(settings.Exclude));
@@ -91,15 +100,17 @@ namespace NuKeeper.Configuration
             var repoOwner = pathParts[0];
             var repoName = pathParts[1].Replace(".git", string.Empty);
 
-            return new Settings(new RepositoryModeSettings
-            {
-                GithubUri = settings.GithubRepositoryUri,
-                GithubToken = settings.GithubToken,
-                GithubApiBase = EnsureTrailingSlash(settings.GithubApiEndpoint),
-                RepositoryName = repoName,
-                RepositoryOwner = repoOwner,
-                MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
-            });
+            var repoSettings = new RepositoryModeSettings
+                {
+                    GithubUri = settings.GithubRepositoryUri,
+                    GithubToken = settings.GithubToken,
+                    GithubApiBase = EnsureTrailingSlash(settings.GithubApiEndpoint),
+                    RepositoryName = repoName,
+                    RepositoryOwner = repoOwner,
+                    MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
+            };
+
+            return new Settings(repoSettings);
         }
 
         private static string[] ReadNuGetSources(RawConfiguration settings)
@@ -119,13 +130,15 @@ namespace NuKeeper.Configuration
             var githubHost = settings.GithubApiEndpoint;
             var githubOrganisationName = settings.GithubOrganisationName;
 
-            return new Settings(new OrganisationModeSettings
-            {
-                GithubApiBase = EnsureTrailingSlash(githubHost),
-                GithubToken = githubToken,
-                OrganisationName = githubOrganisationName,
-                MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
-            });
+            var orgSettings = new OrganisationModeSettings
+                {
+                    GithubApiBase = EnsureTrailingSlash(githubHost),
+                    GithubToken = githubToken,
+                    OrganisationName = githubOrganisationName,
+                    MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository
+            };
+
+            return new Settings(orgSettings);
         }
 
         private static LogLevel? ParseLogLevel(string value)
@@ -135,6 +148,19 @@ namespace NuKeeper.Configuration
             if (!success)
             {
                 Console.WriteLine($"Unknown log level '{value}'");
+                return null;
+            }
+
+            return result;
+        }
+
+        private static VersionChange? ParseVersionChange(string value)
+        {
+            VersionChange result;
+            var success = Enum.TryParse(value, true, out result);
+            if (!success)
+            {
+                Console.WriteLine($"Unknown version change '{value}'");
                 return null;
             }
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -24,8 +24,7 @@ namespace NuKeeper.Engine
             IPackageUpdater packageUpdater,
             IRepositoryScanner repositoryScanner,
             INuKeeperLogger logger,
-            SolutionsRestore solutionsRestore
-            )
+            SolutionsRestore solutionsRestore)
         {
             _packageLookup = packageLookup;
             _updateSelection = updateSelection;

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
-using NuKeeper.Logging;
 
 namespace NuKeeper.NuGet.Api
 {
@@ -10,16 +9,13 @@ namespace NuKeeper.NuGet.Api
     {
         private readonly IApiPackageLookup _packageLookup;
         private readonly PackageLookupResultReporter _lookupReporter;
-        private readonly INuKeeperLogger _logger;
 
         public BulkPackageLookup(
             IApiPackageLookup packageLookup, 
-            PackageLookupResultReporter lookupReporter, 
-            INuKeeperLogger logger)
+            PackageLookupResultReporter lookupReporter)
         {
             _packageLookup = packageLookup;
             _lookupReporter = lookupReporter;
-            _logger = logger;
         }
 
         public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages)

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -18,14 +18,15 @@ namespace NuKeeper.NuGet.Api
             _lookupReporter = lookupReporter;
         }
 
-        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages)
+        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(
+            IEnumerable<PackageIdentity> packages, VersionChange allowedChange)
         {
             var latestOfEach = packages
                 .GroupBy(pi => pi.Id)
                 .Select(HighestVersion);
 
             var lookupTasks = latestOfEach
-                .Select(id => _packageLookup.FindVersionUpdate(id, VersionChange.Major))
+                .Select(id => _packageLookup.FindVersionUpdate(id, allowedChange))
                 .ToList();
 
             await Task.WhenAll(lookupTasks);

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.NuGet.Api
             _lookupReporter = lookupReporter;
         }
 
-        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(
+        public async Task<Dictionary<string, PackageSearchMedatadataWithSource>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages, VersionChange allowedChange)
         {
             var latestOfEach = packages

--- a/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
@@ -6,7 +6,7 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IBulkPackageLookup
     {
-        Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(
+        Task<Dictionary<string, PackageSearchMedatadataWithSource>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
             VersionChange allowedChange);
     }

--- a/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
@@ -6,6 +6,8 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IBulkPackageLookup
     {
-        Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(IEnumerable<PackageIdentity> packages);
+        Task<Dictionary<string, PackageSearchMedatadataWithSource>> LatestVersions(
+            IEnumerable<PackageIdentity> packages,
+            VersionChange allowedChange);
     }
 }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.NuGet.Api
                 .Select(p => p.Identity)
                 .Distinct();
 
-            var latestVersions = await _bulkPackageLookup.LatestVersions(packageIds);
+            var latestVersions = await _bulkPackageLookup.LatestVersions(packageIds, VersionChange.Major);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuKeeper.Configuration;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.NuGet.Api
@@ -8,10 +9,12 @@ namespace NuKeeper.NuGet.Api
     public class PackageUpdatesLookup : IPackageUpdatesLookup
     {
         private readonly IBulkPackageLookup _bulkPackageLookup;
+        private readonly VersionChange _allowedChange;
 
-        public PackageUpdatesLookup(IBulkPackageLookup bulkPackageLookup)
+        public PackageUpdatesLookup(IBulkPackageLookup bulkPackageLookup, Settings settings)
         {
             _bulkPackageLookup = bulkPackageLookup;
+            _allowedChange = settings.AllowedChange;
         }
 
         public async Task<List<PackageUpdateSet>> FindUpdatesForPackages(IReadOnlyCollection<PackageInProject> packages)
@@ -20,7 +23,7 @@ namespace NuKeeper.NuGet.Api
                 .Select(p => p.Identity)
                 .Distinct();
 
-            var latestVersions = await _bulkPackageLookup.FindVersionUpdates(packageIds, VersionChange.Major);
+            var latestVersions = await _bulkPackageLookup.FindVersionUpdates(packageIds, _allowedChange);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.NuGet.Api
                 .Select(p => p.Identity)
                 .Distinct();
 
-            var latestVersions = await _bulkPackageLookup.LatestVersions(packageIds, VersionChange.Major);
+            var latestVersions = await _bulkPackageLookup.FindVersionUpdates(packageIds, VersionChange.Major);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper/NuGet/Api/VersionChange.cs
+++ b/NuKeeper/NuGet/Api/VersionChange.cs
@@ -6,5 +6,5 @@
         Patch = 1,
         Minor = 2,
         Major = 3
-    };
+    }
 }


### PR DESCRIPTION
Ready for review. 

Surface the "allowed version change" work on config & commandline. 
So you can have `"allowed_version_change": "Minor"` in the config file or `change=Patch` on the commandline What do you think of the param naming? It needs docs in the readme

I would like to refactor settings (and give them more tests) but that's out of scope today.

Also out of scope today: When the update is all done, the commit details text should not just say "NuKeeper has generated an update of `Moq` to `4.7.142` from `4.7.1`", it should add "Allowed version change was `Patch`, there was not/ was another later version _x.y.z_ available." 
But the required information for this text is not propagated that far yet.
That info scrolls past during the run, but then it's gone.