### PR TITLE
Short modes

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Tests.Configuration
             var commandLine = ValidRepoCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Repository));
             Assert.That(settings.Repository, Is.Not.Null);
             Assert.That(settings.Repository.RepositoryName, Is.EqualTo("NuKeeper"));
             Assert.That(settings.GithubToken, Is.EqualTo("abc123"));
@@ -122,7 +122,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Organisation));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Organisation));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Repository));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NuKeeper.Tests.Configuration
             var commandLine = ValidOrgCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Organisation));
             Assert.That(settings.Organisation, Is.Not.Null);
             Assert.That(settings.Organisation.OrganisationName, Is.EqualTo("NuKeeperDotNet"));
             Assert.That(settings.GithubToken, Is.EqualTo("abc123"));

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Tests.Configuration
             var commandLine = ValidRepoCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings.Mode, Is.EqualTo("repository"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
             Assert.That(settings.Repository, Is.Not.Null);
             Assert.That(settings.Repository.RepositoryName, Is.EqualTo("NuKeeper"));
             Assert.That(settings.GithubToken, Is.EqualTo("abc123"));
@@ -122,7 +122,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo("repository"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NuKeeper.Tests.Configuration
             var commandLine = ValidOrgCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
             Assert.That(settings.Organisation, Is.Not.Null);
             Assert.That(settings.Organisation.OrganisationName, Is.EqualTo("NuKeeperDotNet"));
             Assert.That(settings.GithubToken, Is.EqualTo("abc123"));

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -96,6 +96,68 @@ namespace NuKeeper.Tests.Configuration
         }
 
         [Test]
+        public void MissingModeIsNotParsed()
+        {
+            var commandLine = new List<string>
+            {
+                "repo=https://github.com/NuKeeperDotNet/NuKeeper",
+                "t=abc123"
+            };
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Null);
+        }
+
+        [Test]
+        public void ShortOrgModeIsParsed()
+        {
+            var commandLine = new List<string>
+            {
+                "mode=org",
+                "org=NuKeeperDotNet",
+                "t=abc123"
+            };
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+        }
+
+        [Test]
+        public void ShortOrgModeinCapsIsParsed()
+        {
+            var commandLine = new List<string>
+            {
+                "mode=Org",
+                "org=NuKeeperDotNet",
+                "t=abc123"
+            };
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+        }
+
+        [Test]
+        public void ShortRepoModeIsParsed()
+        {
+            var commandLine = new List<string>
+            {
+                "mode=repo",
+                "repo=https://github.com/NuKeeperDotNet/NuKeeper",
+                "t=abc123"
+            };
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.Mode, Is.EqualTo("repository"));
+        }
+
+        [Test]
         public void InvalidLogLevelIsNotParsed()
         {
             var commandLine = ValidRepoCommandLine()

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo("repository"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
             Assert.That(settings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.Info));
         }
@@ -39,7 +39,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo("organisation"));
+            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
             Assert.That(settings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.Info));
         }

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Repository));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Repository));
             Assert.That(settings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.Info));
         }
@@ -39,7 +39,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.Mode, Is.EqualTo(Mode.Organisation));
+            Assert.That(settings.Mode, Is.EqualTo(GithubMode.Organisation));
             Assert.That(settings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.Info));
         }

--- a/NuKeeper/Configuration/GithubMode.cs
+++ b/NuKeeper/Configuration/GithubMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace NuKeeper.Configuration
 {
-    public enum Mode
+    public enum GithubMode
     {
         Repository,
         Organisation

--- a/NuKeeper/Configuration/Mode.cs
+++ b/NuKeeper/Configuration/Mode.cs
@@ -1,0 +1,8 @@
+﻿namespace NuKeeper.Configuration
+{
+    public enum Mode
+    {
+        Repository,
+        Organisation
+    }
+}

--- a/NuKeeper/Configuration/ModeNames.cs
+++ b/NuKeeper/Configuration/ModeNames.cs
@@ -1,0 +1,11 @@
+﻿namespace NuKeeper.Configuration
+{
+    public static class ModeNames
+    {
+        public const string Repo = "repo";
+        public const string Repository = "repository";
+
+        public const string Organisation = "organisation";
+        public const string Org = "org";
+    }
+}

--- a/NuKeeper/Configuration/Settings.cs
+++ b/NuKeeper/Configuration/Settings.cs
@@ -7,22 +7,16 @@ namespace NuKeeper.Configuration
 {
     public class Settings
     {
-        public const string RepoMode = "repo";
-        public const string RepositoryMode = "repository";
-
-        public const string OrganisationMode = "organisation";
-        public const string OrgMode = "org";
-
         public Settings(RepositoryModeSettings repositoryModeSettings)
         {
             Repository = repositoryModeSettings;
-            Mode = RepositoryMode;
+            Mode = ModeNames.Repository;
         }
 
         public Settings(OrganisationModeSettings organisationModeSettings)
         {
             Organisation = organisationModeSettings;
-            Mode = OrganisationMode;
+            Mode = ModeNames.Organisation;
         }
 
         public Settings(RepositoryModeSettings repository, OrganisationModeSettings organisation)

--- a/NuKeeper/Configuration/Settings.cs
+++ b/NuKeeper/Configuration/Settings.cs
@@ -7,8 +7,11 @@ namespace NuKeeper.Configuration
 {
     public class Settings
     {
+        public const string RepoMode = "repo";
         public const string RepositoryMode = "repository";
+
         public const string OrganisationMode = "organisation";
+        public const string OrgMode = "org";
 
         public Settings(RepositoryModeSettings repositoryModeSettings)
         {

--- a/NuKeeper/Configuration/Settings.cs
+++ b/NuKeeper/Configuration/Settings.cs
@@ -10,13 +10,13 @@ namespace NuKeeper.Configuration
         public Settings(RepositoryModeSettings repositoryModeSettings)
         {
             Repository = repositoryModeSettings;
-            Mode = ModeNames.Repository;
+            Mode = Mode.Repository;
         }
 
         public Settings(OrganisationModeSettings organisationModeSettings)
         {
             Organisation = organisationModeSettings;
-            Mode = ModeNames.Organisation;
+            Mode = Mode.Organisation;
         }
 
         public Settings(RepositoryModeSettings repository, OrganisationModeSettings organisation)
@@ -35,7 +35,7 @@ namespace NuKeeper.Configuration
 
         public VersionChange AllowedChange { get; set; }
 
-        public string Mode { get; }
+        public Mode Mode { get; }
 
         public LogLevel LogLevel { get; set; }
 

--- a/NuKeeper/Configuration/Settings.cs
+++ b/NuKeeper/Configuration/Settings.cs
@@ -10,13 +10,13 @@ namespace NuKeeper.Configuration
         public Settings(RepositoryModeSettings repositoryModeSettings)
         {
             Repository = repositoryModeSettings;
-            Mode = Mode.Repository;
+            Mode = GithubMode.Repository;
         }
 
         public Settings(OrganisationModeSettings organisationModeSettings)
         {
             Organisation = organisationModeSettings;
-            Mode = Mode.Organisation;
+            Mode = GithubMode.Organisation;
         }
 
         public Settings(RepositoryModeSettings repository, OrganisationModeSettings organisation)
@@ -35,7 +35,7 @@ namespace NuKeeper.Configuration
 
         public VersionChange AllowedChange { get; set; }
 
-        public Mode Mode { get; }
+        public GithubMode Mode { get; }
 
         public LogLevel LogLevel { get; set; }
 

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -40,7 +40,8 @@ namespace NuKeeper.Configuration
         {
             Settings result;
 
-            switch (settings.Mode.ToLowerInvariant())
+            var modeString = settings.Mode?.ToLowerInvariant() ?? String.Empty;
+            switch (modeString)
             {
                 case ModeNames.Repo:
                 case ModeNames.Repository:
@@ -53,7 +54,7 @@ namespace NuKeeper.Configuration
                     break;
 
                 default:
-                    Console.WriteLine($"Mode {settings.Mode} not supported");
+                    Console.WriteLine($"Mode '{modeString}' not supported");
                     return null;
             }
 

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -40,12 +40,14 @@ namespace NuKeeper.Configuration
         {
             Settings result;
 
-            switch (settings.Mode)
+            switch (settings.Mode.ToLowerInvariant())
             {
+                case Settings.RepoMode:
                 case Settings.RepositoryMode:
                     result = ReadSettingsForRepositoryMode(settings);
                     break;
 
+                case Settings.OrgMode:
                 case Settings.OrganisationMode:
                     result = ReadSettingsForOrganisationMode(settings);
                     break;

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -42,13 +42,13 @@ namespace NuKeeper.Configuration
 
             switch (settings.Mode.ToLowerInvariant())
             {
-                case Settings.RepoMode:
-                case Settings.RepositoryMode:
+                case ModeNames.Repo:
+                case ModeNames.Repository:
                     result = ReadSettingsForRepositoryMode(settings);
                     break;
 
-                case Settings.OrgMode:
-                case Settings.OrganisationMode:
+                case ModeNames.Org:
+                case ModeNames.Organisation:
                     result = ReadSettingsForOrganisationMode(settings);
                     break;
 

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -30,10 +30,10 @@ namespace NuKeeper.Engine
         {
             switch (_settings.Mode)
             {
-                case Mode.Organisation:
+                case GithubMode.Organisation:
                     return await FromOrganisation(_settings.Organisation);
 
-                case Mode.Repository:
+                case GithubMode.Repository:
                     return new[] { _settings.Repository };
 
                 default:

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -28,11 +28,11 @@ namespace NuKeeper.Engine
 
         public async Task<IEnumerable<RepositoryModeSettings>> GetRepositories()
         {
-            if (_settings.Mode == Settings.OrganisationMode)
+            if (_settings.Mode == ModeNames.Organisation)
             {
                 return await FromOrganisation(_settings.Organisation);
             }
-            if (_settings.Mode == Settings.RepositoryMode)
+            if (_settings.Mode == ModeNames.Repository)
             {
                 return new[] { _settings.Repository };
             }

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -28,15 +28,17 @@ namespace NuKeeper.Engine
 
         public async Task<IEnumerable<RepositoryModeSettings>> GetRepositories()
         {
-            if (_settings.Mode == ModeNames.Organisation)
+            switch (_settings.Mode)
             {
-                return await FromOrganisation(_settings.Organisation);
-            }
-            if (_settings.Mode == ModeNames.Repository)
-            {
-                return new[] { _settings.Repository };
-            }
-            return Enumerable.Empty<RepositoryModeSettings>();
+                case Mode.Organisation:
+                    return await FromOrganisation(_settings.Organisation);
+
+                case Mode.Repository:
+                    return new[] { _settings.Repository };
+
+                default:
+                    return Enumerable.Empty<RepositoryModeSettings>();
+            }            
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
 | sources                          | No                         |
 | change                           | No                         |
 
- * *mode* One of `repository` or `organisation`. In `organisation` mode, all the repositories in that organisation will be processed.
+ * *mode* One of `repository` or `organisation`, or synonyms `repo` and `org`. In `organisation` mode, all the repositories in that organisation will be processed.
  * *t* Overrides `NuKeeper_github_token` in environment variables.
  * *github_repository_uri* The repository to scan. Required in `repository` mode, not used `organisation` mode. Aliased to `repo`.
  * *github_organisation_name* the organisation to scan. Required in `organisation` mode, not used in `repository` mode. Aliased to `org`.


### PR DESCRIPTION
allow mode to be `org` and `repo` on the commandline as well as existing `organisation`. `repository`. And make it case insensitive.
Use an enum internally.