### PR TITLE
Option for "Single repo only"

### DIFF
--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -20,8 +20,10 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(Substitute.For<IGithub>(),
                 MakePreferForkSettings(), new NullNuKeeperLogger());
 
-            Assert.ThrowsAsync<Exception>(async () =>
+            var ex = Assert.ThrowsAsync<Exception>(async () =>
                 await forkFinder.FindPushFork("testUser", fallbackFork));
+
+            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
         }
 
         [Test]
@@ -56,8 +58,9 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakePreferForkSettings(), new NullNuKeeperLogger());
 
-            Assert.ThrowsAsync<Exception>(async () =>
+            var ex = Assert.ThrowsAsync<Exception>(async () =>
                 await forkFinder.FindPushFork("testUser", fallbackFork));
+            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
         }
 
         [Test]
@@ -206,8 +209,10 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakeSingleRepoOnlySettings(), new NullNuKeeperLogger());
 
-            Assert.ThrowsAsync<Exception>(async () =>
+            var ex = Assert.ThrowsAsync<Exception>(async () =>
                 await forkFinder.FindPushFork("testUser", fallbackFork));
+
+            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
         }
 
         private ForkData DefaultFork()

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -167,6 +167,49 @@ namespace NuKeeper.Tests.Engine
             AssertForkMatchesRepo(fork, userRepo);
         }
 
+        [Test]
+        public async Task SingleRepoOnlyModeWillNotPreferFork()
+        {
+            var fallbackFork = DefaultFork();
+
+            var userRepo = RespositoryBuilder.MakeRepository();
+
+            var github = Substitute.For<IGithub>();
+            github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(userRepo);
+
+            var forkFinder = new ForkFinder(github,
+                MakeSingleRepoOnlySettings(), new NullNuKeeperLogger());
+
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+
+            Assert.That(fork, Is.EqualTo(fallbackFork));
+        }
+
+
+        [Test]
+        public void SingleRepoOnlyModeWillNotUseForkWhenUpstreamIsUnsuitable()
+        {
+            var fallbackFork = DefaultFork();
+
+            var github = Substitute.For<IGithub>();
+
+            var defaultRepo = RespositoryBuilder.MakeRepository("http://a.com", true, false);
+            github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
+                .Returns(defaultRepo);
+
+            var userRepo = RespositoryBuilder.MakeRepository();
+
+            github.GetUserRepository("testUser", fallbackFork.Name)
+                .Returns(userRepo);
+
+            var forkFinder = new ForkFinder(github,
+                MakeSingleRepoOnlySettings(), new NullNuKeeperLogger());
+
+            Assert.ThrowsAsync<Exception>(async () =>
+                await forkFinder.FindPushFork("testUser", fallbackFork));
+        }
+
         private ForkData DefaultFork()
         {
             return new ForkData(new Uri(RespositoryBuilder.ParentUrl), "testOrg", "someRepo");
@@ -190,6 +233,14 @@ namespace NuKeeper.Tests.Engine
             return new UserSettings
             {
                 ForkMode = ForkMode.PreferSingleRepository
+            };
+        }
+
+        private UserSettings MakeSingleRepoOnlySettings()
+        {
+            return new UserSettings
+            {
+                ForkMode = ForkMode.SingleRepositoryOnly
             };
         }
 

--- a/NuKeeper/Configuration/ForkMode.cs
+++ b/NuKeeper/Configuration/ForkMode.cs
@@ -3,6 +3,7 @@
     public enum ForkMode
     {
         PreferFork,
-        PreferSingleRepository
+        PreferSingleRepository,
+        SingleRepositoryOnly
     }
 }

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using NuKeeper.Engine;
 using NuKeeper.Logging;
 using NuKeeper.NuGet.Api;
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
     * If you set the allowed version change to `Minor`, you will get an update to `1.3.0` as now changes to the major version number are not allowed. Version `1.2.4` is also allowed, but the largest allowed update is applied.
     * If the allowed version change is `Patch` you will only get an update to version `1.2.4`.
 
- * *fork_mode* Values are `PreferFork` and `PreferSingleRepository`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below. 
+ * *fork_mode* Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below. 
 
 
 ### Command-line arguments
@@ -143,9 +143,13 @@ This workflow can be used if:
 
 This is automatic, NuKeeper will find the fork, or attempt to create it if it does not exist. 
 
-The `ForkMode` option controls which workflow is preferred. Values are `PreferFork` and `PreferSingleRepository`. The default is `PreferFork`. If the preferred workflow cannot be used, it will fall back to trying the other.
+The `ForkMode` option controls which workflows will be tried, and in what order. Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. The default is `PreferFork`. 
 
-Failing both of these, NuKeeper has nowhere to push to, and will therefore fail to process the repository.
+In `PreferFork` mode, both workflows will be tried, with the Fork workflow tried first. 
+In `PreferSingleRepository` mode, both workflows will be tried, with the single-repository workflow tried first. 
+In the `SingleRepositoryOnly`, only the single-repository workflow will be tried. 
+
+If NuKeeper does not find a repository to push to, it will fail to process the upstream repository.
 
 Public open-source projects on `github.com` that allow PRs from any outside user are very unlikely to allow that outsider to push to the project's repository, and so this case usually uses the fork workflow. Contributing to an open-source project starts with forking the repo to your own github account.
 


### PR DESCRIPTION
Single repo only mode.

This adds the `SingleRepositoryOnly` fork option, but does not move it to earlier in the repo processing.

Follow on from https://github.com/NuKeeperDotNet/NuKeeper/pull/180

A later PR will make the ForkFinder run earlier - there is no point in issuing the git clone to local files and then finding afterwards that you can't push. It should "skip the repo". Especially as this can be expensive because there's no option to do a "shallow clone". 