### PR TITLE
Link to the package version's page

### DIFF
--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -261,6 +261,7 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Contain("This is an automated update. Merge only if it passes tests"));
             Assert.That(report, Does.EndWith("**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper" + Environment.NewLine));
             Assert.That(report, Does.Contain("1.1.0"));
+            Assert.That(report, Does.Contain("[foo.bar 1.2.3 on NuGet.org](https://www.nuget.org/packages/foo.bar/1.2.3)"));
 
             Assert.That(report, Does.Not.Contain("Exception"));
             Assert.That(report, Does.Not.Contain("System.String"));

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -255,6 +255,17 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.StartWith("NuKeeper has generated a patch update of `foo.bar` to `1.1.9` from `1.1.0"));
         }
 
+        [Test]
+        public void OneUpdateWithInternalPackageSource()
+        {
+            var updates = UpdateSetForInternalSource(MakePackageForV110());
+
+            var report = CommitWording.MakeCommitDetails(updates);
+
+            Assert.That(report, Does.Not.Contain("on NuGet.org"));
+            Assert.That(report, Does.Not.Contain("www.nuget.org"));
+        }
+
         private static void AssertContainsStandardText(string report)
         {
             Assert.That(report, Does.StartWith("NuKeeper has generated a minor update of `foo.bar` to `1.2.3`"));
@@ -285,6 +296,17 @@ namespace NuKeeper.Tests.Engine
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
         }
+
+        private static PackageUpdateSet UpdateSetForInternalSource(params PackageInProject[] packages)
+        {
+            var newPackage = NewPackageFooBar123();
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(newPackage, "http://internalfeed.myco.com/api", publishedDate);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
 
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
         {

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -11,6 +11,8 @@ namespace NuKeeper.Tests.Engine
     [TestFixture]
     public class CommitWordingTests
     {
+        private const string NugetSource = "https://api.nuget.org/v3/index.json";
+
         [Test]
         public void MarkPullRequestTitle_UpdateIsCorrect()
         {
@@ -263,8 +265,8 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Not.Contain("Exception"));
             Assert.That(report, Does.Not.Contain("System.String"));
             Assert.That(report, Does.Not.Contain("Generic"));
-            Assert.That(report, Does.Not.Contain("["));
-            Assert.That(report, Does.Not.Contain("]"));
+            Assert.That(report, Does.Not.Contain("[ "));
+            Assert.That(report, Does.Not.Contain(" ]"));
             Assert.That(report, Does.Not.Contain("There is also a higher version"));
         }
 
@@ -277,12 +279,11 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, "someSource", publishedDate);
+            var latest = new PackageSearchMedatadata(newPackage, NugetSource, publishedDate);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
         }
-
 
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
         {
@@ -292,10 +293,10 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, "someSource", publishedAt);
+            var latest = new PackageSearchMedatadata(latestId, NugetSource, publishedAt);
 
             var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), "someSource", null);
+                NewPackageFooBar123(), NugetSource, null);
 
             var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper/Engine/CommitWording.cs
+++ b/NuKeeper/Engine/CommitWording.cs
@@ -83,15 +83,15 @@ namespace NuKeeper.Engine
                 builder.AppendLine(line);
             }
 
+            builder.AppendLine();
+            builder.AppendLine("This is an automated update. Merge only if it passes tests");
             if (SourceIsPublicNuget(updates.Selected.Source))
             {
                 builder.AppendLine();
                 builder.AppendLine(NugetPackageLink(updates.Selected.Identity));
             }
-
-            builder.AppendLine();
-            builder.AppendLine("This is an automated update. Merge only if it passes tests");
             builder.AppendLine("**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper");
+
             return builder.ToString();
         }
 
@@ -161,7 +161,7 @@ namespace NuKeeper.Engine
         private static string NugetPackageLink(PackageIdentity package)
         {
             var url = $"https://www.nuget.org/packages/{package.Id}/{package.Version}";
-            return $"[{package.Id} {package.Version}]({url})";
+            return $"[{package.Id} {package.Version} on NuGet.org]({url})";
         }
     }
 }

--- a/NuKeeper/Engine/CommitWording.cs
+++ b/NuKeeper/Engine/CommitWording.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.RepositoryInspection;
 
@@ -82,6 +83,12 @@ namespace NuKeeper.Engine
                 builder.AppendLine(line);
             }
 
+            if (SourceIsPublicNuget(updates.Selected.Source))
+            {
+                builder.AppendLine();
+                builder.AppendLine(NugetPackageLink(updates.Selected.Identity));
+            }
+
             builder.AppendLine();
             builder.AppendLine("This is an automated update. Merge only if it passes tests");
             builder.AppendLine("**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper");
@@ -142,6 +149,19 @@ namespace NuKeeper.Engine
         private static string CodeQuote(string value)
         {
             return "`" + value + "`";
+        }
+
+        private static bool SourceIsPublicNuget(string sourceUrl)
+        {
+            return
+                !string.IsNullOrWhiteSpace(sourceUrl) &&
+                sourceUrl.StartsWith("https://api.nuget.org/");
+        }
+
+        private static string NugetPackageLink(PackageIdentity package)
+        {
+            var url = $"https://www.nuget.org/packages/{package.Id}/{package.Version}";
+            return $"[{package.Id} {package.Version}]({url})";
         }
     }
 }


### PR DESCRIPTION
If the package (name and version) came from api.nuget.org
then it has a human-readable page that can be linked to in the commit report.