### PR TITLE
Push perms

### DIFF
--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -11,10 +11,6 @@ namespace NuKeeper.Tests.Engine
     [TestFixture]
     public class ForkFinderTests
     {
-        private const string NoMatchUrl = "http://repos.com/org/nomatch";
-        private const string ParentUrl = "http://repos.com/org/parent";
-        private const string ForkUrl = "http://repos.com/org/repo";
-
         [Test]
         public async Task FallbackForkIsUsedByDefault()
         {
@@ -33,7 +29,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = MakeRepository();
+            var userRepo = RespositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -52,7 +48,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = NoMatchFork();
 
-            var userRepo = MakeRepository();
+            var userRepo = RespositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -70,7 +66,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = MakeRepository();
+            var userRepo = RespositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -88,52 +84,14 @@ namespace NuKeeper.Tests.Engine
             Assert.That(actualFork, Is.Not.EqualTo(fallbackFork));
         }
 
-        private static Repository MakeRepository()
-        {
-            const string omniUrl = "http://somewhere.com/fork";
-            var owner = new User(omniUrl, "test user", null, 0, "test inc",
-                DateTimeOffset.Now, 0, null, 0, 0, false, omniUrl, 1, 1,
-                "testville", "testUser", "Testy",
-                1, null, 0, 0,
-                1, omniUrl, null, false, "test", null);
-
-
-            var perms = new RepositoryPermissions(false, true, true);
-            var parent = MakeParentRepo();
-
-            return new Repository(omniUrl, ForkUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
-                123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
-                1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now, 
-                perms, parent,
-                null, false, false, false, false, 2, 122, true, true, true);
-        }
-
-        private static Repository MakeParentRepo()
-        {
-            const string omniUrl = "http://somewhere.com/parent";
-            var owner = new User(omniUrl, "test user", null, 0, "test inc",
-                DateTimeOffset.Now, 0, null, 0, 0, false, omniUrl, 1, 1,
-                "testville", "testUser", "Testy",
-                1, null, 0, 0,
-                1, omniUrl, null, false, "test", null);
-
-
-            var perms = new RepositoryPermissions(false, true, true);
-
-            return new Repository(omniUrl, ParentUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
-                123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
-                1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now, perms, null,
-                null, false, false, false, false, 2, 122, true, true, true);
-        }
-
         private ForkData DefaultFork()
         {
-            return new ForkData(new Uri(ParentUrl), "testOrg", "someRepo");
+            return new ForkData(new Uri(RespositoryBuilder.ParentUrl), "testOrg", "someRepo");
         }
 
         private ForkData NoMatchFork()
         {
-            return new ForkData(new Uri(NoMatchUrl), "testOrg", "someRepo");
+            return new ForkData(new Uri(RespositoryBuilder.NoMatchUrl), "testOrg", "someRepo");
         }
 
         private static void AssertForkMatchesRepo(ForkData fork, Repository repo)

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -23,11 +23,13 @@ namespace NuKeeper.Tests.Engine
 
             var githubRepositoryDiscovery = new GithubRepositoryDiscovery(github, settings);
 
-            var repos = await githubRepositoryDiscovery.GetRepositories();
+            var reposResponse = await githubRepositoryDiscovery.GetRepositories();
+
+            var repos = reposResponse.ToList();
 
             Assert.That(repos, Is.Not.Null);
-            Assert.That(repos.Count(), Is.EqualTo(1));
-            Assert.That(repos.First(), Is.EqualTo(settings.Repository));
+            Assert.That(repos.Count, Is.EqualTo(1));
+            Assert.That(repos[0], Is.EqualTo(settings.Repository));
         }
 
         [Test]

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Tests.Engine
                 Repository = new RepositorySettings()
             };
 
-            var githubRepositoryDiscovery = new GithubRepositoryDiscovery(github, settings);
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, settings);
 
             var reposResponse = await githubRepositoryDiscovery.GetRepositories();
 
@@ -42,12 +42,17 @@ namespace NuKeeper.Tests.Engine
                     OrganisationName = "testOrg"
                 };
 
-            var githubRepositoryDiscovery = new GithubRepositoryDiscovery(github, settings);
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, settings);
 
             var repos = await githubRepositoryDiscovery.GetRepositories();
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Empty);
+        }
+
+        private static IGithubRepositoryDiscovery MakeGithubRepositoryDiscovery(IGithub github, ModalSettings settings)
+        {
+            return new GithubRepositoryDiscovery(github, settings, new NullNuKeeperLogger());
         }
     }
 }

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Github;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class GithubRepositoryDiscoveryTests
+    {
+        [Test]
+        public async Task SuccessInRepoMode()
+        {
+            var github = Substitute.For<IGithub>();
+            var settings = new ModalSettings
+            {
+                Mode = GithubMode.Repository,
+                Repository = new RepositorySettings()
+            };
+
+            var githubRepositoryDiscovery = new GithubRepositoryDiscovery(github, settings);
+
+            var repos = await githubRepositoryDiscovery.GetRepositories();
+
+            Assert.That(repos, Is.Not.Null);
+            Assert.That(repos.Count(), Is.EqualTo(1));
+            Assert.That(repos.First(), Is.EqualTo(settings.Repository));
+        }
+
+        [Test]
+        public async Task SuccessInOrgMode()
+        {
+            var github = Substitute.For<IGithub>();
+            var settings = new ModalSettings
+                {
+                    Mode = GithubMode.Organisation,
+                    OrganisationName = "testOrg"
+                };
+
+            var githubRepositoryDiscovery = new GithubRepositoryDiscovery(github, settings);
+
+            var repos = await githubRepositoryDiscovery.GetRepositories();
+
+            Assert.That(repos, Is.Not.Null);
+            Assert.That(repos, Is.Empty);
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/RespositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RespositoryBuilder.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Tests.Engine
         public const string ForkUrl = "http://repos.com/org/repo";
         public const string NoMatchUrl = "http://repos.com/org/nomatch";
 
-        public static Repository MakeRepository()
+        public static Repository MakeRepository(string htmlUrl = ForkUrl, bool canPull = true)
         {
             const string omniUrl = "http://somewhere.com/fork";
             var owner = new User(omniUrl, "test user", null, 0, "test inc",
@@ -19,10 +19,10 @@ namespace NuKeeper.Tests.Engine
                 1, omniUrl, null, false, "test", null);
 
 
-            var perms = new RepositoryPermissions(false, true, true);
+            var perms = new RepositoryPermissions(false, true, canPull);
             var parent = MakeParentRepo();
 
-            return new Repository(omniUrl, ForkUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+            return new Repository(omniUrl, htmlUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
                 123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
                 1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now,
                 perms, parent,

--- a/NuKeeper.Tests/Engine/RespositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RespositoryBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Octokit;
+
+namespace NuKeeper.Tests.Engine
+{
+    public class RespositoryBuilder
+    {
+        public const string ParentUrl = "http://repos.com/org/parent";
+        public const string ForkUrl = "http://repos.com/org/repo";
+        public const string NoMatchUrl = "http://repos.com/org/nomatch";
+
+        public static Repository MakeRepository()
+        {
+            const string omniUrl = "http://somewhere.com/fork";
+            var owner = new User(omniUrl, "test user", null, 0, "test inc",
+                DateTimeOffset.Now, 0, null, 0, 0, false, omniUrl, 1, 1,
+                "testville", "testUser", "Testy",
+                1, null, 0, 0,
+                1, omniUrl, null, false, "test", null);
+
+
+            var perms = new RepositoryPermissions(false, true, true);
+            var parent = MakeParentRepo();
+
+            return new Repository(omniUrl, ForkUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+                123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
+                1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now,
+                perms, parent,
+                null, false, false, false, false, 2, 122, true, true, true);
+        }
+
+        public static Repository MakeParentRepo()
+        {
+            const string omniUrl = "http://somewhere.com/parent";
+            var owner = new User(omniUrl, "test user", null, 0, "test inc",
+                DateTimeOffset.Now, 0, null, 0, 0, false, omniUrl, 1, 1,
+                "testville", "testUser", "Testy",
+                1, null, 0, 0,
+                1, omniUrl, null, false, "test", null);
+
+
+            var perms = new RepositoryPermissions(false, true, true);
+
+            return new Repository(omniUrl, ParentUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+                123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
+                1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now, perms, null,
+                null, false, false, false, false, 2, 122, true, true, true);
+        }
+    }
+}

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -49,7 +49,6 @@ namespace NuKeeper.Engine
             if (allOrgRepos.Count > usableRepos.Count)
             {
                 _logger.Verbose($"Can pull from {usableRepos.Count} repos out of {allOrgRepos.Count}");
-
             }
 
             return usableRepos.Select(r => new RepositorySettings(r));

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Github;
+using NuKeeper.Logging;
 
 namespace NuKeeper.Engine
 {
@@ -10,13 +11,16 @@ namespace NuKeeper.Engine
     {
         private readonly IGithub _github;
         private readonly ModalSettings _settings;
+        private readonly INuKeeperLogger _logger;
 
         public GithubRepositoryDiscovery(
             IGithub github, 
-            ModalSettings settings)
+            ModalSettings settings,
+            INuKeeperLogger logger)
         {
             _github = github;
             _settings = settings;
+            _logger = logger;
         }
 
         public async Task<IEnumerable<RepositorySettings>> GetRepositories()
@@ -36,9 +40,19 @@ namespace NuKeeper.Engine
 
         private async Task<IEnumerable<RepositorySettings>> FromOrganisation(string organisationName)
         {
-            var repositories = await _github.GetRepositoriesForOrganisation(organisationName);
+            var allOrgRepos = await _github.GetRepositoriesForOrganisation(organisationName);
 
-            return repositories.Select(r => new RepositorySettings(r));
+            var usableRepos = allOrgRepos
+                .Where(r => r.Permissions.Pull)
+                .ToList();
+
+            if (allOrgRepos.Count > usableRepos.Count)
+            {
+                _logger.Verbose($"Can pull from {usableRepos.Count} repos out of {allOrgRepos.Count}");
+
+            }
+
+            return usableRepos.Select(r => new RepositorySettings(r));
         }
     }
 }

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -19,13 +19,6 @@ namespace NuKeeper.Engine
             _settings = settings;
         }
 
-        public async Task<IEnumerable<RepositorySettings>> FromOrganisation(string organisationName)
-        {
-            var repositories = await _github.GetRepositoriesForOrganisation(organisationName);
-
-            return repositories.Select(r => new RepositorySettings(r));
-        }
-
         public async Task<IEnumerable<RepositorySettings>> GetRepositories()
         {
             switch (_settings.Mode)
@@ -39,6 +32,13 @@ namespace NuKeeper.Engine
                 default:
                     return Enumerable.Empty<RepositorySettings>();
             }
+        }
+
+        private async Task<IEnumerable<RepositorySettings>> FromOrganisation(string organisationName)
+        {
+            var repositories = await _github.GetRepositoriesForOrganisation(organisationName);
+
+            return repositories.Select(r => new RepositorySettings(r));
         }
     }
 }

--- a/NuKeeper/Engine/IGithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/IGithubRepositoryDiscovery.cs
@@ -6,7 +6,6 @@ namespace NuKeeper.Engine
 {
     public interface IGithubRepositoryDiscovery
     {
-        Task<IEnumerable<RepositorySettings>> FromOrganisation(string organisationName);
         Task<IEnumerable<RepositorySettings>> GetRepositories();
     }
 }

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -36,10 +36,13 @@ namespace NuKeeper.Github
 
         public async Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string organisationName)
         {
-            var results = await _client.Repository.GetAllForOrg(organisationName);
-            var resultList = results.Where(r => r.Permissions.Pull && r.Permissions.Push).ToList().AsReadOnly();
-            _logger.Verbose($"Read {resultList.Count} repos for org '{organisationName}'");
-            return resultList;
+            var allOrgRepos = await _client.Repository.GetAllForOrg(organisationName);
+            var usableRepos = allOrgRepos
+                .Where(r => r.Permissions.Pull)
+                .ToList().AsReadOnly();
+
+            _logger.Verbose($"Read {usableRepos.Count} repos for org '{organisationName}'");
+            return usableRepos;
         }
 
         public async Task<Repository> GetUserRepository(string userName, string repositoryName)

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -36,19 +36,9 @@ namespace NuKeeper.Github
 
         public async Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string organisationName)
         {
-            var allOrgRepos = await _client.Repository.GetAllForOrg(organisationName);
-            var usableRepos = allOrgRepos
-                .Where(r => r.Permissions.Pull)
-                .ToList().AsReadOnly();
-
-            _logger.Info($"Read {usableRepos.Count} repos for org '{organisationName}'");
-            if (allOrgRepos.Count > usableRepos.Count)
-            {
-                _logger.Verbose($"Filtered to {usableRepos.Count} repos out of {allOrgRepos.Count}");
-
-            }
-
-            return usableRepos;
+            var repos = await _client.Repository.GetAllForOrg(organisationName);
+            _logger.Info($"Read {repos.Count} repos for org '{organisationName}'");
+            return repos;
         }
 
         public async Task<Repository> GetUserRepository(string userName, string repositoryName)

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -41,7 +41,13 @@ namespace NuKeeper.Github
                 .Where(r => r.Permissions.Pull)
                 .ToList().AsReadOnly();
 
-            _logger.Verbose($"Read {usableRepos.Count} repos for org '{organisationName}'");
+            _logger.Info($"Read {usableRepos.Count} repos for org '{organisationName}'");
+            if (allOrgRepos.Count > usableRepos.Count)
+            {
+                _logger.Verbose($"Filtered to {usableRepos.Count} repos out of {allOrgRepos.Count}");
+
+            }
+
             return usableRepos;
         }
 


### PR DESCRIPTION
Don't filter out repos with no push permission in the initial list of repos for an org.

We don't necessarily need push perms to the source repo at this point any more, as we might be pushing to a fork.

Moved the organisation repo list filtering up to `GithubRepositoryDiscovery` class, as that class is testable. Made tests. 