### PR TITLE
Rename report classes

### DIFF
--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -9,14 +9,14 @@ using NUnit.Framework;
 namespace NuKeeper.Tests.Engine
 {
     [TestFixture]
-    public class CommitReportTests
+    public class CommitWordingTests
     {
         [Test]
         public void MarkPullRequestTitle_UpdateIsCorrect()
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakePullRequestTitle(updates);
+            var report = CommitWording.MakePullRequestTitle(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -28,7 +28,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitMessage(updates);
+            var report = CommitWording.MakeCommitMessage(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -40,7 +40,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
-            var report = CommitReport.MakeCommitMessage(updates);
+            var report = CommitWording.MakeCommitMessage(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -52,7 +52,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = CommitReport.MakeCommitMessage(updates);
+            var report = CommitWording.MakeCommitMessage(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -65,7 +65,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -76,7 +76,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             AssertContainsStandardText(report);
         }
@@ -86,7 +86,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.StartWith("NuKeeper has generated an update of `foo.bar` to `1.2.3` from `1.1.0`"));
         }
@@ -96,7 +96,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("`foo.bar 1.2.3` was published at `2018-02-19T11:12:07Z`"));
         }
@@ -107,7 +107,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("1 project update:"));
             Assert.That(report, Does.Contain("Updated `folder\\src\\project1\\packages.config` to `foo.bar` `1.2.3` from `1.1.0`"));
@@ -118,7 +118,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -129,7 +129,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             AssertContainsStandardText(report);
             Assert.That(report, Does.Contain("1.0.0"));
@@ -140,7 +140,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.StartWith("NuKeeper has generated an update of `foo.bar` to `1.2.3`"));
             Assert.That(report, Does.Contain("2 versions of `foo.bar` were found in use: `1.1.0`, `1.0.0`"));
@@ -151,7 +151,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("2 project updates:"));
             Assert.That(report, Does.Contain("Updated `folder\\src\\project1\\packages.config` to `foo.bar` `1.2.3` from `1.1.0`"));
@@ -163,7 +163,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
@@ -174,7 +174,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             AssertContainsStandardText(report);
         }
@@ -184,7 +184,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.StartWith("NuKeeper has generated an update of `foo.bar` to `1.2.3` from `1.1.0`"));
         }
@@ -194,7 +194,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("2 project updates:"));
             Assert.That(report, Does.Contain("Updated `folder\\src\\project1\\packages.config` to `foo.bar` `1.2.3` from `1.1.0`"));
@@ -206,7 +206,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = UpdateSetForLimited(MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("There is also a higher version, `foo.bar 2.3.4`, but this was not applied as only `Minor` version changes are allowed."));
         }
@@ -217,7 +217,7 @@ namespace NuKeeper.Tests.Engine
             var publishedAt = new DateTimeOffset(2018, 2, 20, 11, 32 ,45, TimeSpan.Zero);
             var updates = UpdateSetForLimited(publishedAt, MakePackageForV110());
 
-            var report = CommitReport.MakeCommitDetails(updates);
+            var report = CommitWording.MakeCommitDetails(updates);
 
             Assert.That(report, Does.Contain("There is also a higher version, `foo.bar 2.3.4` published at `2018-02-20T11:32:45Z`,"));
             Assert.That(report, Does.Contain(" ago, but this was not applied as only `Minor` version changes are allowed."));

--- a/NuKeeper/Engine/CommitWording.cs
+++ b/NuKeeper/Engine/CommitWording.cs
@@ -6,7 +6,7 @@ using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
 {
-    public static class CommitReport
+    public static class CommitWording
     {
         private const string CommitEmoji = "package";
         public static string MakePullRequestTitle(PackageUpdateSet updates)

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -44,12 +44,12 @@ namespace NuKeeper.Engine.Packages
 
                 await UpdateAllCurrentUsages(updateSet);
 
-                var commitMessage = CommitReport.MakeCommitMessage(updateSet);
+                var commitMessage = CommitWording.MakeCommitMessage(updateSet);
                 git.Commit(commitMessage);
 
                 git.Push("nukeeper_push", branchName);
 
-                var prTitle = CommitReport.MakePullRequestTitle(updateSet);
+                var prTitle = CommitWording.MakePullRequestTitle(updateSet);
                 await MakeGitHubPullRequest(updateSet, repository, prTitle, branchName);
 
                 git.Checkout(repository.DefaultBranch);
@@ -112,7 +112,7 @@ namespace NuKeeper.Engine.Packages
 
             var pr = new NewPullRequest(title, qualifiedBranch, repository.DefaultBranch)
             {
-                Body = CommitReport.MakeCommitDetails(updates)
+                Body = CommitWording.MakeCommitDetails(updates)
             };
 
             await _github.OpenPullRequest(repository.Pull, pr);

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Engine.Packages
         {
             try
             {
-                _logger.Terse(EngineReport.OldVersionsToBeUpdated(updateSet));
+                _logger.Terse(UpdatesLogger.OldVersionsToBeUpdated(updateSet));
 
                 git.Checkout(repository.DefaultBranch);
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -104,11 +104,11 @@ namespace NuKeeper.Engine
             var packages = _repositoryScanner.FindAllNuGetPackages(git.WorkingFolder)
                 .ToList();
 
-            _logger.Log(EngineReport.PackagesFound(packages));
+            _logger.Log(UpdatesLogger.PackagesFound(packages));
 
             // look for package updates
             var updates = await _packageLookup.FindUpdatesForPackages(packages);
-            _logger.Log(EngineReport.UpdatesFound(updates));
+            _logger.Log(UpdatesLogger.UpdatesFound(updates));
             return updates;
         }
 

--- a/NuKeeper/Engine/UpdatesLogger.cs
+++ b/NuKeeper/Engine/UpdatesLogger.cs
@@ -6,7 +6,7 @@ using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine
 {
-    public static class EngineReport
+    public static class UpdatesLogger
     {
         public static LogData PackagesFound(List<PackageInProject> packages)
         {


### PR DESCRIPTION
To avoid confusion, I want to use the word "Report" to refer only to generating the output files, the new CSVReport.

So rename some other classes that use the name "report" in other ways:

`CommitReport` -> `CommitWording`
`EngineReport` -> `UpdatesLogger`.

I think these are better names anyway.