### PR TITLE
Update lib2gitsharp from one preview to another

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0081" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="SimpleInjector" Version="4.0.12" />
   </ItemGroup>


### PR DESCRIPTION
Lets try a later preview of [Lib2GitSharp](https://www.nuget.org/packages/LibGit2Sharp/), targeting NetStandard 2 this time.
To: `0.25.0-preview-0081`, 10 days ago, targets netstandard 2.0
From: `0.25.0-preview-0033`, 8  months ago,  targets netstandard 1.3
It's still not a released version, but there's a better chance of it working on linux.