### PR TITLE
Commit report highest ago

### DIFF
--- a/NuKeeper.Tests/Engine/CommitReportTests.cs
+++ b/NuKeeper.Tests/Engine/CommitReportTests.cs
@@ -219,7 +219,8 @@ namespace NuKeeper.Tests.Engine
 
             var report = CommitReport.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain("There is also a higher version, `foo.bar 2.3.4` published at `2018-02-20T11:32:45Z`, but this was not applied as only `Minor` version changes are allowed."));
+            Assert.That(report, Does.Contain("There is also a higher version, `foo.bar 2.3.4` published at `2018-02-20T11:32:45Z`,"));
+            Assert.That(report, Does.Contain(" ago, but this was not applied as only `Minor` version changes are allowed."));
         }
 
         private static void AssertContainsStandardText(string report)

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -89,7 +89,7 @@ namespace NuKeeper.Engine
             var highestPublishedAt = HighestPublishedAt(updates.Packages.Major.Published);
 
             builder.AppendLine(
-                $"There is also a higher version, {highest}{highestPublishedAt}," +
+                $"There is also a higher version, {highest}{highestPublishedAt}, " +
                 $"but this was not applied as only {allowedChange} version changes are allowed.");
         }
 

--- a/NuKeeper/Engine/CommitReport.cs
+++ b/NuKeeper/Engine/CommitReport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
@@ -54,16 +55,7 @@ namespace NuKeeper.Engine
             var highestVersion = updates.Packages.Major?.Identity.Version;
             if (highestVersion != null && (highestVersion > updates.SelectedVersion))
             {
-                var allowedChange = CodeQuote(updates.AllowedChange.ToString());
-                var highest = CodeQuote(updates.SelectedId + " " + highestVersion);
-                string highestPublishedAt = string.Empty;
-                if (updates.Packages.Major.Published.HasValue)
-                {
-                    highestPublishedAt = " published at " +
-                        CodeQuote(DateFormat.AsUtcIso8601(updates.Packages.Major.Published));
-                }
-                builder.AppendLine(
-                    $"There is also a higher version, {highest}{highestPublishedAt}, but this was not applied as only {allowedChange} version changes are allowed.");
+                LogHighestVersion(updates, highestVersion, builder);
             }
 
             builder.AppendLine();
@@ -87,6 +79,32 @@ namespace NuKeeper.Engine
             builder.AppendLine("This is an automated update. Merge only if it passes tests");
             builder.AppendLine("**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper");
             return builder.ToString();
+        }
+
+        private static void LogHighestVersion(PackageUpdateSet updates, NuGetVersion highestVersion, StringBuilder builder)
+        {
+            var allowedChange = CodeQuote(updates.AllowedChange.ToString());
+            var highest = CodeQuote(updates.SelectedId + " " + highestVersion);
+
+            var highestPublishedAt = HighestPublishedAt(updates.Packages.Major.Published);
+
+            builder.AppendLine(
+                $"There is also a higher version, {highest}{highestPublishedAt}," +
+                $"but this was not applied as only {allowedChange} version changes are allowed.");
+        }
+
+        private static string HighestPublishedAt(DateTimeOffset? highestPublishedAt)
+        {
+            if (!highestPublishedAt.HasValue)
+            {
+                return string.Empty;
+            }
+
+            var highestPubDate = highestPublishedAt.Value;
+            var formattedPubDate = CodeQuote(DateFormat.AsUtcIso8601(highestPubDate));
+            var highestAgo = TimeSpanFormat.Ago(highestPubDate.UtcDateTime, DateTime.UtcNow);
+
+            return $" published at {formattedPubDate}, {highestAgo}";
         }
 
         private static string CodeQuote(string value)


### PR DESCRIPTION
Change the commit report wording to include the "ago" form of the highest version published date 

 e.g. from:
"There is also a higher version, `Foo.Bar 11.1.0` published at `2017-10-24T16:10:15Z`" 
to:
"There is also a higher version, `Foo.Bar 11.1.0` published at `2017-10-24T16:10:15Z`, 4 months ago".

