### PR TITLE
Automatic update of NUnit3TestAdapter to 3.10.0

### DIFF
--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NUnit" Version="3.9.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper\NuKeeper.csproj" />

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper\NuKeeper.csproj" />


### PR DESCRIPTION
NuKeeper has generated an update of `NUnit3TestAdapter` to `3.10.0` from `3.9.0`
`NUnit3TestAdapter 3.10.0` was published at `2018-03-08T17:05:51Z`, 15 hours ago

2 project updates:
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `NUnit3TestAdapter` `3.10.0` from `3.9.0`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `NUnit3TestAdapter` `3.10.0` from `3.9.0`

This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
