### PR TITLE
Handle VS 2017 projects for .NET classic

### DIFF
--- a/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using System.Text;
 using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
@@ -29,7 +31,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 </packages>";
 
             var reader = MakeReader();
-            var packages = reader.Read(emptyContents, TempPath());
+            var packages = reader.Read(StreamFromString(emptyContents), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -39,7 +41,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void SinglePackageShouldBeRead()
         {
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithSinglePackage, TempPath());
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Not.Empty);
@@ -49,7 +51,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void SinglePackageShouldBePopulated()
         {
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithSinglePackage, TempPath());
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
 
             var package = packages.FirstOrDefault();
             PackageAssert.IsPopulated(package);
@@ -59,7 +61,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void SinglePackageShouldBeCorrect()
         {
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithSinglePackage, TempPath());
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
 
             var package = packages.FirstOrDefault();
 
@@ -72,7 +74,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void TwoPackagesShouldBePopulated()
         {
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithTwoPackages, TempPath())
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
                 .ToList();
 
             Assert.That(packages, Is.Not.Null);
@@ -86,7 +88,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void TwoPackagesShouldBeRead()
         {
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithTwoPackages, TempPath())
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
                 .ToList();
 
             Assert.That(packages.Count, Is.EqualTo(2));
@@ -104,7 +106,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var path = TempPath();
 
             var reader = MakeReader();
-            var packages = reader.Read(PackagesFileWithTwoPackages, path);
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), path);
 
             foreach (var package in packages)
             {
@@ -120,7 +122,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion");
 
             var reader = MakeReader();
-            var packages = reader.Read(badVersion, TempPath())
+            var packages = reader.Read(StreamFromString(badVersion), TempPath())
                 .ToList();
 
             Assert.That(packages.Count, Is.EqualTo(1));
@@ -136,6 +138,11 @@ namespace NuKeeper.Tests.RepositoryInspection
         private PackagesFileReader MakeReader()
         {
             return new PackagesFileReader(new NullNuKeeperLogger());
+        }
+
+        private Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
         }
     }
 }

--- a/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using System.Text;
 using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
@@ -51,7 +53,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 </foo>";
 
             var reader = MakeReader();
-            var packages = reader.Read(NoProject, TempPath());
+            var packages = reader.Read(StreamFromString(NoProject), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -66,7 +68,7 @@ namespace NuKeeper.Tests.RepositoryInspection
 </Project>";
 
             var reader = MakeReader();
-            var packages = reader.Read(NoProject, TempPath());
+            var packages = reader.Read(StreamFromString(NoProject), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -76,7 +78,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void ProjectWithoutPackageListCanBeRead()
         {
             var reader = MakeReader();
-            var packages = reader.Read(Vs2017ProjectFileTemplateWithoutPackages, TempPath());
+            var packages = reader.Read(StreamFromString(Vs2017ProjectFileTemplateWithoutPackages), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -88,7 +90,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", "");
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath());
+            var packages = reader.Read(StreamFromString(projectFile), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Empty);
@@ -102,7 +104,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath());
+            var packages = reader.Read(StreamFromString(projectFile), TempPath());
 
             Assert.That(packages, Is.Not.Null);
             Assert.That(packages, Is.Not.Empty);
@@ -116,7 +118,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath());
+            var packages = reader.Read(StreamFromString(projectFile), TempPath());
 
             var package = packages.FirstOrDefault();
 
@@ -131,7 +133,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath());
+            var packages = reader.Read(StreamFromString(projectFile), TempPath());
 
             var package = packages.FirstOrDefault();
 
@@ -144,7 +146,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         public void SinglePackageFullFrameworkProjectIsCorectlyRead()
         {
             var reader = MakeReader();
-            var packages = reader.Read(Vs2017ProjectFileFullFrameworkWithPackages, TempPath());
+            var packages = reader.Read(StreamFromString(Vs2017ProjectFileFullFrameworkWithPackages), TempPath());
 
             var package = packages.Single();
 
@@ -163,7 +165,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath())
+            var packages = reader.Read(StreamFromString(projectFile), TempPath())
                 .ToList();
 
             Assert.That(packages, Is.Not.Null);
@@ -182,7 +184,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath())
+            var packages = reader.Read(StreamFromString(projectFile), TempPath())
                 .ToList();
 
             Assert.That(packages[0].Id, Is.EqualTo("foo"));
@@ -198,7 +200,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var path = TempPath();
 
             var reader = MakeReader();
-            var packages = reader.Read(Vs2017ProjectFileTemplateWithPackages, path);
+            var packages = reader.Read(StreamFromString(Vs2017ProjectFileTemplateWithPackages), path);
 
             foreach (var package in packages)
             {
@@ -218,7 +220,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
 
             var reader = MakeReader();
-            var packages = reader.Read(projectFile, TempPath())
+            var packages = reader.Read(StreamFromString(projectFile), TempPath())
                 .ToList();
 
             Assert.That(packages.Count, Is.EqualTo(1));
@@ -234,6 +236,11 @@ namespace NuKeeper.Tests.RepositoryInspection
         private ProjectFileReader MakeReader()
         {
             return new ProjectFileReader(new NullNuKeeperLogger());
+        }
+
+        private Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
         }
     }
 }

--- a/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -31,6 +31,17 @@ namespace NuKeeper.Tests.RepositoryInspection
   </ItemGroup>
 </Project>";
 
+        private const string Vs2017ProjectFileFullFrameworkWithPackages =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""14.0"" DefaultTargets=""Build"">
+  <ItemGroup>
+    <PackageReference Include=""StyleCop.Analyzers"">
+      <Version>1.0.2</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+";
+
         [Test]
         public void NoProjectCanBeRead()
         {
@@ -126,6 +137,19 @@ namespace NuKeeper.Tests.RepositoryInspection
 
             Assert.That(package.Id, Is.EqualTo("foo"));
             Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.ProjectFile));
+        }
+
+        [Test]
+        public void SinglePackageFullFrameworkProjectIsCorectlyRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(Vs2017ProjectFileFullFrameworkWithPackages, TempPath());
+
+            var package = packages.Single();
+
+            Assert.That(package.Id, Is.EqualTo("StyleCop.Analyzers"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.0.2")));
             Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.ProjectFile));
         }
 

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -79,7 +79,7 @@ namespace NuKeeper.Engine
 
         private IFileRestoreCommand GetRestoreCommand(PackageReferenceType packageReferenceType)
         {
-            if (packageReferenceType == PackageReferenceType.PackagesConfig)
+            if (packageReferenceType != PackageReferenceType.ProjectFile)
             {
                 return new NuGetFileRestoreCommand(_logger, _settings);
             }

--- a/NuKeeper/Engine/PackageUpdater.cs
+++ b/NuKeeper/Engine/PackageUpdater.cs
@@ -89,7 +89,7 @@ namespace NuKeeper.Engine
 
         private IUpdatePackageCommand GetUpdateCommand(PackageReferenceType packageReferenceType)
         {
-            if (packageReferenceType == PackageReferenceType.ProjectFile)
+            if (packageReferenceType != PackageReferenceType.PackagesConfig)
             {
                 return new DotNetUpdatePackageCommand(_logger, _settings);
             }

--- a/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
@@ -31,6 +31,7 @@ namespace NuKeeper.NuGet.Process
             var sources = GetSourcesCommandLine(_sources);
             var updateCommand = $"cd {dirName}"
                 + $" & dotnet restore {sources}"
+                + $" & dotnet remove package {currentPackage.Id}"
                 + $" & dotnet add package {currentPackage.Id} -v {newVersion} -s {packageSource}";
             _logger.Verbose(updateCommand);
 

--- a/NuKeeper/RepositoryInspection/PackageReferenceType.cs
+++ b/NuKeeper/RepositoryInspection/PackageReferenceType.cs
@@ -3,6 +3,7 @@
     public enum PackageReferenceType
     {
         PackagesConfig,
-        ProjectFile
+        ProjectFile,
+        ProjectFileOldStyle
     }
 }

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -16,10 +16,11 @@ namespace NuKeeper.RepositoryInspection
             _logger = logger;
         }
 
-        public IEnumerable<PackageInProject> ReadFile(PackagePath path)
+        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
-            var fileContents = File.ReadAllText(path.FullName);
-            return Read(fileContents, path);
+            var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.PackagesConfig);
+            var fileContents = File.ReadAllText(packagePath.FullName);
+            return Read(fileContents, packagePath);
         }
 
         public IEnumerable<PackageInProject> Read(string fileContents, PackagePath path)

--- a/NuKeeper/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper/RepositoryInspection/PackagesFileReader.cs
@@ -19,13 +19,15 @@ namespace NuKeeper.RepositoryInspection
         public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
             var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.PackagesConfig);
-            var fileContents = File.ReadAllText(packagePath.FullName);
-            return Read(fileContents, packagePath);
+            using (var fileContents = File.OpenRead(packagePath.FullName))
+            {
+                return Read(fileContents, packagePath);
+            }
         }
 
-        public IEnumerable<PackageInProject> Read(string fileContents, PackagePath path)
+        public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)
         {
-            var xml = XDocument.Parse(fileContents);
+            var xml = XDocument.Load(fileContents);
 
             var packagesNode = xml.Element("packages");
             if (packagesNode == null)

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -25,15 +25,16 @@ namespace NuKeeper.RepositoryInspection
         public IEnumerable<PackageInProject> Read(string fileContents, PackagePath path)
         {
             var xml = XDocument.Parse(fileContents);
-            var project = xml.Element("Project");
+            var ns = xml.Root.GetDefaultNamespace();
+            var project = xml.Element(ns + "Project");
 
             if (project == null)
             {
                 return Enumerable.Empty<PackageInProject>();
             }
 
-            var itemGroups = project.Elements("ItemGroup");
-            var packageRefs = itemGroups.SelectMany(ig => ig.Elements("PackageReference"));
+            var itemGroups = project.Elements(ns + "ItemGroup");
+            var packageRefs = itemGroups.SelectMany(ig => ig.Elements(ns + "PackageReference"));
 
             return packageRefs
                 .Select(el => XmlToPackage(el, path))
@@ -46,7 +47,7 @@ namespace NuKeeper.RepositoryInspection
             try
             {
                 var id = el.Attribute("Include")?.Value;
-                var version = el.Attribute("Version")?.Value;
+                var version = el.Attribute("Version")?.Value ?? el.Value;
 
                 return new PackageInProject(id, version, path);
             }

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -16,10 +16,11 @@ namespace NuKeeper.RepositoryInspection
             _logger = logger;
         }
 
-        public IEnumerable<PackageInProject> ReadFile(PackagePath path)
+        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
-            var fileContents = File.ReadAllText(path.FullName);
-            return Read(fileContents, path);
+            var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.ProjectFile);
+            var fileContents = File.ReadAllText(packagePath.FullName);
+            return Read(fileContents, packagePath);
         }
 
         public IEnumerable<PackageInProject> Read(string fileContents, PackagePath path)

--- a/NuKeeper/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper/RepositoryInspection/ProjectFileReader.cs
@@ -19,13 +19,15 @@ namespace NuKeeper.RepositoryInspection
         public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
             var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.ProjectFile);
-            var fileContents = File.ReadAllText(packagePath.FullName);
-            return Read(fileContents, packagePath);
+            using (var fileContents = File.OpenRead(packagePath.FullName))
+            {
+                return Read(fileContents, packagePath);
+            }
         }
 
-        public IEnumerable<PackageInProject> Read(string fileContents, PackagePath path)
+        public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)
         {
-            var xml = XDocument.Parse(fileContents);
+            var xml = XDocument.Load(fileContents);
             var ns = xml.Root.GetDefaultNamespace();
             var project = xml.Element(ns + "Project");
 

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using NuKeeper.Files;
 
@@ -60,7 +61,10 @@ namespace NuKeeper.RepositoryInspection
 
         private string GetRelativeFileName(string rootDir, string fileName)
         {
-            return fileName.Replace(rootDir, string.Empty);
+            var rootDirWithSeparator = rootDir.EndsWith(Path.DirectorySeparatorChar.ToString())
+                ? rootDir
+                : rootDir + Path.DirectorySeparatorChar;
+            return fileName.Replace(rootDirWithSeparator, string.Empty);
         }
     }
 }

--- a/NuKeeper/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper/RepositoryInspection/RepositoryScanner.cs
@@ -18,8 +18,7 @@ namespace NuKeeper.RepositoryInspection
         public IEnumerable<PackageInProject> FindAllNuGetPackages(IFolder workingFolder)
         {
 
-            return 
-                PackageFiles(workingFolder)
+            return PackageFiles(workingFolder)
                 .Concat(ProjectFiles(workingFolder))
                 .ToList();
         }
@@ -33,8 +32,8 @@ namespace NuKeeper.RepositoryInspection
 
             foreach (var packagesFile in packagesFiles)
             {
-                var path = MakePackagePath(workingFolder.FullPath, packagesFile.FullName, PackageReferenceType.PackagesConfig);
-                var packages = _packagesFileReader.ReadFile(path);
+                var packages = _packagesFileReader.ReadFile(workingFolder.FullPath,
+                    GetRelativeFileName(workingFolder.FullPath, packagesFile.FullName));
                 results.AddRange(packages);
             }
 
@@ -51,19 +50,17 @@ namespace NuKeeper.RepositoryInspection
 
             foreach (var projectFile in projectFiles)
             {
-                var path = MakePackagePath(workingFolder.FullPath, projectFile.FullName, PackageReferenceType.ProjectFile);
-                var packages = _projectFileReader.ReadFile(path);
+                var packages = _projectFileReader.ReadFile(workingFolder.FullPath,
+                    GetRelativeFileName(workingFolder.FullPath, projectFile.FullName));
                 results.AddRange(packages);
             }
 
             return results;
         }
 
-        private PackagePath MakePackagePath(string rootDir, string fileName, 
-            PackageReferenceType packageReferenceType)
+        private string GetRelativeFileName(string rootDir, string fileName)
         {
-            var relativeFileName = fileName.Replace(rootDir, string.Empty);
-            return new PackagePath(rootDir, relativeFileName, packageReferenceType);
+            return fileName.Replace(rootDir, string.Empty);
         }
     }
 }


### PR DESCRIPTION
Test uses a sample from 4.6.1 VS2017 project format, with a namespace and slightly different version storage (node instead of attribute).