### PR TITLE
Skip repos that cannot be pushed

### DIFF
--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -13,17 +13,16 @@ namespace NuKeeper.Tests.Engine
     public class ForkFinderTests
     {
         [Test]
-        public void ThrowsWhenNoPushableForkCanBeFound()
+        public async Task ThrowsWhenNoPushableForkCanBeFound()
         {
             var fallbackFork = DefaultFork();
 
             var forkFinder = new ForkFinder(Substitute.For<IGithub>(),
                 MakePreferForkSettings(), new NullNuKeeperLogger());
 
-            var ex = Assert.ThrowsAsync<Exception>(async () =>
-                await forkFinder.FindPushFork("testUser", fallbackFork));
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
-            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
+            Assert.That(fork, Is.Null);
         }
 
         [Test]
@@ -46,7 +45,7 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public void FallbackForkIsNotUsedWhenItIsNotPushable()
+        public async Task FallbackForkIsNotUsedWhenItIsNotPushable()
         {
             var fallbackFork = DefaultFork();
 
@@ -58,9 +57,9 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakePreferForkSettings(), new NullNuKeeperLogger());
 
-            var ex = Assert.ThrowsAsync<Exception>(async () =>
-                await forkFinder.FindPushFork("testUser", fallbackFork));
-            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+
+            Assert.That(fork, Is.Null);
         }
 
         [Test]
@@ -191,7 +190,7 @@ namespace NuKeeper.Tests.Engine
 
 
         [Test]
-        public void SingleRepoOnlyModeWillNotUseForkWhenUpstreamIsUnsuitable()
+        public async Task SingleRepoOnlyModeWillNotUseForkWhenUpstreamIsUnsuitable()
         {
             var fallbackFork = DefaultFork();
 
@@ -209,10 +208,9 @@ namespace NuKeeper.Tests.Engine
             var forkFinder = new ForkFinder(github,
                 MakeSingleRepoOnlySettings(), new NullNuKeeperLogger());
 
-            var ex = Assert.ThrowsAsync<Exception>(async () =>
-                await forkFinder.FindPushFork("testUser", fallbackFork));
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
 
-            Assert.That(ex.Message, Does.Contain("No pushable fork found"));
+            Assert.That(fork, Is.Null);
         }
 
         private ForkData DefaultFork()

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -97,8 +97,7 @@ namespace NuKeeper.Engine
 
         private void NoPushableForkFound(string name)
         {
-            _logger.Error($"No pushable fork found for {name}");
-            throw new Exception($"No pushable fork found for {name}");
+            _logger.Error($"No pushable fork found for {name} in mode {_forkMode}");
         }
 
         private async Task<bool> IsPushableRepo(ForkData originFork)

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -54,6 +54,11 @@ namespace NuKeeper.Engine
             var pullFork = new ForkData(repository.GithubUri, repository.RepositoryOwner, repository.RepositoryName);
             var pushFork = await _forkFinder.FindPushFork(userName, pullFork);
 
+            if (pushFork == null)
+            {
+                throw new Exception($"No pushable fork found for {repository.GithubUri}");
+            }
+
             return new RepositoryData(pullFork, pushFork);
         }
     }

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -33,9 +33,14 @@ namespace NuKeeper.Engine
         {
             try
             {
+                var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
+                if (repo == null)
+                {
+                    return;
+                }
+
                 var tempFolder = _folderFactory.UniqueTemporaryFolder();
                 var git = new LibGit2SharpDriver(_logger, tempFolder, gitCreds);
-                var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
 
                 await _repositoryUpdater.Run(git, repo);
 
@@ -56,7 +61,8 @@ namespace NuKeeper.Engine
 
             if (pushFork == null)
             {
-                throw new Exception($"No pushable fork found for {repository.GithubUri}");
+                _logger.Info($"No pushable fork found for {repository.GithubUri}");
+                return null;
             }
 
             return new RepositoryData(pullFork, pushFork);

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;


### PR DESCRIPTION
Skip repos that cannot be pushed, slightly more gracefully.
This should happen before we make a temp folder, try to pull files, etc.