### PR TITLE
Package update set refactor

### DIFF
--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Tests.Engine
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("foo"));
+            Assert.That(results[0].MatchId, Is.EqualTo("foo"));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(GitWithNoBranches(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("bar"));
+            Assert.That(results[0].MatchId, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(GitWithNoBranches(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("bar"));
+            Assert.That(results[0].MatchId, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(GitWithNoBranches(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("bar"));
+            Assert.That(results[0].MatchId, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(GitWithNoBranches(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("foo"));
+            Assert.That(results[0].MatchId, Is.EqualTo("foo"));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(GitWithNoBranches(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("foo"));
+            Assert.That(results[0].MatchId, Is.EqualTo("foo"));
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace NuKeeper.Tests.Engine
             var results = target.SelectTargets(git, updateSets);
 
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].PackageId, Is.EqualTo("bar"));
+            Assert.That(results[0].MatchId, Is.EqualTo("bar"));
             git.Received().BranchExists(Arg.Any<string>());
         }
 

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             Assert.That(updates.PackageId, Is.EqualTo("foo"));
             Assert.That(updates.NewVersion, Is.EqualTo(match.Identity.Version));
             Assert.That(updates.PackageSource, Is.EqualTo(ASource));
-            Assert.That(updates.Highest, Is.EqualTo(VersionFour()));
+            Assert.That(updates.HighestVersion, Is.EqualTo(VersionFour()));
             Assert.That(updates.AllowedChange, Is.EqualTo(VersionChange.Major));
         }
 

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -74,9 +74,10 @@ namespace NuKeeper.Tests.RepositoryInspection
             var updates = new PackageUpdateSet(VersionChange.Major, highest, match, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
-            Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
-            Assert.That(updates.PackageId, Is.EqualTo("foo"));
-            Assert.That(updates.NewVersion, Is.EqualTo(match.Identity.Version));
+            Assert.That(updates.Match, Is.Not.Null);
+            Assert.That(updates.Match.Identity, Is.EqualTo(LatestVersionOfPackageFoo()));
+            Assert.That(updates.MatchId, Is.EqualTo("foo"));
+            Assert.That(updates.MatchVersion, Is.EqualTo(match.Identity.Version));
             Assert.That(updates.Match.Source, Is.EqualTo(ASource));
             Assert.That(updates.HighestVersion, Is.EqualTo(VersionFour()));
             Assert.That(updates.AllowedChange, Is.EqualTo(VersionChange.Major));
@@ -111,10 +112,11 @@ namespace NuKeeper.Tests.RepositoryInspection
             var updates = new PackageUpdateSet(VersionChange.Major, LatestFooMetadata(), LatestFooMetadata(), currentPackages);
 
             Assert.That(updates, Is.Not.Null);
-            Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
+            Assert.That(updates.Match, Is.Not.Null);
+            Assert.That(updates.Match.Identity, Is.EqualTo(LatestVersionOfPackageFoo()));
 
-            Assert.That(updates.PackageId, Is.EqualTo("foo"));
-            Assert.That(updates.NewVersion, Is.EqualTo(newPackage.Version));
+            Assert.That(updates.MatchId, Is.EqualTo("foo"));
+            Assert.That(updates.MatchVersion, Is.EqualTo(newPackage.Version));
         }
 
         [Test]

--- a/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -77,7 +77,7 @@ namespace NuKeeper.Tests.RepositoryInspection
             Assert.That(updates.NewPackage, Is.EqualTo(LatestVersionOfPackageFoo()));
             Assert.That(updates.PackageId, Is.EqualTo("foo"));
             Assert.That(updates.NewVersion, Is.EqualTo(match.Identity.Version));
-            Assert.That(updates.PackageSource, Is.EqualTo(ASource));
+            Assert.That(updates.Match.Source, Is.EqualTo(ASource));
             Assert.That(updates.HighestVersion, Is.EqualTo(VersionFour()));
             Assert.That(updates.AllowedChange, Is.EqualTo(VersionChange.Major));
         }

--- a/NuKeeper/Engine/BranchNamer.cs
+++ b/NuKeeper/Engine/BranchNamer.cs
@@ -1,4 +1,4 @@
-﻿using NuKeeper.RepositoryInspection;
+using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
 {
@@ -6,7 +6,7 @@ namespace NuKeeper.Engine
     {
         public static string MakeName(PackageUpdateSet updateSet)
         {
-            return $"nukeeper-update-{updateSet.PackageId}-to-{updateSet.NewVersion}";
+            return $"nukeeper-update-{updateSet.MatchId}-to-{updateSet.MatchVersion}";
         }
     }
 }

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text;
 using NuKeeper.RepositoryInspection;
 
@@ -40,7 +40,7 @@ namespace NuKeeper.Engine
                 builder.AppendLine($"{oldVersions.Count} versions of {packageId} were found in use: {oldVersions.JoinWithCommas()}");
             }
 
-            var highestVersion = updates.Highest;
+            var highestVersion = updates.HighestVersion;
             if (highestVersion != null && (highestVersion > updates.NewVersion))
             {
                 var allowedChange = CodeQuote(updates.AllowedChange.ToString());

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Engine
         private const string CommitEmoji = "package";
         public static string MakePullRequestTitle(PackageUpdateSet updates)
         {
-            return $"Automatic update of {updates.PackageId} to {updates.NewVersion}";
+            return $"Automatic update of {updates.MatchId} to {updates.MatchVersion}";
         }
 
         public static string MakeCommitMessage(PackageUpdateSet updates)
@@ -25,8 +25,8 @@ namespace NuKeeper.Engine
                 .Select(v => CodeQuote(v.ToString()))
                 .ToList();
  
-            var newVersion = CodeQuote(updates.NewVersion.ToString());
-            var packageId = CodeQuote(updates.PackageId);
+            var newVersion = CodeQuote(updates.MatchVersion.ToString());
+            var packageId = CodeQuote(updates.MatchId);
 
             var builder = new StringBuilder();
 
@@ -41,10 +41,10 @@ namespace NuKeeper.Engine
             }
 
             var highestVersion = updates.HighestVersion;
-            if (highestVersion != null && (highestVersion > updates.NewVersion))
+            if (highestVersion != null && (highestVersion > updates.MatchVersion))
             {
                 var allowedChange = CodeQuote(updates.AllowedChange.ToString());
-                var highest = CodeQuote(updates.PackageId + " " + highestVersion);
+                var highest = CodeQuote(updates.MatchId + " " + highestVersion);
                 builder.AppendLine(
                     $"There is also a higher version, {highest}, but this was not applied as only {allowedChange} version changes are allowed.");
             }
@@ -60,7 +60,7 @@ namespace NuKeeper.Engine
 
             foreach (var current in updates.CurrentPackages)
             {
-                var line = $"Updated {CodeQuote(current.Path.RelativePath)} to {packageId} {CodeQuote(updates.NewVersion.ToString())} from {CodeQuote(current.Version.ToString())}";
+                var line = $"Updated {CodeQuote(current.Path.RelativePath)} to {packageId} {CodeQuote(updates.MatchVersion.ToString())} from {CodeQuote(current.Version.ToString())}";
                 builder.AppendLine(line);
             }
 

--- a/NuKeeper/Engine/EngineReport.cs
+++ b/NuKeeper/Engine/EngineReport.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.Engine
             {
                 foreach (var current in updateSet.CurrentPackages)
                 {
-                    details.AppendLine($"{updateSet.PackageId} from {current.Version} to {updateSet.NewVersion} in {current.Path.RelativePath}");
+                    details.AppendLine($"{updateSet.MatchId} from {current.Version} to {updateSet.MatchVersion} in {current.Path.RelativePath}");
                 }
             }
             return new LogData
@@ -55,7 +55,7 @@ namespace NuKeeper.Engine
                 .Select(u => u.Version.ToString())
                 .Distinct();
 
-            return $"Updating '{updateSet.PackageId}' from {oldVersions.JoinWithCommas()} to {updateSet.NewVersion} in {updateSet.CurrentPackages.Count} projects";
+            return $"Updating '{updateSet.MatchId}' from {oldVersions.JoinWithCommas()} to {updateSet.MatchVersion} in {updateSet.CurrentPackages.Count} projects";
         }
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NuKeeper.Configuration;
@@ -44,7 +44,7 @@ namespace NuKeeper.Engine.Packages
 
             foreach (var updateSet in capped)
             {
-                _logger.Info($"Selected package update of {updateSet.PackageId} to {updateSet.NewVersion}");
+                _logger.Info($"Selected package update of {updateSet.MatchId} to {updateSet.MatchVersion}");
             }
 
             return capped;
@@ -64,12 +64,12 @@ namespace NuKeeper.Engine.Packages
 
         private static bool MatchesInclude(Regex regex, PackageUpdateSet packageUpdateSet)
         {
-            return regex == null || regex.IsMatch(packageUpdateSet.PackageId);
+            return regex == null || regex.IsMatch(packageUpdateSet.MatchId);
         }
 
         private static bool MatchesExclude(Regex regex, PackageUpdateSet packageUpdateSet)
         {
-            return regex != null && regex.IsMatch(packageUpdateSet.PackageId);
+            return regex != null && regex.IsMatch(packageUpdateSet.MatchId);
         }
 
         private static bool HasExistingBranch(IGitDriver git, PackageUpdateSet packageUpdateSet)

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -71,7 +71,7 @@ namespace NuKeeper.Engine.Packages
                 }
 
                 var updateCommand = GetUpdateCommand(current.Path.PackageReferenceType);
-                await updateCommand.Invoke(updateSet.NewVersion, updateSet.Match.Source, current);
+                await updateCommand.Invoke(updateSet.MatchVersion, updateSet.Match.Source, current);
             }
         }
 

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Git;
@@ -71,7 +71,7 @@ namespace NuKeeper.Engine.Packages
                 }
 
                 var updateCommand = GetUpdateCommand(current.Path.PackageReferenceType);
-                await updateCommand.Invoke(updateSet.NewVersion, updateSet.PackageSource, current);
+                await updateCommand.Invoke(updateSet.NewVersion, updateSet.Match.Source, current);
             }
         }
 

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -51,7 +51,7 @@ namespace NuKeeper.Engine.Report
             var highestDate = ToUtcIso8601(update.Highest.Published);
             var packageSource = update.Match.Source;
 
-            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.HighestVersion},{highestDate},{packageSource}");
+            writer.WriteLine($"{update.MatchId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.HighestVersion},{highestDate},{packageSource}");
         }
 
         private StreamWriter MakeOutputStream(string name)

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -48,7 +48,9 @@ namespace NuKeeper.Engine.Report
             var lowest = versionsInUse.Min();
             var highest = versionsInUse.Max();
 
-            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.Highest},{ToUtcIso8601(update.HighestPublished)},{update.PackageSource}");
+            var highestDate = ToUtcIso8601(update.Highest.Published);
+
+            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.HighestVersion},{highestDate},{update.PackageSource}");
         }
 
         private StreamWriter MakeOutputStream(string name)

--- a/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper/Engine/Report/AvailableUpdatesReporter.cs
@@ -49,8 +49,9 @@ namespace NuKeeper.Engine.Report
             var highest = versionsInUse.Max();
 
             var highestDate = ToUtcIso8601(update.Highest.Published);
+            var packageSource = update.Match.Source;
 
-            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.HighestVersion},{highestDate},{update.PackageSource}");
+            writer.WriteLine($"{update.PackageId},{occurences},{update.CountCurrentVersions()},{lowest},{highest},{update.HighestVersion},{highestDate},{packageSource}");
         }
 
         private StreamWriter MakeOutputStream(string name)

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -9,8 +9,6 @@ namespace NuKeeper.RepositoryInspection
 {
     public class PackageUpdateSet
     {
-        private readonly PackageSearchMedatadata _match;
-
         public PackageUpdateSet(VersionChange allowedChange,
             PackageSearchMedatadata highest,
             PackageSearchMedatadata match,
@@ -38,24 +36,25 @@ namespace NuKeeper.RepositoryInspection
                 throw new ArgumentException($"{nameof(currentPackages)} is empty", nameof(currentPackages));
             }
 
-            _match = match;
-            Highest = highest;
             AllowedChange = allowedChange;
+            Highest = highest;
+            Match = match;
             CurrentPackages = currentPackagesList;
 
             CheckIdConsistency();
         }
 
         public VersionChange AllowedChange { get; }
+        public PackageSearchMedatadata Highest { get; }
+        public PackageSearchMedatadata Match { get; }
+
         public IReadOnlyCollection<PackageInProject> CurrentPackages { get; }
 
-        public PackageIdentity NewPackage => _match.Identity;
+        public PackageIdentity NewPackage => Match.Identity;
 
-        public string PackageId => NewPackage.Id;
-        public NuGetVersion NewVersion => NewPackage.Version;
-        public string PackageSource => _match.Source;
+        public string PackageId => Match.Identity.Id;
+        public NuGetVersion NewVersion => Match.Identity.Version;
 
-        public PackageSearchMedatadata Highest { get; }
         public NuGetVersion HighestVersion=> Highest.Identity.Version;
 
         public int CountCurrentVersions()

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -9,7 +9,6 @@ namespace NuKeeper.RepositoryInspection
 {
     public class PackageUpdateSet
     {
-        private readonly PackageSearchMedatadata _highest;
         private readonly PackageSearchMedatadata _match;
 
         public PackageUpdateSet(VersionChange allowedChange,
@@ -40,7 +39,7 @@ namespace NuKeeper.RepositoryInspection
             }
 
             _match = match;
-            _highest = highest;
+            Highest = highest;
             AllowedChange = allowedChange;
             CurrentPackages = currentPackagesList;
 
@@ -55,8 +54,9 @@ namespace NuKeeper.RepositoryInspection
         public string PackageId => NewPackage.Id;
         public NuGetVersion NewVersion => NewPackage.Version;
         public string PackageSource => _match.Source;
-        public NuGetVersion Highest=> _highest.Identity.Version;
-        public DateTimeOffset? HighestPublished => _highest.Published;
+
+        public PackageSearchMedatadata Highest { get; }
+        public NuGetVersion HighestVersion=> Highest.Identity.Version;
 
         public int CountCurrentVersions()
         {

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.NuGet.Api;
 
@@ -50,10 +49,8 @@ namespace NuKeeper.RepositoryInspection
 
         public IReadOnlyCollection<PackageInProject> CurrentPackages { get; }
 
-        public PackageIdentity NewPackage => Match.Identity;
-
-        public string PackageId => Match.Identity.Id;
-        public NuGetVersion NewVersion => Match.Identity.Version;
+        public string MatchId => Match.Identity.Id;
+        public NuGetVersion MatchVersion => Match.Identity.Version;
 
         public NuGetVersion HighestVersion=> Highest.Identity.Version;
 
@@ -67,14 +64,14 @@ namespace NuKeeper.RepositoryInspection
 
         private void CheckIdConsistency()
         {
-            if (CurrentPackages.Any(p => p.Id != NewPackage.Id))
+            if (CurrentPackages.Any(p => p.Id != MatchId))
             {
                 var errorIds = CurrentPackages
                     .Select(p => p.Id)
                     .Distinct()
-                    .Where(id => id != NewPackage.Id);
+                    .Where(id => id != MatchId);
 
-                throw new ArgumentException($"Updates must all be for package '{NewPackage.Id}', got '{errorIds.JoinWithCommas()}'");
+                throw new ArgumentException($"Updates must all be for package '{MatchId}', got '{errorIds.JoinWithCommas()}'");
             }
         }
     }


### PR DESCRIPTION
refactoring `PackageUpdateSet` - mostly renaming properties
to make it more like `PackageLookupResult`
