### PR TITLE
Package version Published date is in the report

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Integration.Tests.NuGet.Api;
@@ -11,7 +11,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
     public class PackageVersionsLookupTests
     {
         [Test]
-        public async Task WellKnownPackageName_ShouldReturnResults()
+        public async Task WellKnownPackageName_ShouldReturnResultsList()
         {
             var lookup = BuildPackageLookup();
 
@@ -21,7 +21,30 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
 
             var packageList = packages.ToList();
             Assert.That(packageList, Is.Not.Empty);
-            Assert.That(packageList[0].Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+            Assert.That(packageList.Count, Is.GreaterThan(1));
+        }
+
+        [Test]
+        public async Task WellKnownPackageName_ShouldReturnPopulatedResults()
+        {
+            var lookup = BuildPackageLookup();
+
+            var packages = await lookup.Lookup("Newtonsoft.Json");
+
+            Assert.That(packages, Is.Not.Null);
+
+            var packageList = packages.ToList();
+            var latest = packageList
+                .OrderByDescending(p => p.Identity.Version)
+                .FirstOrDefault();
+
+            Assert.That(latest, Is.Not.Null);
+            Assert.That(latest.Identity, Is.Not.Null);
+            Assert.That(latest.Identity.Version, Is.Not.Null);
+
+            Assert.That(latest.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
+            Assert.That(latest.Identity.Version.Major, Is.GreaterThan(1));
+            Assert.That(latest.Published.HasValue, Is.True);
         }
 
         private IPackageVersionsLookup BuildPackageLookup()

--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Engine;
@@ -218,18 +218,23 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
         {
             var newPackage = NewPackageFooBar123();
-            return new PackageUpdateSet(newPackage,
-                "someSource",
-                newPackage.Version,
+
+            var latest = new PackageSearchMedatadata(newPackage, "someSource", DateTimeOffset.Now);
+
+            return new PackageUpdateSet(latest, latest,
                 VersionChange.Major,
                 packages);
         }
 
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
         {
-            return new PackageUpdateSet(NewPackageFooBar123(),
-                "someSource",
-                new NuGetVersion("2.3.4"),
+            var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
+            var latest = new PackageSearchMedatadata(latestId, "someSource", DateTimeOffset.Now);
+
+            var match = new PackageSearchMedatadata(
+                NewPackageFooBar123(), "someSource", DateTimeOffset.Now);
+
+            return new PackageUpdateSet(match, latest,
                 VersionChange.Minor,
                 packages);
         }

--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -221,9 +221,8 @@ namespace NuKeeper.Tests.Engine
 
             var latest = new PackageSearchMedatadata(newPackage, "someSource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(latest, latest,
-                VersionChange.Major,
-                packages);
+            return new PackageUpdateSet(VersionChange.Major,
+                latest, latest, packages);
         }
 
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
@@ -234,9 +233,8 @@ namespace NuKeeper.Tests.Engine
             var match = new PackageSearchMedatadata(
                 NewPackageFooBar123(), "someSource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(match, latest,
-                VersionChange.Minor,
-                packages);
+            return new PackageUpdateSet(VersionChange.Minor,
+                latest, match, packages);
         }
 
         private static PackageIdentity NewPackageFooBar123()

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Configuration;
-using NuKeeper.Engine;
 using NuKeeper.Engine.Packages;
 using NuKeeper.Git;
 using NuKeeper.NuGet.Api;
@@ -200,8 +200,10 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foobar", "1.0.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, "ASource", 
-                new NuGetVersion("4.0.0"), VersionChange.Major, 
+            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
+
+            return new PackageUpdateSet(latest, latest,
+                VersionChange.Major, 
                 currentPackages);
         }
 
@@ -215,8 +217,13 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, "ASource",
-                new NuGetVersion("4.0.0"), VersionChange.Major,
+            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
+
+            var matchVersion = new NuGetVersion("4.0.0");
+            var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion), "ASource", DateTimeOffset.Now);
+
+            return new PackageUpdateSet(match, latest,
+                VersionChange.Major,
                 currentPackages);
         }
 
@@ -230,8 +237,12 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("bar", "1.2.1", PathToProjectTwo())
             };
 
-            return new PackageUpdateSet(newPackage, "ASource", 
-                new NuGetVersion("4.0.0"), VersionChange.Major, 
+            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
+            var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
+            var match = new PackageSearchMedatadata(matchId, "ASource", DateTimeOffset.Now);
+
+            return new PackageUpdateSet(match, latest,
+                VersionChange.Major, 
                 currentPackages);
         }
 

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -202,9 +202,8 @@ namespace NuKeeper.Tests.Engine
 
             var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(latest, latest,
-                VersionChange.Major, 
-                currentPackages);
+            return new PackageUpdateSet(VersionChange.Major, 
+                latest, latest, currentPackages);
         }
 
         private PackageUpdateSet UpdateFooFromOneVersion()
@@ -222,9 +221,8 @@ namespace NuKeeper.Tests.Engine
             var matchVersion = new NuGetVersion("4.0.0");
             var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion), "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(match, latest,
-                VersionChange.Major,
-                currentPackages);
+            return new PackageUpdateSet(VersionChange.Major,
+                latest, match, currentPackages);
         }
 
         private PackageUpdateSet UpdateBarFromTwoVersions()
@@ -241,9 +239,8 @@ namespace NuKeeper.Tests.Engine
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
             var match = new PackageSearchMedatadata(matchId, "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(match, latest,
-                VersionChange.Major, 
-                currentPackages);
+            return new PackageUpdateSet(VersionChange.Major, 
+                latest, match, currentPackages);
         }
 
         private PackageIdentity LatestVersionOfPackageFoobar()

--- a/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -142,7 +143,7 @@ namespace NuKeeper.Tests.NuGet.Api
         private static void ApiHasNewVersionForPackage(IApiPackageLookup lookup, string packageName)
         {
             var responseMetaData = new PackageSearchMedatadata(
-                new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test");
+                new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test", DateTimeOffset.Now);
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
                 .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData));

--- a/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageLookupResultReporterTests.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute;
+using System;
+using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Logging;
@@ -35,7 +36,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var fooMetadata = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)), 
-                "someSource");
+                "someSource", DateTimeOffset.Now);
 
             var data = new PackageLookupResult(VersionChange.Major, fooMetadata, fooMetadata);
 
@@ -56,7 +57,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var fooMetadata = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
-                "someSource");
+                "someSource", DateTimeOffset.Now);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMetadata, fooMetadata);
 
@@ -78,10 +79,10 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var fooMajor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
-                "someSource");
+                "someSource", DateTimeOffset.Now);
             var fooMinor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
-                "someSource");
+                "someSource", DateTimeOffset.Now);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMajor, fooMinor);
 
@@ -102,7 +103,7 @@ namespace NuKeeper.Tests.NuGet.Api
 
             var fooMajor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
-                "someSource");
+                "someSource", DateTimeOffset.Now);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMajor, null);
 

--- a/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
+++ b/NuKeeper.Tests/NuGet/Api/PackageVersionTestData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
@@ -85,8 +85,7 @@ namespace NuKeeper.Tests.NuGet.Api
         {
             var version = new NuGetVersion(major, minor, patch);
             var metadata = new PackageIdentity("TestPackage", version);
-            return new PackageSearchMedatadata(metadata, "someSource");
+            return new PackageSearchMedatadata(metadata, "someSource", DateTimeOffset.Now);
         }
     }
 }
-        

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var exception = Assert.Throws<ArgumentNullException>(() =>
                 new PackageUpdateSet(null, LatestFooMetadata(), VersionChange.Major, packages));
 
-            Assert.That(exception.ParamName, Is.EqualTo("newPackage"));
+            Assert.That(exception.ParamName, Is.EqualTo("match"));
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             var exception = Assert.Throws<ArgumentNullException>(() =>
                 new PackageUpdateSet(LatestFooMetadata(), null, VersionChange.Major, packages));
 
-            Assert.That(exception.ParamName, Is.EqualTo("newPackage"));
+            Assert.That(exception.ParamName, Is.EqualTo("highest"));
         }
 
         [Test]
@@ -63,19 +63,22 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void OneUpdate_IsValid()
         {
-            var newPackage = LatestVersionOfPackageFoo();
+            var fooVersionFour = new PackageIdentity("foo", VersionFour());
+            var highest = new PackageSearchMedatadata(fooVersionFour, ASource, DateTimeOffset.Now);
+
+            var match = LatestFooMetadata();
 
             var currentPackages = new List<PackageInProject>
             {
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(match, highest, VersionChange.Major, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
             Assert.That(updates.PackageId, Is.EqualTo("foo"));
-            Assert.That(updates.NewVersion, Is.EqualTo(newPackage.Version));
+            Assert.That(updates.NewVersion, Is.EqualTo(match.Identity.Version));
             Assert.That(updates.PackageSource, Is.EqualTo(ASource));
             Assert.That(updates.Highest, Is.EqualTo(VersionFour()));
             Assert.That(updates.AllowedChange, Is.EqualTo(VersionChange.Major));

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -23,7 +23,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             };
 
             var exception = Assert.Throws<ArgumentNullException>(() =>
-                new PackageUpdateSet(null, LatestFooMetadata(), VersionChange.Major, packages));
+                new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), null, packages));
 
             Assert.That(exception.ParamName, Is.EqualTo("match"));
         }
@@ -37,7 +37,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             };
 
             var exception = Assert.Throws<ArgumentNullException>(() =>
-                new PackageUpdateSet(LatestFooMetadata(), null, VersionChange.Major, packages));
+                new PackageUpdateSet(VersionChange.Major, null, LatestFooMetadata(), packages));
 
             Assert.That(exception.ParamName, Is.EqualTo("highest"));
         }
@@ -45,8 +45,7 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void NullPackages_IsNotAllowed()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(
-                LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), null));
 
             Assert.That(exception.ParamName, Is.EqualTo("currentPackages"));
         }
@@ -54,9 +53,8 @@ namespace NuKeeper.Tests.RepositoryInspection
         [Test]
         public void EmptyPackages_IsNotAllowed()
         {
-            var exception = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
-                LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major,
-                Enumerable.Empty<PackageInProject>()));
+            var exception = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(VersionChange.Major,
+                LatestFooMetadata(), LatestFooMetadata(), Enumerable.Empty<PackageInProject>()));
             Assert.That(exception.ParamName, Is.EqualTo("currentPackages"));
         }
 
@@ -73,7 +71,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(match, highest, VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, highest, match, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
@@ -92,7 +90,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
             Assert.That(updates.CurrentPackages.Count, Is.EqualTo(1));
@@ -110,7 +108,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
@@ -128,7 +126,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
             var currents = updates.CurrentPackages.ToList();
@@ -149,8 +147,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
-                LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackageBar));
+            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackageBar));
         }
 
         [Test]
@@ -163,8 +160,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("fish", "1.0.0", PathToProjectOne())
             };
 
-            var ex = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
-                LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages));
+            var ex = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages));
 
             Assert.That(ex.Message, Is.EqualTo("Updates must all be for package 'foo', got 'bar, fish'"));
         }
@@ -178,8 +174,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(
-                LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackagesFooAndBar));
+            Assert.Throws<ArgumentException>(() => new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackagesFooAndBar));
         }
 
         [Test]
@@ -190,7 +185,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectOne())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
         }
@@ -206,7 +201,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
         }
@@ -222,7 +217,7 @@ namespace NuKeeper.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var updates = new PackageUpdateSet(LatestFooMetadata(), LatestFooMetadata(), VersionChange.Major, currentPackages);
+            var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(2));
         }

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Engine.Report
 
         private void WriteHeading(StreamWriter writer)
         {
-            writer.WriteLine("Package id,Usage count,Versions in use,Lowest version in use,Highest Version in use,Highest available,Package source");
+            writer.WriteLine("Package id,Usage count,Versions in use,Lowest version in use,Highest Version in use,Highest available,Highest published date,Package source");
         }
 
         private void WriteLine(StreamWriter writer, PackageUpdateSet update)
@@ -38,7 +38,7 @@ namespace NuKeeper.Engine.Report
             var lowest = versionsInUse.Min();
             var highest = versionsInUse.Max();
 
-            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.Highest},{update.PackageSource}");
+            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.Highest},{ToUtcIso8601(update.HighestPublished)},{update.PackageSource}");
         }
 
         private StreamWriter MakeOutputStream(string name)

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -4,11 +4,19 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using NuKeeper.Logging;
 
 namespace NuKeeper.Engine.Report
 {
     public class AvailableUpdatesReporter: IAvailableUpdatesReporter
     {
+        private readonly INuKeeperLogger _logger;
+
+        public AvailableUpdatesReporter(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
         public void Report(string name, List<PackageUpdateSet> updates)
         {
             using (var writer = MakeOutputStream(name))
@@ -44,6 +52,9 @@ namespace NuKeeper.Engine.Report
         private StreamWriter MakeOutputStream(string name)
         {
             var fileName = name + "_nukeeeper_report.csv";
+
+            _logger.Verbose($"writing report to file at '{fileName}'");
+
             var output = new FileStream(fileName, FileMode.OpenOrCreate);
             return new StreamWriter(output);
         }

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -1,5 +1,7 @@
+using System;
 using NuKeeper.RepositoryInspection;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -23,7 +25,7 @@ namespace NuKeeper.Engine.Report
 
         private void WriteHeading(StreamWriter writer)
         {
-            writer.WriteLine("Package id,Usage count,Versions in use,Lowest version in use, Highest Version in use,Highest available,Package source");
+            writer.WriteLine("Package id,Usage count,Versions in use,Lowest version in use,Highest Version in use,Highest available,Package source");
         }
 
         private void WriteLine(StreamWriter writer, PackageUpdateSet update)
@@ -44,6 +46,18 @@ namespace NuKeeper.Engine.Report
             var fileName = name + "_nukeeeper_report.csv";
             var output = new FileStream(fileName, FileMode.OpenOrCreate);
             return new StreamWriter(output);
+        }
+
+        private static string ToUtcIso8601(DateTimeOffset? source)
+        {
+            if (!source.HasValue)
+            {
+                return string.Empty;
+            }
+
+            const string iso8601Format = "yyyy-MM-ddTHH\\:mm\\:ss";
+            var utcValue = source.Value.ToUniversalTime();
+            return string.Concat(utcValue.ToString(iso8601Format, CultureInfo.InvariantCulture), "Z");
         }
     }
 }

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -22,6 +22,8 @@ namespace NuKeeper.Engine.Report
             using (var writer = MakeOutputStream(name))
             {
                 WriteHeading(writer);
+                _logger.Verbose($"writing {updates.Count} lines to report");
+
                 foreach (var update in updates)
                 {
                     WriteLine(writer, update);

--- a/NuKeeper/NuGet/Api/PackageLookupResult.cs
+++ b/NuKeeper/NuGet/Api/PackageLookupResult.cs
@@ -1,10 +1,11 @@
-﻿namespace NuKeeper.NuGet.Api
+namespace NuKeeper.NuGet.Api
 {
     public class PackageLookupResult
     {
         public PackageLookupResult(
-            VersionChange allowedChange, 
-            PackageSearchMedatadata highest, PackageSearchMedatadata match)
+            VersionChange allowedChange,
+            PackageSearchMedatadata highest,
+            PackageSearchMedatadata match)
         {
             AllowedChange = allowedChange;
             Highest = highest;

--- a/NuKeeper/NuGet/Api/PackageSearchMedatadata.cs
+++ b/NuKeeper/NuGet/Api/PackageSearchMedatadata.cs
@@ -7,7 +7,8 @@ namespace NuKeeper.NuGet.Api
     {
         public PackageSearchMedatadata(
             PackageIdentity identity,
-            string source)
+            string source,
+            DateTimeOffset? published)
         {
             if (identity == null)
             {
@@ -21,9 +22,11 @@ namespace NuKeeper.NuGet.Api
 
             Identity = identity;
             Source = source;
+            Published = published;
         }
 
         public PackageIdentity Identity { get; }
         public string Source { get; }
+        public DateTimeOffset? Published { get; }
     }
 }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
@@ -38,10 +38,8 @@ namespace NuKeeper.NuGet.Api
 
                 if (updatesForThisPackage.Count > 0)
                 {
-                    var updateSet = new PackageUpdateSet(
-                        match, latestPackage.Highest,
-                        latestPackage.AllowedChange,
-                        updatesForThisPackage);
+                    var updateSet = new PackageUpdateSet(latestPackage.AllowedChange,
+                        latestPackage.Highest, match, updatesForThisPackage);
                     results.Add(updateSet);
                 }
             }

--- a/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageUpdatesLookup.cs
@@ -30,18 +30,16 @@ namespace NuKeeper.NuGet.Api
             foreach (var packageId in latestVersions.Keys)
             {
                 var latestPackage = latestVersions[packageId];
-                var identity = latestPackage.Match.Identity;
+                var match = latestPackage.Match;
 
                 var updatesForThisPackage = packages
-                    .Where(p => p.Id == packageId && p.Version < identity.Version)
+                    .Where(p => p.Id == packageId && p.Version < match.Identity.Version)
                     .ToList();
 
                 if (updatesForThisPackage.Count > 0)
                 {
                     var updateSet = new PackageUpdateSet(
-                        identity,
-                        latestPackage.Match.Source,
-                        latestPackage.Highest.Identity.Version,
+                        match, latestPackage.Highest,
                         latestPackage.AllowedChange,
                         updatesForThisPackage);
                     results.Add(updateSet);

--- a/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
+++ b/NuKeeper/NuGet/Api/PackageVersionsLookup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -35,7 +35,7 @@ namespace NuKeeper.NuGet.Api
             var sourceRepository = BuildSourceRepository(source);
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
             var metadatas = await FindPackage(metadataResource, packageName);
-            return metadatas.Select(m => new PackageSearchMedatadata(m.Identity, source));
+            return metadatas.Select(m => new PackageSearchMedatadata(m.Identity, source, m.Published));
         }
 
         private static SourceRepository BuildSourceRepository(string source)

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -57,6 +57,7 @@ namespace NuKeeper.RepositoryInspection
         public NuGetVersion NewVersion => NewPackage.Version;
         public string PackageSource => _match.Source;
         public NuGetVersion Highest=> _highest.Identity.Version;
+        public DateTimeOffset? HighestPublished => _highest.Published;
 
         public int CountCurrentVersions()
         {

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -9,23 +9,22 @@ namespace NuKeeper.RepositoryInspection
 {
     public class PackageUpdateSet
     {
-        private readonly PackageSearchMedatadata _match;
         private readonly PackageSearchMedatadata _highest;
+        private readonly PackageSearchMedatadata _match;
 
-        public PackageUpdateSet(
-            PackageSearchMedatadata match,
+        public PackageUpdateSet(VersionChange allowedChange,
             PackageSearchMedatadata highest,
-            VersionChange allowedChange,
+            PackageSearchMedatadata match,
             IEnumerable<PackageInProject> currentPackages)
         {
-            if (match == null)
-            {
-                throw new ArgumentNullException(nameof(match));
-            }
-
             if (highest == null)
             {
                 throw new ArgumentNullException(nameof(highest));
+            }
+
+            if (match == null)
+            {
+                throw new ArgumentNullException(nameof(match));
             }
 
             if (currentPackages == null)


### PR DESCRIPTION
Work for #185  (Age of Updates)

Each package version on the nuget feed has a "published date". This is typed as `DateTimeOffset?` but it seems to usually have a value so we can use it as UTC `DateTime`, with a bit of caution.

The purpose of this PR is to read that value and keep it through the  NuKeeper processing - this means that it goes in to `PackageLookupResult` and `PackageUpdateSet`. 

The first use of this datetime is  to just emit it in the report - the consumers of the report might e.g. distinguish between a potential update that has been around 6 hours vs. 6 months when scoring.

There may be other uses later (e.g. don't apply packages that do not meet a minimum age requirement)

And this gives rise to opportunities for refactoring: next steps would be `PackageLookupResult` and `PackageUpdateSet` are now very similar, could work better between them. Also, we would want to keep the identity (version number, published date etc) of the applicable, major, minor and patch updates all the way through, as well as which of these was selected by the commandline option.