### PR TITLE
Package age min

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -51,11 +51,32 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
+            Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new[] { "https://api.nuget.org/v3/index.json" }));
+            Assert.That(settings.UserSettings.PackageIncludes, Is.Null);
+            Assert.That(settings.UserSettings.PackageExcludes, Is.Null);
+        }
+
+        [Test]
+        public void ValidRepoCommandLineHasDefaultUserOptions()
+        {
+            var commandLine = ValidRepoCommandLine();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(3));
+            Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.FromDays(7)));
+        }
+
+        [Test]
+        public void ValidRepoCommandLineHasDefaultUserEnums()
+        {
+            var commandLine = ValidRepoCommandLine();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
-            Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new[] { "https://api.nuget.org/v3/index.json" }));
         }
 
         [Test]
@@ -272,7 +293,34 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
+            Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.FromDays(7)));
             Assert.That(settings.UserSettings.NuGetSources, Is.EqualTo(new[] { "https://api.nuget.org/v3/index.json" }));
+        }
+
+        [Test]
+        public void MinPackageAgeIsParsed()
+        {
+            var commandLine = ValidRepoCommandLine()
+                .Append("MinAge=3w");
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.UserSettings, Is.Not.Null);
+            Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.FromDays(21)));
+        }
+
+        [Test]
+        public void InvalidMinPackageAgeIsParsed()
+        {
+            var commandLine = ValidRepoCommandLine()
+                .Append("MinAge=78ff");
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.UserSettings, Is.Not.Null);
+            Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.Zero));
         }
 
         private static IEnumerable<string> ValidRepoCommandLine()

--- a/NuKeeper.Tests/DurationParserTests.cs
+++ b/NuKeeper.Tests/DurationParserTests.cs
@@ -1,0 +1,70 @@
+using System;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests
+{
+    [TestFixture]
+    public class DurationParserTests
+    {
+        [Test]
+        public void NullStringIsNotParsed()
+        {
+            var value = DurationParser.Parse(null);
+            Assert.That(value, Is.Null);
+        }
+
+        [Test]
+        public void EmptyStringIsNotParsed()
+        {
+            var value = DurationParser.Parse(string.Empty);
+            Assert.That(value, Is.Null);
+        }
+
+        [Test]
+        public void BadStringIsNotParsed()
+        {
+            var value = DurationParser.Parse("ghoti");
+            Assert.That(value, Is.Null);
+        }
+
+        [Test]
+        public void UnknownDurationTypeIsNotParsed()
+        {
+            var value = DurationParser.Parse("37x");
+            Assert.That(value, Is.Null);
+        }
+
+        [TestCase("1d", 1)]
+        [TestCase("3d", 3)]
+        [TestCase("12d", 12)]
+        [TestCase("123d", 123)]
+        public void DaysAreParsed(string input, int expectedDays)
+        {
+            var parsed = DurationParser.Parse(input);
+            Assert.That(parsed, Is.Not.Null);
+            Assert.That(parsed.Value, Is.EqualTo(TimeSpan.FromDays(expectedDays)));
+        }
+
+        [TestCase("1h", 1)]
+        [TestCase("3h", 3)]
+        [TestCase("12h", 12)]
+        [TestCase("123h", 123)]
+        public void HoursAreParsed(string input, int expectedHours)
+        {
+            var parsed = DurationParser.Parse(input);
+            Assert.That(parsed, Is.Not.Null);
+            Assert.That(parsed.Value, Is.EqualTo(TimeSpan.FromHours(expectedHours)));
+        }
+
+        [TestCase("1w", 1)]
+        [TestCase("3w", 3)]
+        [TestCase("12w", 12)]
+        [TestCase("123w", 123)]
+        public void WeeksAreParsed(string input, int expectedWeeks)
+        {
+            var parsed = DurationParser.Parse(input);
+            Assert.That(parsed, Is.Not.Null);
+            Assert.That(parsed.Value, Is.EqualTo(TimeSpan.FromDays(expectedWeeks * 7)));
+        }
+    }
+}

--- a/NuKeeper.Tests/DurationParserTests.cs
+++ b/NuKeeper.Tests/DurationParserTests.cs
@@ -28,7 +28,15 @@ namespace NuKeeper.Tests
         }
 
         [Test]
-        public void UnknownDurationTypeIsNotParsed()
+        public void ZeroIsParsed()
+        {
+            // when you send a zero, no point in specifying the units
+            var value = DurationParser.Parse("0");
+            Assert.That(value, Is.EqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void UnknownUnitsIsNotParsed()
         {
             var value = DurationParser.Parse("37x");
             Assert.That(value, Is.Null);

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -208,8 +208,6 @@ namespace NuKeeper.Tests.Engine
 
         private PackageUpdateSet UpdateFooFromOneVersion()
         {
-            var newPackage = LatestVersionOfPackageFoo();
-
             var currentPackages = new List<PackageInProject>
             {
                 new PackageInProject("foo", "1.0.1", PathToProjectOne()),
@@ -225,8 +223,6 @@ namespace NuKeeper.Tests.Engine
 
         private PackageUpdateSet UpdateBarFromTwoVersions()
         {
-            var newPackage = LatestVersionOfPackageBar();
-
             var currentPackages = new List<PackageInProject>
             {
                 new PackageInProject("bar", "1.0.1", PathToProjectOne()),
@@ -243,16 +239,6 @@ namespace NuKeeper.Tests.Engine
         private PackageIdentity LatestVersionOfPackageFoobar()
         {
             return new PackageIdentity("foobar", new NuGetVersion("1.2.3"));
-        }
-
-        private PackageIdentity LatestVersionOfPackageFoo()
-        {
-            return new PackageIdentity("foo", new NuGetVersion("1.2.3"));
-        }
-
-        private PackageIdentity LatestVersionOfPackageBar()
-        {
-            return new PackageIdentity("bar", new NuGetVersion("2.3.4"));
         }
 
         private PackagePath PathToProjectOne()

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -48,6 +48,10 @@ namespace NuKeeper.Configuration
         [OverriddenBy(ConfigurationSources.CommandLine, "change")]
         public VersionChange AllowedChange;
 
+        [JsonConfig("min_package_age"), Default("7d")]
+        [OverriddenBy(ConfigurationSources.CommandLine, "MinAge")]
+        public string MinPackageAge;
+
         [JsonConfig("fork_mode"), Default("PreferFork")]
         [OverriddenBy(ConfigurationSources.CommandLine, "fork")]
         public ForkMode ForkMode;

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -48,6 +48,13 @@ namespace NuKeeper.Configuration
                 EnsureTrailingSlash(settings.GithubApiEndpoint),
                 settings.GithubToken);
 
+            var minPackageAge = DurationParser.Parse(settings.MinPackageAge);
+            if (!minPackageAge.HasValue)
+            {
+                minPackageAge = TimeSpan.Zero;
+                Console.WriteLine($"Min package age '{settings.MinPackageAge}' could not be parsed");
+            }
+
             var userPrefs = new UserSettings
             {
                 AllowedChange = settings.AllowedChange,
@@ -57,7 +64,8 @@ namespace NuKeeper.Configuration
                 MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository,
                 NuGetSources = ReadNuGetSources(settings),
                 PackageIncludes = ParseRegex(settings.Include, nameof(settings.Include)),
-                PackageExcludes = ParseRegex(settings.Exclude, nameof(settings.Exclude))
+                PackageExcludes = ParseRegex(settings.Exclude, nameof(settings.Exclude)),
+                MinimumPackageAge = minPackageAge.Value
             };
 
             return new SettingsContainer

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using NuKeeper.Engine.Report;
 using NuKeeper.Logging;
@@ -14,6 +15,8 @@ namespace NuKeeper.Configuration
         public Regex PackageExcludes { get; set; }
 
         public int MaxPullRequestsPerRepository { get; set; }
+
+        public TimeSpan MinimumPackageAge { get; set; }
 
         public VersionChange AllowedChange { get; set; }
 

--- a/NuKeeper/DurationParser.cs
+++ b/NuKeeper/DurationParser.cs
@@ -11,6 +11,11 @@ namespace NuKeeper
                 return null;
             }
 
+            if (value == "0")
+            {
+                return TimeSpan.Zero;
+            }
+
             char suffix = value[value.Length - 1];
             var prefix = value.Substring(0, value.Length - 1);
 

--- a/NuKeeper/DurationParser.cs
+++ b/NuKeeper/DurationParser.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace NuKeeper
+{
+    public static class DurationParser
+    {
+        public static TimeSpan? Parse(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            char suffix = value[value.Length - 1];
+            var prefix = value.Substring(0, value.Length - 1);
+
+            var parsed = int.TryParse(prefix, out int count);
+            if (!parsed)
+            {
+                return null;
+            }
+
+            switch (suffix)
+            {
+                case 'h':
+                    return TimeSpan.FromHours(count);
+
+                case 'd':
+                    return TimeSpan.FromDays(count);
+
+                case 'w':
+                    return TimeSpan.FromDays(count * 7);
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -15,12 +15,22 @@ namespace NuKeeper.Git
 
         public IFolder WorkingFolder { get; }
 
-        public LibGit2SharpDriver(INuKeeperLogger logger,  
+        public LibGit2SharpDriver(INuKeeperLogger logger,
             IFolder workingFolder, Credentials gitCredentials, Identity userIdentity)
         {
+            if (workingFolder == null)
+            {
+                throw new ArgumentNullException(nameof(workingFolder));
+            }
+
             if (gitCredentials == null)
             {
                 throw new ArgumentNullException(nameof(gitCredentials));
+            }
+
+            if (userIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(userIdentity));
             }
 
             _logger = logger;

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
 | allowed_version_change           | No                | Yes (`change`)       | Major                               |
 | fork_mode                        | No                | Yes (`fork`)         | PreferFork                          |
 | report_mode                      | No                | Yes (`report`)       | Off                                 |
+| min_package_age                  | No                | Yes (`minage`)       | 7d                                  |
 
  * *github_api_endpoint* This is the api endpoint for the github instance you're targetting. If you are using an internal github server and not the public one, you must set it to the api url for your github server. The value will be e.g. `https://github.mycompany.com/api/v3`. This applies to all modes.
  * *max_pull_requests_per_repository* The maximum number of pull requests to raise on any repository.
@@ -78,6 +79,12 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
 
  * *fork_mode* Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below.
  * *report_mode* Values are `Off`, `On`, `ReportOnly`. This setting controls if a CSV report file of possible updates is generated. The default value `Off` means that no report is generated. `On` will generate it and then proceed with the run, `ReportOnly` is used to generate the report and then exit without making any PRs.
+
+ *  *min_package_age* In order to not consume packages immediately after they are released, exclude updates that do not meet a minimum age, 
+This age is the duration between the published date of the selected package update, to now. 
+The default is 7 days. A value can be expressed in command options as an integer and a unit suffix, 
+where the unit is one of `h` for hour, `d` for days, `w` for weeks. A zero with no unit is also allowed.
+e.g. `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks. 
 
 ### Command-line arguments
 
@@ -96,6 +103,7 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
 | change                           | No                         |
 | fork                             | No                         |
 | report                           | No                         |
+| minage                           | No                         |
 
  * *mode* One of `repository` or `organisation`, or synonyms `repo` and `org`. In `organisation` mode, all the repositories in that organisation will be processed.
  * *t* Overrides `NuKeeper_github_token` in environment variables.
@@ -110,6 +118,7 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
  * *change* Overrides  `allowed_version_change` in `config.json`
  * *fork* Overrides  `fork_mode` in `config.json`
  * *report* Overrides `report_mode` in `config.json`
+ * *minage* Overrides `min_package_age` in `config.json`
 
 
 ## When to use NuKeeper

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ $ dotnet run mode=organisation t=<GitToken> github_organisation_name=<OrgName>
  * *fork_mode* Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below.
  * *report_mode* Values are `Off`, `On`, `ReportOnly`. This setting controls if a CSV report file of possible updates is generated. The default value `Off` means that no report is generated. `On` will generate it and then proceed with the run, `ReportOnly` is used to generate the report and then exit without making any PRs.
 
- *  *min_package_age* In order to not consume packages immediately after they are released, exclude updates that do not meet a minimum age, 
-This age is the duration between the published date of the selected package update, to now. 
-The default is 7 days. A value can be expressed in command options as an integer and a unit suffix, 
+ *  *min_package_age* In order to not consume packages immediately after they are released, exclude updates that do not meet a minimum age. 
+The default is 7 days.
+This age is the duration between the published date of the selected package update and now. 
+ A value can be expressed in command options as an integer and a unit suffix, 
 where the unit is one of `h` for hour, `d` for days, `w` for weeks. A zero with no unit is also allowed.
-e.g. `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks. 
+Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks. 
 
 ### Command-line arguments
 


### PR DESCRIPTION
Don't take packages that were published a few minutes ago.
Filter packages to have a minimum age 
defined as duration between the published date of the selected package update, and now.

Default is 7 days, and can be expressed in command options as a number and unit, where unit is one of `h` for hour, `d` for days, `w` for weeks, or as a zero with no unit.

e.g. `0` = immediate, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
