### PR TITLE
A better package update sort

### DIFF
--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Tests.Engine.Packages
         {
             var items = new List<PackageUpdateSet>
             {
-                OnePackageUpdateSet()
+                OnePackageUpdateSet(1)
             };
 
             var output = PackageUpdateSort.Sort(items)
@@ -38,6 +38,39 @@ namespace NuKeeper.Tests.Engine.Packages
             Assert.That(output, Is.Not.Null);
             Assert.That(output.Count, Is.EqualTo(1));
             Assert.That(output[0], Is.EqualTo(items[0]));
+        }
+
+        [Test]
+        public void CanSortTwoItems()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet(1),
+                OnePackageUpdateSet(2)
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output, Is.Not.Null);
+            Assert.That(output.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void CanSortThreeItems()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet(1),
+                OnePackageUpdateSet(2),
+                OnePackageUpdateSet(3),
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output, Is.Not.Null);
+            Assert.That(output.Count, Is.EqualTo(3));
         }
 
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
@@ -55,11 +88,18 @@ namespace NuKeeper.Tests.Engine.Packages
                 PackageReferenceType.PackagesConfig);
             return new PackageInProject(package.Id, package.Version.ToString(), path);
         }
-        private static PackageUpdateSet OnePackageUpdateSet()
+
+        private static PackageUpdateSet OnePackageUpdateSet(int projectCount)
         {
             var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
 
-            return UpdateSetFor(package, MakePackageForV110(package));
+            var projects = new List<PackageInProject>();
+            foreach(int i in Enumerable.Range(1, projectCount))
+            {
+                projects.Add(MakePackageForV110(package));
+            }
+
+            return UpdateSetFor(package, projects.ToArray());
         }
     }
 }

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -1,0 +1,65 @@
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Engine.Packages;
+using NuKeeper.NuGet.Api;
+using NuKeeper.RepositoryInspection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuKeeper.Tests.Engine.Packages
+{
+    [TestFixture]
+    public class PackageUpdateSortTests
+    {
+        [Test]
+        public void CanSortWhenListIsEmpty()
+        {
+            var items = new List<PackageUpdateSet>();
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output, Is.Not.Null);
+        }
+
+        [Test]
+        public void CanSortOneItem()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet()
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output, Is.Not.Null);
+            Assert.That(output.Count, Is.EqualTo(1));
+            Assert.That(output[0], Is.EqualTo(items[0]));
+        }
+
+        private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
+        {
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(package, "someSource", publishedDate);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        private static PackageInProject MakePackageForV110(PackageIdentity package)
+        {
+            var path = new PackagePath("c:\\temp", "folder\\src\\project1\\packages.config",
+                PackageReferenceType.PackagesConfig);
+            return new PackageInProject(package.Id, package.Version.ToString(), path);
+        }
+        private static PackageUpdateSet OnePackageUpdateSet()
+        {
+            var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+
+            return UpdateSetFor(package, MakePackageForV110(package));
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -76,16 +76,7 @@ namespace NuKeeper.Tests.Engine.Packages
         [Test]
         public void TwoPackageVersionsIsSortedToTop()
         {
-            var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
-            var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4"));
-            var projects = new List<PackageInProject>
-            {
-                MakePackageInProjectFor(package123),
-                MakePackageInProjectFor(package124),
-            };
-
-            var twoVersions = UpdateSetFor(package124, projects.ToArray());
-
+            var twoVersions = MakeTwoProjectVersions();
             var items = new List<PackageUpdateSet>
             {
                 OnePackageUpdateSet(3),
@@ -98,6 +89,45 @@ namespace NuKeeper.Tests.Engine.Packages
 
             Assert.That(output, Is.Not.Null);
             Assert.That(output[0], Is.EqualTo(twoVersions));
+        }
+
+        [Test]
+        public void WillSortByProjectCount()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet(1),
+                OnePackageUpdateSet(2),
+                OnePackageUpdateSet(3),
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output.Count, Is.EqualTo(3));
+            Assert.That(output[0].CurrentPackages.Count, Is.EqualTo(3));
+            Assert.That(output[1].CurrentPackages.Count, Is.EqualTo(2));
+            Assert.That(output[2].CurrentPackages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WillSortByProjectVersionsOverProjectCount()
+        {
+            var twoVersions = MakeTwoProjectVersions();
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet(10),
+                OnePackageUpdateSet(20),
+                twoVersions,
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output.Count, Is.EqualTo(3));
+            Assert.That(output[0], Is.EqualTo(twoVersions));
+            Assert.That(output[1].CurrentPackages.Count, Is.EqualTo(20));
+            Assert.That(output[2].CurrentPackages.Count, Is.EqualTo(10));
         }
 
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
@@ -127,6 +157,19 @@ namespace NuKeeper.Tests.Engine.Packages
             }
 
             return UpdateSetFor(package, projects.ToArray());
+        }
+
+        private PackageUpdateSet MakeTwoProjectVersions()
+        {
+            var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4"));
+            var projects = new List<PackageInProject>
+            {
+                MakePackageInProjectFor(package123),
+                MakePackageInProjectFor(package124),
+            };
+
+            return UpdateSetFor(package124, projects.ToArray());
         }
     }
 }

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -73,6 +73,33 @@ namespace NuKeeper.Tests.Engine.Packages
             Assert.That(output.Count, Is.EqualTo(3));
         }
 
+        [Test]
+        public void TwoPackageVersionsIsSortedToTop()
+        {
+            var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4"));
+            var projects = new List<PackageInProject>
+            {
+                MakePackageInProjectFor(package123),
+                MakePackageInProjectFor(package124),
+            };
+
+            var twoVersions = UpdateSetFor(package124, projects.ToArray());
+
+            var items = new List<PackageUpdateSet>
+            {
+                OnePackageUpdateSet(3),
+                OnePackageUpdateSet(4),
+                twoVersions
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output, Is.Not.Null);
+            Assert.That(output[0], Is.EqualTo(twoVersions));
+        }
+
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
@@ -82,7 +109,7 @@ namespace NuKeeper.Tests.Engine.Packages
             return new PackageUpdateSet(updates, packages);
         }
 
-        private static PackageInProject MakePackageForV110(PackageIdentity package)
+        private static PackageInProject MakePackageInProjectFor(PackageIdentity package)
         {
             var path = new PackagePath("c:\\temp", "folder\\src\\project1\\packages.config",
                 PackageReferenceType.PackagesConfig);
@@ -96,7 +123,7 @@ namespace NuKeeper.Tests.Engine.Packages
             var projects = new List<PackageInProject>();
             foreach(int i in Enumerable.Range(1, projectCount))
             {
-                projects.Add(MakePackageForV110(package));
+                projects.Add(MakePackageInProjectFor(package));
             }
 
             return UpdateSetFor(package, projects.ToArray());

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -136,8 +136,9 @@ namespace NuKeeper.Tests.Engine.Packages
             var items = new List<PackageUpdateSet>
             {
                 PackageChange("1.2.4", "1.2.3"),
-                PackageChange("1.3.0", "1.2.3"),
-                PackageChange("2.0.0", "1.2.3")
+                PackageChange("2.0.0", "1.2.3"),
+                PackageChange("4.0.0", "1.2.3"),
+                PackageChange("6.0.0", "1.2.3"),
             };
 
             var output = PackageUpdateSort.Sort(items)

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -149,6 +149,26 @@ namespace NuKeeper.Tests.Engine.Packages
             Assert.That(SelectedVersion(output[2]), Is.EqualTo("1.2.4"));
         }
 
+        [Test]
+        public void WillSortByGettingOutOfBetaFirst()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                PackageChange("2.0.0", "1.2.3"),
+                PackageChange("1.2.4", "1.2.3-beta1"),
+                PackageChange("1.3.0-pre-2", "1.2.3-beta1")
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output.Count, Is.EqualTo(3));
+            Assert.That(SelectedVersion(output[0]), Is.EqualTo("1.2.4"));
+            Assert.That(SelectedVersion(output[1]), Is.EqualTo("2.0.0"));
+            Assert.That(SelectedVersion(output[2]), Is.EqualTo("1.3.0-pre-2"));
+        }
+
+
         private string SelectedVersion(PackageUpdateSet packageUpdateSet)
         {
             return packageUpdateSet.Selected.Identity.Version.ToString();

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -137,8 +137,7 @@ namespace NuKeeper.Tests.Engine.Packages
             {
                 PackageChange("1.2.4", "1.2.3"),
                 PackageChange("2.0.0", "1.2.3"),
-                PackageChange("4.0.0", "1.2.3"),
-                PackageChange("6.0.0", "1.2.3"),
+                PackageChange("1.3.0", "1.2.3")
             };
 
             var output = PackageUpdateSort.Sort(items)

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -130,6 +130,30 @@ namespace NuKeeper.Tests.Engine.Packages
             Assert.That(output[2].CurrentPackages.Count, Is.EqualTo(10));
         }
 
+        [Test]
+        public void WillSortByBiggestVersionChange()
+        {
+            var items = new List<PackageUpdateSet>
+            {
+                PackageChange("1.2.4", "1.2.3"),
+                PackageChange("1.3.0", "1.2.3"),
+                PackageChange("2.0.0", "1.2.3")
+            };
+
+            var output = PackageUpdateSort.Sort(items)
+                .ToList();
+
+            Assert.That(output.Count, Is.EqualTo(3));
+            Assert.That(SelectedVersion(output[0]), Is.EqualTo("2.0.0"));
+            Assert.That(SelectedVersion(output[1]), Is.EqualTo("1.3.0"));
+            Assert.That(SelectedVersion(output[2]), Is.EqualTo("1.2.4"));
+        }
+
+        private string SelectedVersion(PackageUpdateSet packageUpdateSet)
+        {
+            return packageUpdateSet.Selected.Identity.Version.ToString();
+        }
+
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
@@ -148,6 +172,7 @@ namespace NuKeeper.Tests.Engine.Packages
 
         private static PackageUpdateSet OnePackageUpdateSet(int projectCount)
         {
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5"));
             var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
 
             var projects = new List<PackageInProject>();
@@ -156,11 +181,13 @@ namespace NuKeeper.Tests.Engine.Packages
                 projects.Add(MakePackageInProjectFor(package));
             }
 
-            return UpdateSetFor(package, projects.ToArray());
+            return UpdateSetFor(newPackage, projects.ToArray());
         }
 
         private PackageUpdateSet MakeTwoProjectVersions()
         {
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5"));
+
             var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
             var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4"));
             var projects = new List<PackageInProject>
@@ -169,7 +196,21 @@ namespace NuKeeper.Tests.Engine.Packages
                 MakePackageInProjectFor(package124),
             };
 
-            return UpdateSetFor(package124, projects.ToArray());
+            return UpdateSetFor(newPackage, projects.ToArray());
         }
+
+        private static PackageUpdateSet PackageChange(string newVersion, string oldVersion)
+        {
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion(newVersion));
+            var oldPackage = new PackageIdentity("foo.bar", new NuGetVersion(oldVersion));
+
+            var projects = new List<PackageInProject>
+            {
+                MakePackageInProjectFor(oldPackage)
+            };
+
+            return UpdateSetFor(newPackage, projects.ToArray());
+        }
+
     }
 }

--- a/NuKeeper.Tests/Engine/Report/AvailableUpdatesReporterTests.cs
+++ b/NuKeeper.Tests/Engine/Report/AvailableUpdatesReporterTests.cs
@@ -128,6 +128,5 @@ namespace NuKeeper.Tests.Engine.Report
                 UpdateSetFor(package, MakePackageForV110(package))
             };
         }
-
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
@@ -27,8 +27,7 @@ namespace NuKeeper.Engine.Packages
             IGitDriver git,
             IEnumerable<PackageUpdateSet> potentialUpdates)
         {
-            var unfiltered = potentialUpdates
-                .OrderByDescending(Priority)
+            var unfiltered = PackageUpdateSort.Sort(potentialUpdates)
                 .ToList();
 
             var filtered = unfiltered
@@ -64,11 +63,6 @@ namespace NuKeeper.Engine.Packages
             }
 
             _logger.Terse(message);
-        }
-
-        private int Priority(PackageUpdateSet update)
-        {
-            return update.CountCurrentVersions();
         }
 
         private bool MatchesIncludeExclude(PackageUpdateSet packageUpdateSet)

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -13,11 +13,11 @@ namespace NuKeeper.Engine.Packages
             return packages.OrderByDescending(Priority);
         }
 
-        private static int Priority(PackageUpdateSet update)
+        private static long Priority(PackageUpdateSet update)
         {
 
-            const int Shift = 100;
-            var score = update.CountCurrentVersions();
+            const long Shift = 1000;
+            long score = update.CountCurrentVersions();
             score = score * Shift;
             score = score + update.CurrentPackages.Count;
             score = score * Shift;
@@ -32,6 +32,24 @@ namespace NuKeeper.Engine.Packages
 
         private static int ScoreVersionChange(NuGetVersion newVersion, NuGetVersion oldVersion)
         {
+            var majors = newVersion.Major - oldVersion.Major;
+            if (majors > 0)
+            {
+                return majors * 100;
+            }
+
+            var minors = newVersion.Minor - oldVersion.Minor;
+            if (minors > 0)
+            {
+                return minors * 10;
+            }
+
+            var patches = newVersion.Patch - oldVersion.Patch;
+            if (patches > 0)
+            {
+                return patches;
+            }
+
             return 0;
         }
     }

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -14,7 +14,9 @@ namespace NuKeeper.Engine.Packages
 
         private static int Priority(PackageUpdateSet update)
         {
-            return update.CountCurrentVersions();
+            return
+                update.CountCurrentVersions() * 100  +
+                update.CurrentPackages.Count;
         }
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -1,3 +1,4 @@
+using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 using System;
 using System.Collections.Generic;
@@ -14,9 +15,24 @@ namespace NuKeeper.Engine.Packages
 
         private static int Priority(PackageUpdateSet update)
         {
-            return
-                update.CountCurrentVersions() * 100  +
-                update.CurrentPackages.Count;
+
+            const int Shift = 100;
+            var score = update.CountCurrentVersions();
+            score = score * Shift;
+            score = score + update.CurrentPackages.Count;
+            score = score * Shift;
+
+            var newVersion = update.Selected.Identity.Version;
+            var versionInUse = update.CurrentPackages
+                .Select(p => p.Version)
+                .Max();
+            score = score + ScoreVersionChange(newVersion, versionInUse);
+            return score;
+        }
+
+        private static int ScoreVersionChange(NuGetVersion newVersion, NuGetVersion oldVersion)
+        {
+            return 0;
         }
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -38,9 +38,8 @@ namespace NuKeeper.Engine.Packages
                 return 0;
             }
 
-            var today = DateTime.UtcNow;
-            var interval = today.Subtract(publishedDate.Value.ToUniversalTime().DateTime);
-
+            var published = publishedDate.Value.ToUniversalTime().DateTime;
+            var interval = DateTime.UtcNow.Subtract(published);
             return interval.Days;
         }
 

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -1,0 +1,20 @@
+using NuKeeper.RepositoryInspection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuKeeper.Engine.Packages
+{
+    public static class PackageUpdateSort
+    {
+        public static IEnumerable<PackageUpdateSet> Sort(IEnumerable<PackageUpdateSet> packages)
+        {
+            return packages.OrderByDescending(Priority);
+        }
+
+        private static int Priority(PackageUpdateSet update)
+        {
+            return update.CountCurrentVersions();
+        }
+    }
+}

--- a/NuKeeper/Engine/Packages/PackageUpdateSort.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSort.cs
@@ -58,7 +58,7 @@ namespace NuKeeper.Engine.Packages
             long preReleaseScore = 0;
             if (oldVersion.IsPrerelease && !newVersion.IsPrerelease)
             {
-                preReleaseScore = Shift * 10;
+               preReleaseScore = Shift * 12;
             }
 
             var majors = newVersion.Major - oldVersion.Major;


### PR DESCRIPTION
A better package update sort.

**Previously**: sorted only on the number of different versions in use.

**Now**: sort on the number of different versions in use, then the number of projects affected, then on the largest version change.
Older updates get a score boost. Change from pre-release to not pre-release gets a score boost.

And tests on it