### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.6.1

### DIFF
--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NUnit" Version="3.9.0">
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0">
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated an update of `Microsoft.NET.Test.Sdk` to `15.6.1` from `15.6.0`
`Microsoft.NET.Test.Sdk 15.6.1` was published at `2018-03-09T17:12:20Z`, 2 days ago

2 project updates:
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `Microsoft.NET.Test.Sdk` `15.6.1` from `15.6.0`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `Microsoft.NET.Test.Sdk` `15.6.1` from `15.6.0`

This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
