### PR TITLE
Forkfinder was not right - compare CloneUrl not HtmlUrl

### DIFF
--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -29,11 +29,11 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsUsedWhenItIsFound()
         {
             var fallbackFork = DefaultFork();
+            var fallbackRepoData = RespositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
-            var defaultRepo = RespositoryBuilder.MakeRepository();
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
-                .Returns(defaultRepo);
+                .Returns(fallbackRepoData);
 
             var forkFinder = new ForkFinder(github, 
                 MakePreferForkSettings(), new NullNuKeeperLogger());
@@ -48,11 +48,11 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsNotUsedWhenItIsNotPushable()
         {
             var fallbackFork = DefaultFork();
+            var fallbackRepoData = RespositoryBuilder.MakeRepository(true, false);
 
             var github = Substitute.For<IGithub>();
-            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
-                .Returns(defaultRepo);
+                .Returns(fallbackRepoData);
 
             var forkFinder = new ForkFinder(github,
                 MakePreferForkSettings(), new NullNuKeeperLogger());
@@ -63,7 +63,7 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public async Task WhenSuitableUserForkIsFoundItIsUsedOverUpstream()
+        public async Task WhenSuitableUserForkIsFoundItIsUsedOverFallback()
         {
             var fallbackFork = DefaultFork();
 
@@ -252,7 +252,7 @@ namespace NuKeeper.Tests.Engine
             Assert.That(fork, Is.Not.Null);
             Assert.That(fork.Name, Is.EqualTo(repo.Name));
             Assert.That(fork.Owner, Is.EqualTo(repo.Owner.Login));
-            Assert.That(fork.Uri, Is.EqualTo(new Uri(repo.HtmlUrl)));
+            Assert.That(fork.Uri, Is.EqualTo(new Uri(repo.CloneUrl)));
         }
     }
 }

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -83,6 +83,26 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
+        public async Task WhenSuitableUserForkIsFound_ThatMatchesParentHtmlUrl_ItIsUsedOverFallback()
+        {
+            var fallbackFork = new ForkData(new Uri(RespositoryBuilder.ParentHtmlUrl), "testOrg", "someRepo");
+
+            var userRepo = RespositoryBuilder.MakeRepository();
+
+            var github = Substitute.For<IGithub>();
+            github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(userRepo);
+
+            var forkFinder = new ForkFinder(github,
+                MakePreferForkSettings(), new NullNuKeeperLogger());
+
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+
+            Assert.That(fork, Is.Not.EqualTo(fallbackFork));
+            AssertForkMatchesRepo(fork, userRepo);
+        }
+
+        [Test]
         public async Task WhenUnsuitableUserForkIsFoundItIsNotUsed()
         {
             var fallbackFork = NoMatchFork();

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Configuration;
@@ -50,7 +50,7 @@ namespace NuKeeper.Tests.Engine
             var fallbackFork = DefaultFork();
 
             var github = Substitute.For<IGithub>();
-            var defaultRepo = RespositoryBuilder.MakeRepository("http://a.com", true, false);
+            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
@@ -151,7 +151,7 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGithub>();
 
-            var defaultRepo = RespositoryBuilder.MakeRepository("http://a.com", true, false);
+            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
@@ -196,7 +196,7 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGithub>();
 
-            var defaultRepo = RespositoryBuilder.MakeRepository("http://a.com", true, false);
+            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
@@ -215,7 +215,7 @@ namespace NuKeeper.Tests.Engine
 
         private ForkData DefaultFork()
         {
-            return new ForkData(new Uri(RespositoryBuilder.ParentUrl), "testOrg", "someRepo");
+            return new ForkData(new Uri(RespositoryBuilder.ParentCloneUrl), "testOrg", "someRepo");
         }
 
         private ForkData NoMatchFork()

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -78,8 +78,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RespositoryBuilder.MakeRepository("http://a.com/repo1", false),
-                RespositoryBuilder.MakeRepository("http://b.com/repob", true)
+                RespositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
+                RespositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 

--- a/NuKeeper.Tests/Engine/RespositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RespositoryBuilder.cs
@@ -1,15 +1,25 @@
-﻿using System;
+using System;
 using Octokit;
 
 namespace NuKeeper.Tests.Engine
 {
     public class RespositoryBuilder
     {
-        public const string ParentUrl = "http://repos.com/org/parent";
-        public const string ForkUrl = "http://repos.com/org/repo";
+        public const string ParentHtmlUrl = "http://repos.com/org/parent";
+        public const string ParentCloneUrl = "http://repos.com/org/parent.git";
+
+        public const string ForkHtmlUrl = "http://repos.com/org/repo";
+        public const string ForkCloneUrl = "http://repos.com/org/repo.git";
         public const string NoMatchUrl = "http://repos.com/org/nomatch";
 
-        public static Repository MakeRepository(string htmlUrl = ForkUrl, 
+        public static Repository MakeRepository(bool canPull, bool canPush)
+        {
+            return MakeRepository(ForkHtmlUrl, ForkCloneUrl, canPull, canPush);
+        }
+
+        public static Repository MakeRepository(
+            string forkHtmlkUrl = ForkHtmlUrl, 
+            string forGitkUrl = ForkHtmlUrl, 
             bool canPull = true, bool canPush = true)
         {
             const string omniUrl = "http://somewhere.com/fork";
@@ -23,7 +33,7 @@ namespace NuKeeper.Tests.Engine
             var perms = new RepositoryPermissions(false, canPush, canPull);
             var parent = MakeParentRepo();
 
-            return new Repository(omniUrl, htmlUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+            return new Repository(omniUrl, forkHtmlkUrl, forGitkUrl, omniUrl, omniUrl, omniUrl, omniUrl,
                 123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
                 1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now,
                 perms, parent,
@@ -42,7 +52,7 @@ namespace NuKeeper.Tests.Engine
 
             var perms = new RepositoryPermissions(false, true, true);
 
-            return new Repository(omniUrl, ParentUrl, omniUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+            return new Repository(omniUrl, ParentHtmlUrl, ParentCloneUrl, omniUrl, omniUrl, omniUrl, omniUrl,
                 123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
                 1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now, perms, null,
                 null, false, false, false, false, 2, 122, true, true, true);

--- a/NuKeeper.Tests/Engine/RespositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RespositoryBuilder.cs
@@ -18,8 +18,8 @@ namespace NuKeeper.Tests.Engine
         }
 
         public static Repository MakeRepository(
-            string forkHtmlkUrl = ForkHtmlUrl, 
-            string forGitkUrl = ForkHtmlUrl, 
+            string forkHtmlUrl = ForkHtmlUrl, 
+            string forkCloneUrl = ForkCloneUrl, 
             bool canPull = true, bool canPush = true)
         {
             const string omniUrl = "http://somewhere.com/fork";
@@ -33,14 +33,16 @@ namespace NuKeeper.Tests.Engine
             var perms = new RepositoryPermissions(false, canPush, canPull);
             var parent = MakeParentRepo();
 
-            return new Repository(omniUrl, forkHtmlkUrl, forGitkUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+            return new Repository(omniUrl, forkHtmlUrl, forkCloneUrl, omniUrl, omniUrl, omniUrl, omniUrl,
                 123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
                 1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now,
                 perms, parent,
                 null, false, false, false, false, 2, 122, true, true, true);
         }
 
-        public static Repository MakeParentRepo()
+        private static Repository MakeParentRepo(
+            string htmlUrl = ParentHtmlUrl,
+            string cloneUrl = ParentCloneUrl)
         {
             const string omniUrl = "http://somewhere.com/parent";
             var owner = new User(omniUrl, "test user", null, 0, "test inc",
@@ -52,7 +54,7 @@ namespace NuKeeper.Tests.Engine
 
             var perms = new RepositoryPermissions(false, true, true);
 
-            return new Repository(omniUrl, ParentHtmlUrl, ParentCloneUrl, omniUrl, omniUrl, omniUrl, omniUrl,
+            return new Repository(omniUrl, htmlUrl, cloneUrl, omniUrl, omniUrl, omniUrl, omniUrl,
                 123, owner, "repoName", "repoName", "a test repo", omniUrl, "EN", false, true,
                 1, 1, "master", 1, null, DateTimeOffset.Now, DateTimeOffset.Now, perms, null,
                 null, false, false, false, false, 2, 122, true, true, true);

--- a/NuKeeper.Tests/Engine/RespositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RespositoryBuilder.cs
@@ -51,7 +51,6 @@ namespace NuKeeper.Tests.Engine
                 1, null, 0, 0,
                 1, omniUrl, null, false, "test", null);
 
-
             var perms = new RepositoryPermissions(false, true, true);
 
             return new Repository(omniUrl, htmlUrl, cloneUrl, omniUrl, omniUrl, omniUrl, omniUrl,

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -140,22 +140,14 @@ namespace NuKeeper.Engine
                 return false;
             }
 
-            var testParentCloneUrl = userRepo.Parent?.CloneUrl;
+            return UrlIsMatch(userRepo.Parent?.CloneUrl, parentUrl)
+                || UrlIsMatch(userRepo.Parent?.HtmlUrl, parentUrl);
+        }
 
-            if (!string.IsNullOrWhiteSpace(testParentCloneUrl) &&
-                string.Equals(testParentCloneUrl, parentUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            var testParentHtmlUrl = userRepo.Parent?.HtmlUrl;
-            if (!string.IsNullOrWhiteSpace(testParentHtmlUrl) &&
-                string.Equals(testParentHtmlUrl, parentUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
+        private static bool UrlIsMatch(string test, string expected)
+        {
+            return !string.IsNullOrWhiteSpace(test) &&
+                string.Equals(test, expected, StringComparison.OrdinalIgnoreCase);
         }
 
         private static ForkData RepositoryToForkData(Repository repo)

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -135,10 +135,27 @@ namespace NuKeeper.Engine
 
         private static bool RepoIsForkOf(Repository userRepo, string parentUrl)
         {
-            var testParentUrl = userRepo.Parent?.CloneUrl;
-            return userRepo.Fork &&
-                !string.IsNullOrWhiteSpace(testParentUrl) &&
-                string.Equals(testParentUrl, parentUrl, StringComparison.OrdinalIgnoreCase);
+            if (! userRepo.Fork)
+            {
+                return false;
+            }
+
+            var testParentCloneUrl = userRepo.Parent?.CloneUrl;
+
+            if (!string.IsNullOrWhiteSpace(testParentCloneUrl) &&
+                string.Equals(testParentCloneUrl, parentUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var testParentHtmlUrl = userRepo.Parent?.HtmlUrl;
+            if (!string.IsNullOrWhiteSpace(testParentHtmlUrl) &&
+                string.Equals(testParentHtmlUrl, parentUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static ForkData RepositoryToForkData(Repository repo)

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Github;
@@ -33,7 +33,7 @@ namespace NuKeeper.Engine
                     return await FindUpstreamRepoOrUserFork(userName, fallbackFork);
 
                 case ForkMode.SingleRepositoryOnly:
-                    return await FindUpstreamRepoOnly(userName, fallbackFork);
+                    return await FindUpstreamRepoOnly(fallbackFork);
 
                 default:
                     throw new Exception($"Unknown fork mode: {_forkMode}");
@@ -81,7 +81,7 @@ namespace NuKeeper.Engine
             return null;
         }
 
-        private async Task<ForkData> FindUpstreamRepoOnly(string userName, ForkData pullFork)
+        private async Task<ForkData> FindUpstreamRepoOnly(ForkData pullFork)
         {
             // Only want to pull and push from the same origin repo.
             var canUseOriginRepo = await IsPushableRepo(pullFork);
@@ -133,16 +133,17 @@ namespace NuKeeper.Engine
             return null;
         }
 
-        private static bool RepoIsForkOf(Repository userRepo, string parentUri)
+        private static bool RepoIsForkOf(Repository userRepo, string parentUrl)
         {
+            var testParentUrl = userRepo.Parent?.CloneUrl;
             return userRepo.Fork &&
-                !string.IsNullOrWhiteSpace(userRepo.Parent?.HtmlUrl) &&
-                string.Equals(userRepo.Parent.HtmlUrl, parentUri, StringComparison.OrdinalIgnoreCase);
+                !string.IsNullOrWhiteSpace(testParentUrl) &&
+                string.Equals(testParentUrl, parentUrl, StringComparison.OrdinalIgnoreCase);
         }
 
         private static ForkData RepositoryToForkData(Repository repo)
         {
-            return new ForkData(new Uri(repo.HtmlUrl), repo.Owner.Login, repo.Name);
+            return new ForkData(new Uri(repo.CloneUrl), repo.Owner.Login, repo.Name);
         }
     }
 }

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -46,7 +46,7 @@ namespace NuKeeper.Github
             try
             {
                 var result = await _client.Repository.Get(userName, repositoryName);
-                _logger.Info($"User fork found at {result.GitUrl}  for {result.Owner.Login}");
+                _logger.Info($"User fork found at {result.GitUrl} for {result.Owner.Login}");
                 return result;
             }
             catch (NotFoundException)


### PR DESCRIPTION
When the upstream is https://github.com/NuKeeperDotNet/JustEat.StatsD
and the user fork is https://github.com/NuKeeperBot/JustEat.StatsD
it was not finding the user Fork
purely due to the question of which of the many url fields to use - `CloneUrl`, `HtmlUrl` etc.

After this fix it does, note the origin branch of this PR: https://github.com/NuKeeperDotNet/JustEat.StatsD/pull/29

