### PR TITLE
Flow the allowed and latest version

### DIFF
--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -197,7 +197,7 @@ namespace NuKeeper.Tests.Engine
 
             var report = CommitReport.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain("There is also a higher version `2.3.4` of package `foo.bar`, but this was not applied as only `Minor` version changes are allowed."));
+            Assert.That(report, Does.Contain("There is also a higher version, `foo.bar` `2.3.4`, but this was not applied as only `Minor` version changes are allowed."));
         }
 
         private static void AssertContainsStandardText(string report)
@@ -212,6 +212,7 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Not.Contain("Generic"));
             Assert.That(report, Does.Not.Contain("["));
             Assert.That(report, Does.Not.Contain("]"));
+            Assert.That(report, Does.Not.Contain("There is also a higher version"));
         }
 
         private static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)

--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -190,6 +190,15 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Contain("Updated `folder\\src\\project3\\packages.config` to `foo.bar` `1.2.3` from `1.1.0`"));
         }
 
+        [Test]
+        public void OneUpdate_MakeCommitDetails_HasVersionLimitData()
+        {
+            var updates = UpdateSetForLimited(MakePackageForV110());
+
+            var report = CommitReport.MakeCommitDetails(updates);
+
+            Assert.That(report, Does.Contain("There is also a higher version `2.3.4` of package `foo.bar`, but this was not applied as only `Minor` version changes are allowed."));
+        }
 
         private static void AssertContainsStandardText(string report)
         {
@@ -207,8 +216,18 @@ namespace NuKeeper.Tests.Engine
 
         private static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
         {
-            return new PackageUpdateSet(NewPackageFooBar123(), 
-                "someSource", 
+            var newPackage = NewPackageFooBar123();
+            return new PackageUpdateSet(newPackage, 
+                "someSource",
+                newPackage.Version,
+                VersionChange.Major,
+                packages);
+        }
+
+        private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
+        {
+            return new PackageUpdateSet(NewPackageFooBar123(),
+                "someSource",
                 new NuGetVersion("2.3.4"),
                 VersionChange.Minor,
                 packages);

--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -2,6 +2,7 @@
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Engine;
+using NuKeeper.NuGet.Api;
 using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
 
@@ -206,7 +207,11 @@ namespace NuKeeper.Tests.Engine
 
         private static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
         {
-            return new PackageUpdateSet(NewPackageFooBar123(), string.Empty, packages);
+            return new PackageUpdateSet(NewPackageFooBar123(), 
+                "someSource", 
+                new NuGetVersion("2.3.4"),
+                VersionChange.Minor,
+                packages);
         }
 
         private static PackageIdentity NewPackageFooBar123()

--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -197,7 +197,7 @@ namespace NuKeeper.Tests.Engine
 
             var report = CommitReport.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain("There is also a higher version, `foo.bar` `2.3.4`, but this was not applied as only `Minor` version changes are allowed."));
+            Assert.That(report, Does.Contain("There is also a higher version, `foo.bar 2.3.4`, but this was not applied as only `Minor` version changes are allowed."));
         }
 
         private static void AssertContainsStandardText(string report)

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -7,6 +7,7 @@ using NuGet.Versioning;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Git;
+using NuKeeper.NuGet.Api;
 using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
 
@@ -198,7 +199,9 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foobar", "1.0.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            return new PackageUpdateSet(newPackage, "ASource", 
+                new NuGetVersion("4.0.0"), VersionChange.Major, 
+                currentPackages);
         }
 
         private PackageUpdateSet UpdateFooFromOneVersion()
@@ -211,7 +214,9 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            return new PackageUpdateSet(newPackage, "ASource",
+                new NuGetVersion("4.0.0"), VersionChange.Major,
+                currentPackages);
         }
 
         private PackageUpdateSet UpdateBarFromTwoVersions()
@@ -224,7 +229,9 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("bar", "1.2.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            return new PackageUpdateSet(newPackage, "ASource", 
+                new NuGetVersion("4.0.0"), VersionChange.Major, 
+                currentPackages);
         }
 
         private PackageIdentity LatestVersionOfPackageFoobar()

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -145,12 +145,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test");
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
-                .Returns(new PackageLookupResult
-                    {
-                        AllowedChange = VersionChange.Major,
-                        Highest = responseMetaData,
-                        Match = responseMetaData
-                    });
+                .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData));
         }
 
         private static BulkPackageLookup BuildBulkPackageLookup(IApiPackageLookup apiLookup)

--- a/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Tests.NuGet.Api
             var logger = Substitute.For<INuKeeperLogger>();
             var reporter = new PackageLookupResultReporter(logger);
 
-            var data = new PackageLookupResult();
+            var data = new PackageLookupResult(VersionChange.Major, null, null);
 
             reporter.Report(data);
 
@@ -37,12 +37,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)), 
                 "someSource");
 
-            var data = new PackageLookupResult
-            {
-                AllowedChange = VersionChange.Major,
-                Match = fooMetadata,
-                Highest = fooMetadata
-            };
+            var data = new PackageLookupResult(VersionChange.Major, fooMetadata, fooMetadata);
 
             reporter.Report(data);
 
@@ -63,12 +58,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
                 "someSource");
 
-            var data = new PackageLookupResult
-            {
-                AllowedChange = VersionChange.Minor,
-                Match = fooMetadata,
-                Highest = fooMetadata
-            };
+            var data = new PackageLookupResult(VersionChange.Minor, fooMetadata, fooMetadata);
 
             reporter.Report(data);
 
@@ -93,12 +83,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
                 "someSource");
 
-            var data = new PackageLookupResult
-            {
-                AllowedChange = VersionChange.Minor,
-                Match = fooMinor,
-                Highest = fooMajor
-            };
+            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, fooMinor);
 
             reporter.Report(data);
 
@@ -119,12 +104,7 @@ namespace NuKeeper.Tests.NuGet.Api
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
                 "someSource");
 
-            var data = new PackageLookupResult
-            {
-                AllowedChange = VersionChange.Minor,
-                Match = null,
-                Highest = fooMajor
-            };
+            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, null);
 
             reporter.Report(data);
 

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.NuGet.Api;
 using NuKeeper.RepositoryInspection;
 using NUnit.Framework;
 
@@ -11,6 +12,8 @@ namespace NuKeeper.Tests.RepositoryInspection
     [TestFixture]
     public class PackageUpdateSetTests
     {
+        private const string ASource = "somePackageSource";
+
         [Test]
         public void NullNewPackageId_IsNotAllowed()
         {
@@ -19,14 +22,32 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(null, string.Empty, packages));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
+                null, ASource, VersionFour(), VersionChange.Major, packages));
+
             Assert.That(exception.ParamName, Is.EqualTo("newPackage"));
+        }
+
+        [Test]
+        public void NullMaxVersion_IsNotAllowed()
+        {
+            var packages = new List<PackageInProject>
+            {
+                new PackageInProject("foo", "1.0.0", PathToProjectOne())
+            };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
+                LatestVersionOfPackageFoo(), ASource, null, VersionChange.Major, packages));
+
+            Assert.That(exception.ParamName, Is.EqualTo("highest"));
         }
 
         [Test]
         public void NullPackages_IsNotAllowed()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(LatestVersionOfPackageFoo(), string.Empty, null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
+                LatestVersionOfPackageFoo(), ASource, VersionFour(), VersionChange.Major, null));
+
             Assert.That(exception.ParamName, Is.EqualTo("currentPackages"));
         }
 
@@ -38,15 +59,30 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(LatestVersionOfPackageFoo(), null, packages));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
+                LatestVersionOfPackageFoo(), null, VersionFour(), VersionChange.Major, packages));
+            Assert.That(exception.ParamName, Is.EqualTo("packageSource"));
+        }
+
+        [Test]
+        public void EmptySource_IsNotAllowed()
+        {
+            var packages = new List<PackageInProject>
+            {
+                new PackageInProject("foo", "1.0.0", PathToProjectOne())
+            };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
+                LatestVersionOfPackageFoo(), string.Empty, VersionFour(), VersionChange.Major, packages));
             Assert.That(exception.ParamName, Is.EqualTo("packageSource"));
         }
 
         [Test]
         public void EmptyPackages_IsNotAllowed()
         {
-            var exception = Assert.Throws<ArgumentException>(
-                () => new PackageUpdateSet(LatestVersionOfPackageFoo(), string.Empty, Enumerable.Empty<PackageInProject>()));
+            var exception = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
+                LatestVersionOfPackageFoo(), ASource, VersionFour(), VersionChange.Major,
+                Enumerable.Empty<PackageInProject>()));
             Assert.That(exception.ParamName, Is.EqualTo("currentPackages"));
         }
 
@@ -60,12 +96,15 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
             Assert.That(updates.PackageId, Is.EqualTo("foo"));
             Assert.That(updates.NewVersion, Is.EqualTo(newPackage.Version));
+            Assert.That(updates.PackageSource, Is.EqualTo(ASource));
+            Assert.That(updates.Highest, Is.EqualTo(VersionFour()));
+            Assert.That(updates.AllowedChange, Is.EqualTo(VersionChange.Major));
         }
 
         [Test]
@@ -78,7 +117,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
             Assert.That(updates.CurrentPackages.Count, Is.EqualTo(1));
@@ -96,7 +135,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
@@ -116,7 +155,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
             var currents = updates.CurrentPackages.ToList();
@@ -139,7 +178,8 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(newPackageFoo, string.Empty, currentPackageBar));
+            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
+                newPackageFoo, ASource, VersionFour(), VersionChange.Major, currentPackageBar));
         }
 
         [Test]
@@ -154,7 +194,8 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("fish", "1.0.0", PathToProjectOne())
             };
 
-            var ex = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(newPackageFoo, string.Empty, currentPackages));
+            var ex = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
+                newPackageFoo, ASource, VersionFour(), VersionChange.Major, currentPackages));
 
             Assert.That(ex.Message, Is.EqualTo("Updates must all be for package 'foo', got 'bar, fish'"));
         }
@@ -170,7 +211,8 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(newPackageFoo, string.Empty, currentPackagesFooAndBar));
+            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
+                newPackageFoo, ASource, VersionFour(), VersionChange.Major, currentPackagesFooAndBar));
         }
 
         [Test]
@@ -183,7 +225,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
         }
@@ -199,7 +241,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
         }
@@ -215,7 +257,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(newPackage, string.Empty, currentPackages);
+            var updates = new PackageUpdateSet(newPackage, ASource, VersionFour(), VersionChange.Major, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(2));
         }
@@ -223,6 +265,11 @@ namespace NuKeeper.Tests.RepositoryInspection
         private PackageIdentity LatestVersionOfPackageFoo()
         {
             return new PackageIdentity("foo", new NuGetVersion("1.2.3"));
+        }
+
+        private NuGetVersion VersionFour()
+        {
+            return new NuGetVersion("4.0.0");
         }
 
         private PackagePath PathToProjectOne()

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -43,9 +43,9 @@ namespace NuKeeper.Engine
             var highestVersion = updates.Highest;
             if (highestVersion != null && (highestVersion > updates.NewVersion))
             {
-                var allowed = CodeQuote(updates.AllowedChange.ToString());
+                var allowedChange = CodeQuote(updates.AllowedChange.ToString());
                 builder.AppendLine(
-                    $"There is also a higher version {CodeQuote(highestVersion.ToString())} of package {packageId}, but this was not applied as only {allowed} version changes are allowed.");
+                    $"There is also a higher version, {packageId} {CodeQuote(highestVersion.ToString())}, but this was not applied as only {allowedChange} version changes are allowed.");
             }
 
             if (updates.CurrentPackages.Count == 1)

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -40,6 +40,14 @@ namespace NuKeeper.Engine
                 builder.AppendLine($"{oldVersions.Count} versions of {packageId} were found in use: {oldVersions.JoinWithCommas()}");
             }
 
+            var highestVersion = updates.Highest;
+            if (highestVersion != null && (highestVersion > updates.NewVersion))
+            {
+                var allowed = CodeQuote(updates.AllowedChange.ToString());
+                builder.AppendLine(
+                    $"There is also a higher version {CodeQuote(highestVersion.ToString())} of package {packageId}, but this was not applied as only {allowed} version changes are allowed.");
+            }
+
             if (updates.CurrentPackages.Count == 1)
             {
                 builder.AppendLine("1 project update:");

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -44,8 +44,9 @@ namespace NuKeeper.Engine
             if (highestVersion != null && (highestVersion > updates.NewVersion))
             {
                 var allowedChange = CodeQuote(updates.AllowedChange.ToString());
+                var highest = CodeQuote(updates.PackageId + " " + highestVersion);
                 builder.AppendLine(
-                    $"There is also a higher version, {packageId} {CodeQuote(highestVersion.ToString())}, but this was not applied as only {allowedChange} version changes are allowed.");
+                    $"There is also a higher version, {highest}, but this was not applied as only {allowedChange} version changes are allowed.");
             }
 
             if (updates.CurrentPackages.Count == 1)

--- a/NuKeeper/NuGet/Api/ApiPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/ApiPackageLookup.cs
@@ -26,13 +26,8 @@ namespace NuKeeper.NuGet.Api
             var highest = orderedByVersion.FirstOrDefault();
             var highestThatMatchesFilter = orderedByVersion
                 .FirstOrDefault(p => filter(package.Version, p.Identity.Version));
-            
-            return new PackageLookupResult
-            {
-                AllowedChange = allowedChange,
-                Highest = highest,
-                Match = highestThatMatchesFilter
-            };
+
+            return new PackageLookupResult(allowedChange, highest, highestThatMatchesFilter);
         }
     }
 }

--- a/NuKeeper/NuGet/Api/BulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/BulkPackageLookup.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.NuGet.Api
             _lookupReporter = lookupReporter;
         }
 
-        public async Task<Dictionary<string, PackageSearchMedatadata>> FindVersionUpdates(
+        public async Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages, VersionChange allowedChange)
         {
             var latestOfEach = packages
@@ -31,7 +31,7 @@ namespace NuKeeper.NuGet.Api
 
             await Task.WhenAll(lookupTasks);
 
-            var result = new Dictionary<string, PackageSearchMedatadata>();
+            var result = new Dictionary<string, PackageLookupResult>();
 
             foreach (var lookupTask in lookupTasks)
             {
@@ -42,15 +42,15 @@ namespace NuKeeper.NuGet.Api
             return result;
         }
 
-        private void ProcessLookupResult(PackageLookupResult lookupResult, Dictionary<string, PackageSearchMedatadata> result)
+        private void ProcessLookupResult(PackageLookupResult packageLookup, Dictionary<string, PackageLookupResult> result)
         {
-            var matchingVersion = lookupResult.Match;
+            var matchingVersion = packageLookup.Match;
 
             if (matchingVersion?.Identity?.Version != null)
             {
-                _lookupReporter.Report(lookupResult);
+                _lookupReporter.Report(packageLookup);
                 var packageId = matchingVersion.Identity.Id;
-                result.Add(packageId, matchingVersion);
+                result.Add(packageId, packageLookup);
             }
         }
 

--- a/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
+++ b/NuKeeper/NuGet/Api/IBulkPackageLookup.cs
@@ -6,7 +6,7 @@ namespace NuKeeper.NuGet.Api
 {
     public interface IBulkPackageLookup
     {
-        Task<Dictionary<string, PackageSearchMedatadata>> FindVersionUpdates(
+        Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
             VersionChange allowedChange);
     }

--- a/NuKeeper/NuGet/Api/PackageLookupResult.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResult.cs
@@ -2,10 +2,17 @@
 {
     public class PackageLookupResult
     {
-        public VersionChange AllowedChange { get; set; }
+        public PackageLookupResult(
+            VersionChange allowedChange, 
+            PackageSearchMedatadata highest, PackageSearchMedatadata match)
+        {
+            AllowedChange = allowedChange;
+            Highest = highest;
+            Match = match;
+        }
 
-        public PackageSearchMedatadata Highest { get; set; }
-
-        public PackageSearchMedatadata Match { get; set; }
+        public VersionChange AllowedChange { get; }
+        public PackageSearchMedatadata Highest { get; }
+        public PackageSearchMedatadata Match { get; }
     }
 }

--- a/NuKeeper/NuGet/Api/PackageLookupResult.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResult.cs
@@ -5,6 +5,7 @@
         public VersionChange AllowedChange { get; set; }
 
         public PackageSearchMedatadata Highest { get; set; }
+
         public PackageSearchMedatadata Match { get; set; }
     }
 }

--- a/NuKeeper/NuGet/Api/PackageSearchMedatadata.cs
+++ b/NuKeeper/NuGet/Api/PackageSearchMedatadata.cs
@@ -1,3 +1,4 @@
+using System;
 using NuGet.Packaging.Core;
 
 namespace NuKeeper.NuGet.Api
@@ -8,6 +9,16 @@ namespace NuKeeper.NuGet.Api
             PackageIdentity identity,
             string source)
         {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
             Identity = identity;
             Source = source;
         }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.NuGet.Api
             foreach (var packageId in latestVersions.Keys)
             {
                 var latestPackage = latestVersions[packageId];
-                var identity = latestPackage.Identity;
+                var identity = latestPackage.Match.Identity;
 
                 var updatesForThisPackage = packages
                     .Where(p => p.Id == packageId && p.Version < identity.Version)
@@ -38,7 +38,10 @@ namespace NuKeeper.NuGet.Api
 
                 if (updatesForThisPackage.Count > 0)
                 {
-                    var updateSet = new PackageUpdateSet(identity, latestPackage.Source, updatesForThisPackage);
+                    var updateSet = new PackageUpdateSet(
+                        identity, 
+                        latestPackage.Match.Source, 
+                        updatesForThisPackage);
                     results.Add(updateSet);
                 }
             }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -39,8 +39,10 @@ namespace NuKeeper.NuGet.Api
                 if (updatesForThisPackage.Count > 0)
                 {
                     var updateSet = new PackageUpdateSet(
-                        identity, 
-                        latestPackage.Match.Source, 
+                        identity,
+                        latestPackage.Match.Source,
+                        latestPackage.Highest.Identity.Version,
+                        latestPackage.AllowedChange,
                         updatesForThisPackage);
                     results.Add(updateSet);
                 }

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -3,26 +3,37 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.NuGet.Api;
 
 namespace NuKeeper.RepositoryInspection
 {
     public class PackageUpdateSet
     {
-        public PackageUpdateSet(PackageIdentity newPackage, string packageSource, IEnumerable<PackageInProject> currentPackages)
+        public PackageUpdateSet(
+            PackageIdentity newPackage,
+            string packageSource,
+            NuGetVersion highest,
+            VersionChange allowedChange,
+            IEnumerable<PackageInProject> currentPackages)
         {
             if (newPackage == null)
             {
                 throw new ArgumentNullException(nameof(newPackage));
             }
 
+            if (string.IsNullOrWhiteSpace(packageSource))
+            {
+                throw new ArgumentNullException(nameof(packageSource));
+            }
+
+            if (highest == null)
+            {
+                throw new ArgumentNullException(nameof(highest));
+            }
+
             if (currentPackages == null)
             {
                 throw new ArgumentNullException(nameof(currentPackages));
-            }
-
-            if (packageSource == null)
-            {
-                throw new ArgumentNullException(nameof(packageSource));
             }
 
             var currentPackagesList = currentPackages.ToList();
@@ -45,6 +56,8 @@ namespace NuKeeper.RepositoryInspection
             NewPackage = newPackage;
             CurrentPackages = currentPackagesList;
             PackageSource = packageSource;
+            Highest = highest;
+            AllowedChange = allowedChange;
         }
 
         public PackageIdentity NewPackage { get; }
@@ -54,6 +67,8 @@ namespace NuKeeper.RepositoryInspection
         public string PackageId => NewPackage.Id;
         public NuGetVersion NewVersion => NewPackage.Version;
         public string PackageSource { get; }
+        public NuGetVersion Highest { get; }
+        public VersionChange AllowedChange { get; }
 
         public int CountCurrentVersions()
         {


### PR DESCRIPTION
Flow the allowed and latest version data all the way through to appearing in the commit report
And a test.

What this means is that even if you don't look at the command line program's output, when you are e.g. only allowing `Minor` version updates and there is also a potential `Major` version update that was not applied, you will see the wording on generated the PR telling you about it
e.g.:
> NuKeeper has generated an update of `Foo.bar` to `1.2.3` from `1.1.0`
There is also a higher version, `Foo.bar 2.3.4`, but this was not applied as only `Minor` version changes are allowed.
