### PR TITLE
Fork control on commandline

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -34,7 +34,17 @@ namespace NuKeeper.Tests.Configuration
         }
 
         [Test]
-        public void ValidRepoCommandLineHasDefaultValues()
+        public void ValidRepoCommandLineHasDefaultGithubSettings()
+        {
+            var commandLine = ValidRepoCommandLine();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.GithubAuthSettings.ApiBase, Is.EqualTo(new Uri("https://api.github.com/")));
+        }
+
+        [Test]
+        public void ValidRepoCommandLineHasDefaultUserSettings()
         {
             var commandLine = ValidRepoCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
@@ -42,8 +52,8 @@ namespace NuKeeper.Tests.Configuration
             AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(3));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
-            Assert.That(settings.GithubAuthSettings.ApiBase, Is.EqualTo(new Uri("https://api.github.com/")));
-            Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new [] {"https://api.nuget.org/v3/index.json"}));
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
+            Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new[] { "https://api.nuget.org/v3/index.json" }));
         }
 
         [Test]
@@ -80,6 +90,18 @@ namespace NuKeeper.Tests.Configuration
 
             AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Patch));
+        }
+
+        [Test]
+        public void ForkModeOverrideIsParsed()
+        {
+            var commandLine = ValidRepoCommandLine()
+                .Append("fork=PreferUpstream");
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferUpstream));
         }
 
         [Test]
@@ -216,7 +238,17 @@ namespace NuKeeper.Tests.Configuration
         }
 
         [Test]
-        public void ValidOrgCommandLineHasDefaultValues()
+        public void ValidOrgCommandLineHasDefaultGithubValues()
+        {
+            var commandLine = ValidOrgCommandLine();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.GithubAuthSettings.ApiBase, Is.EqualTo(new Uri("https://api.github.com/")));
+        }
+
+        [Test]
+        public void ValidOrgCommandLineHasDefaultUserSettings()
         {
             var commandLine = ValidOrgCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
@@ -224,10 +256,9 @@ namespace NuKeeper.Tests.Configuration
             AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(3));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
-            Assert.That(settings.GithubAuthSettings.ApiBase, Is.EqualTo(new Uri("https://api.github.com/")));
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new[] { "https://api.nuget.org/v3/index.json" }));
         }
-
 
         private static IEnumerable<string> ValidRepoCommandLine()
         {

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -96,12 +96,12 @@ namespace NuKeeper.Tests.Configuration
         public void ForkModeOverrideIsParsed()
         {
             var commandLine = ValidRepoCommandLine()
-                .Append("fork=PreferUpstream");
+                .Append("fork=PreferSingleRepository");
 
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferUpstream));
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferSingleRepository));
         }
 
         [Test]

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -29,6 +29,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Repository));
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
         }
 
         [Test]
@@ -42,6 +43,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Organisation));
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
+            Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
         }
 
         private static RawConfiguration ValidRepoSettings()
@@ -53,7 +55,8 @@ namespace NuKeeper.Tests.Configuration
                 Mode = "repository",
                 GithubRepositoryUri = new Uri("https://github.com/NuKeeperDotNet/NuKeeper"),
                 AllowedChange = VersionChange.Major,
-                LogLevel = LogLevel.Info
+                LogLevel = LogLevel.Info,
+                ForkMode = ForkMode.PreferFork
             };
         }
 
@@ -66,7 +69,8 @@ namespace NuKeeper.Tests.Configuration
                 Mode = "organisation",
                 GithubOrganisationName = "NuKeeperDotNet",
                 AllowedChange = VersionChange.Major,
-                LogLevel = LogLevel.Info
+                LogLevel = LogLevel.Info,
+                ForkMode = ForkMode.PreferFork
             };
         }
 

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -124,7 +124,7 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public async Task PreferUpstreamModeWillNotPreferFork()
+        public async Task PreferSingleRepoModeWillNotPreferFork()
         {
             var fallbackFork = DefaultFork();
 
@@ -135,7 +135,7 @@ namespace NuKeeper.Tests.Engine
                 .Returns(userRepo);
 
             var forkFinder = new ForkFinder(github,
-                MakePreferUpstreamSettings(), new NullNuKeeperLogger());
+                MakePreferSingleRepoSettings(), new NullNuKeeperLogger());
 
             var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
@@ -143,7 +143,7 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public async Task PreferUpstreamModeWillUseForkWhenUpstreamIsUnsuitable()
+        public async Task PreferSingleRepoModeWillUseForkWhenUpstreamIsUnsuitable()
         {
             var fallbackFork = DefaultFork();
 
@@ -159,7 +159,7 @@ namespace NuKeeper.Tests.Engine
                 .Returns(userRepo);
 
             var forkFinder = new ForkFinder(github,
-                MakePreferUpstreamSettings(), new NullNuKeeperLogger());
+                MakePreferSingleRepoSettings(), new NullNuKeeperLogger());
 
             var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
@@ -185,7 +185,7 @@ namespace NuKeeper.Tests.Engine
             };
         }
 
-        private UserSettings MakePreferUpstreamSettings()
+        private UserSettings MakePreferSingleRepoSettings()
         {
             return new UserSettings
             {

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Tests.Engine
                 MakeSettings(), new NullNuKeeperLogger());
 
             Assert.ThrowsAsync<Exception>(async () =>
-                await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork));
+                await forkFinder.FindPushFork("testUser", fallbackFork));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github, 
                 MakeSettings(), new NullNuKeeperLogger());
 
-            var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.Null);
             Assert.That(fork, Is.EqualTo(fallbackFork));
@@ -57,7 +57,7 @@ namespace NuKeeper.Tests.Engine
                 MakeSettings(), new NullNuKeeperLogger());
 
             Assert.ThrowsAsync<Exception>(async () =>
-                await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork));
+                await forkFinder.FindPushFork("testUser", fallbackFork));
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakeSettings(), new NullNuKeeperLogger());
 
-            var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.EqualTo(fallbackFork));
             AssertForkMatchesRepo(fork, userRepo);
@@ -94,7 +94,7 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakeSettings(), new NullNuKeeperLogger());
 
-            var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
             Assert.That(fork, Is.EqualTo(fallbackFork));
         }
@@ -115,7 +115,7 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakeSettings(), new NullNuKeeperLogger());
 
-            var actualFork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
+            var actualFork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
             await github.Received(1).MakeUserFork(Arg.Any<string>(), Arg.Any<string>());
 

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Github;
 using NUnit.Framework;
@@ -16,7 +17,8 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var forkFinder = new ForkFinder(Substitute.For<IGithub>(), new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(Substitute.For<IGithub>(),
+                MakeSettings(), new NullNuKeeperLogger());
 
             Assert.ThrowsAsync<Exception>(async () =>
                 await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork));
@@ -32,7 +34,8 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var forkFinder = new ForkFinder(github, new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(github, 
+                MakeSettings(), new NullNuKeeperLogger());
 
             var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
 
@@ -50,7 +53,8 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var forkFinder = new ForkFinder(github, new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(github,
+                MakeSettings(), new NullNuKeeperLogger());
 
             Assert.ThrowsAsync<Exception>(async () =>
                 await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork));
@@ -67,7 +71,8 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github, new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(github,
+                MakeSettings(), new NullNuKeeperLogger());
 
             var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
 
@@ -86,7 +91,8 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github, new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(github,
+                MakeSettings(), new NullNuKeeperLogger());
 
             var fork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
 
@@ -106,7 +112,8 @@ namespace NuKeeper.Tests.Engine
             github.MakeUserFork(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github, new NullNuKeeperLogger());
+            var forkFinder = new ForkFinder(github,
+                MakeSettings(), new NullNuKeeperLogger());
 
             var actualFork = await forkFinder.FindPushFork("testUser", "someRepo", fallbackFork);
 
@@ -124,6 +131,14 @@ namespace NuKeeper.Tests.Engine
         private ForkData NoMatchFork()
         {
             return new ForkData(new Uri(RespositoryBuilder.NoMatchUrl), "testOrg", "someRepo");
+        }
+
+        private UserSettings MakeSettings()
+        {
+            return new UserSettings
+            {
+                ForkMode = ForkMode.PreferFork
+            };
         }
 
         private static void AssertForkMatchesRepo(ForkData fork, Repository repo)

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -189,7 +189,7 @@ namespace NuKeeper.Tests.Engine
         {
             return new UserSettings
             {
-                ForkMode = ForkMode.PreferUpstream
+                ForkMode = ForkMode.PreferSingleRepository
             };
         }
 

--- a/NuKeeper/Configuration/ForkMode.cs
+++ b/NuKeeper/Configuration/ForkMode.cs
@@ -1,4 +1,4 @@
-﻿namespace NuKeeper.Engine
+﻿namespace NuKeeper.Configuration
 {
     public enum ForkMode
     {

--- a/NuKeeper/Configuration/ForkMode.cs
+++ b/NuKeeper/Configuration/ForkMode.cs
@@ -3,6 +3,6 @@
     public enum ForkMode
     {
         PreferFork,
-        PreferUpstream
+        PreferSingleRepository
     }
 }

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -1,6 +1,7 @@
 using System;
 using EasyConfig;
 using EasyConfig.Attributes;
+using NuKeeper.Engine;
 using NuKeeper.Logging;
 using NuKeeper.NuGet.Api;
 
@@ -46,5 +47,9 @@ namespace NuKeeper.Configuration
         [JsonConfig("allowed_version_change"), Default("Major")]
         [OverriddenBy(ConfigurationSources.CommandLine, "change")]
         public VersionChange AllowedChange;
+
+        [JsonConfig("fork_mode"), Default("PreferFork")]
+        [OverriddenBy(ConfigurationSources.CommandLine, "fork")]
+        public ForkMode ForkMode;
     }
 }

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -51,6 +51,7 @@ namespace NuKeeper.Configuration
             var userPrefs = new UserSettings
             {
                 AllowedChange = settings.AllowedChange,
+                ForkMode = settings.ForkMode,
                 LogLevel = settings.LogLevel,
                 MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository,
                 NuGetSources = ReadNuGetSources(settings),

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using NuKeeper.Engine;
 using NuKeeper.Logging;
 using NuKeeper.NuGet.Api;
 
@@ -15,6 +16,8 @@ namespace NuKeeper.Configuration
         public int MaxPullRequestsPerRepository { get; set; }
 
         public VersionChange AllowedChange { get; set; }
+
+        public ForkMode ForkMode { get; set; }
 
         public LogLevel LogLevel { get; set; }
     }

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -1,29 +1,35 @@
 ﻿using System;
 using System.Threading.Tasks;
+using NuKeeper.Configuration;
 using NuKeeper.Github;
 using NuKeeper.Logging;
 using Octokit;
 
 namespace NuKeeper.Engine
 {
-
     public class ForkFinder: IForkFinder
     {
         private readonly IGithub _github;
         private readonly INuKeeperLogger _logger;
+        private ForkMode _forkMode;
 
-        public ForkFinder(IGithub github,INuKeeperLogger logger)
+        public ForkFinder(IGithub github, UserSettings settings, INuKeeperLogger logger)
         {
             _github = github;
+            _forkMode = settings.ForkMode;
             _logger = logger;
         }
 
         public async Task<ForkData> FindPushFork(string userName, string repositoryName, ForkData fallbackFork)
         {
-            var userFork = await TryFindUserFork(userName, repositoryName, fallbackFork);
-            if (userFork != null)
+            if (_forkMode == ForkMode.PreferFork)
             {
-                return userFork;
+                var userFork = await TryFindUserFork(userName, repositoryName, fallbackFork);
+                if (userFork != null)
+                {
+                    return userFork;
+                }
+
             }
 
             // as a fallback, we want to pull and push from the same origin repo.

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -22,12 +22,14 @@ namespace NuKeeper.Engine
 
         public async Task<ForkData> FindPushFork(string userName, ForkData fallbackFork)
         {
+            _logger.Verbose($"FindPushFork. Fork Mode is {_forkMode}");
+
             switch (_forkMode)
             {
                 case ForkMode.PreferFork:
                     return await FindForkOrFallback(userName, fallbackFork);
 
-                case ForkMode.PreferUpstream:
+                case ForkMode.PreferSingleRepository:
                     return await FindUpstreamRepoOrFallback(userName, fallbackFork);
 
                 default:

--- a/NuKeeper/Engine/ForkMode.cs
+++ b/NuKeeper/Engine/ForkMode.cs
@@ -1,0 +1,8 @@
+﻿namespace NuKeeper.Engine
+{
+    public enum ForkMode
+    {
+        PreferFork,
+        PreferUpstream
+    }
+}

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -52,7 +52,7 @@ namespace NuKeeper.Engine
             string userName)
         {
             var pullFork = new ForkData(repository.GithubUri, repository.RepositoryOwner, repository.RepositoryName);
-            var pushFork = await _forkFinder.FindPushFork(userName, repository.RepositoryName, pullFork);
+            var pushFork = await _forkFinder.FindPushFork(userName, pullFork);
 
             return new RepositoryData(pullFork, pushFork);
         }

--- a/NuKeeper/Engine/IForkFinder.cs
+++ b/NuKeeper/Engine/IForkFinder.cs
@@ -4,6 +4,6 @@ namespace NuKeeper.Engine
 {
     public interface IForkFinder
     {
-        Task<ForkData> FindPushFork(string userName, string repositoryName, ForkData fallbackFork);
+        Task<ForkData> FindPushFork(string userName, ForkData fallbackFork);
     };
 }

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
     * If you set the allowed version change to `Minor`, you will get an update to `1.3.0` as now changes to the major version number are not allowed. Version `1.2.4` is also allowed, but the largest allowed update is applied.
     * If the allowed version change is `Patch` you will only get an update to version `1.2.4`.
 
- * *fork_mode* Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below. 
-	
+ * *fork_mode* Values are `PreferFork` and `PreferSingleRepository`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below. 
+
 
 ### Command-line arguments
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ The `ForkMode` option controls which workflow is preferred. options are `PreferF
 
 Failing both of these, NuKeeper has nowhere to push to, and will therefore fail to process the repository.
 
-Public open-source projects on `github.com` that allow PRs from any outside user are very unlikely to allow that outsider to push to the project's repository, and so this case usually uses the two repository workflow. Contributing to an open-source project starts with forking the repo to your own github account.
+Public open-source projects on `github.com` that allow PRs from any outside user are very unlikely to allow that outsider to push to the project's repository, and so this case usually uses the fork workflow. Contributing to an open-source project starts with forking the repo to your own github account.
 
-Some organisations use the one-repository workflow, with all team members allowed to push to the shared repository. This is simpler in most ways.
+Some organisations use the single-repository workflow, with all team members allowed to push to the shared repository. This is simpler in most ways.
 
 ## Limitations and warnings
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This workflow can be used if:
 
 This is automatic, NuKeeper will find the fork, or attempt to create it if it does not exist. 
 
-The `ForkMode` option controls which workflow is preferred. options are `PreferFork` and `PreferSingleRepository`. If the preferred workflow cannot be used, it will fall back to trying the other.
+The `ForkMode` option controls which workflow is preferred. Values are `PreferFork` and `PreferSingleRepository`. The default is `PreferFork`. If the preferred workflow cannot be used, it will fall back to trying the other.
 
 Failing both of these, NuKeeper has nowhere to push to, and will therefore fail to process the repository.
 


### PR DESCRIPTION
An option to prefer the upstream over using or creating a fork
comes in the command line and controls the behaviour of `ForkFinder`.

WIP

It needs input on naming, right now is

````
 public enum ForkMode
    {
        PreferFork,
        PreferUpstream
    }
````



And input on defaults, and what should happen if the first preference is not usable - e.g.  we `PreferUpstream` but on this repo we cannot push there. I don't want to make lots of options (.e.g. `PreferUpstream`, `OnlyUpstream`, `UseForkIfItExistsButDontCreateFork` etc ) unless necessary