### PR TITLE
remove the second constructor on  PackageUpdateSet

### DIFF
--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -221,8 +221,8 @@ namespace NuKeeper.Tests.Engine
 
             var latest = new PackageSearchMedatadata(newPackage, "someSource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(VersionChange.Major,
-                latest, latest, packages);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
         }
 
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
@@ -233,8 +233,8 @@ namespace NuKeeper.Tests.Engine
             var match = new PackageSearchMedatadata(
                 NewPackageFooBar123(), "someSource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(VersionChange.Minor,
-                latest, match, packages);
+            var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
+            return new PackageUpdateSet(updates, packages);
         }
 
         private static PackageIdentity NewPackageFooBar123()

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -202,8 +202,8 @@ namespace NuKeeper.Tests.Engine
 
             var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(VersionChange.Major, 
-                latest, latest, currentPackages);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
         }
 
         private PackageUpdateSet UpdateFooFromOneVersion()
@@ -216,13 +216,11 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
-
             var matchVersion = new NuGetVersion("4.0.0");
             var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion), "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(VersionChange.Major,
-                latest, match, currentPackages);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
         }
 
         private PackageUpdateSet UpdateBarFromTwoVersions()
@@ -235,12 +233,11 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("bar", "1.2.1", PathToProjectTwo())
             };
 
-            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
             var match = new PackageSearchMedatadata(matchId, "ASource", DateTimeOffset.Now);
 
-            return new PackageUpdateSet(VersionChange.Major, 
-                latest, match, currentPackages);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
         }
 
         private PackageIdentity LatestVersionOfPackageFoobar()

--- a/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper/RepositoryInspection/PackageUpdateSet.cs
@@ -9,14 +9,15 @@ namespace NuKeeper.RepositoryInspection
     public class PackageUpdateSet
     {
         public PackageUpdateSet(PackageLookupResult data, IEnumerable<PackageInProject> currentPackages)
-            : this(data.AllowedChange, data.Major, data.Selected(), currentPackages)
-        { }
-
-        public PackageUpdateSet(VersionChange allowedChange,
-            PackageSearchMedatadata highest,
-            PackageSearchMedatadata match,
-            IEnumerable<PackageInProject> currentPackages)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            var highest = data.Major;
+            var match = data.Selected();
+
             if (highest == null)
             {
                 throw new ArgumentNullException(nameof(highest));
@@ -39,7 +40,7 @@ namespace NuKeeper.RepositoryInspection
                 throw new ArgumentException($"{nameof(currentPackages)} is empty", nameof(currentPackages));
             }
 
-            AllowedChange = allowedChange;
+            AllowedChange = data.AllowedChange;
             Highest = highest;
             Match = match;
             CurrentPackages = currentPackagesList;


### PR DESCRIPTION
remove the second constructor on  PackageUpdateSet
It is only used in test
and getting rid of it will make the next step easier: Keep the `PackageLookupResult` and all 3 versions in it in the `PackageUpdateSet` for logging.