### PR TITLE
Better ExternalProcessTests

### DIFF
--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NuKeeper.ProcessRunner;
 using NUnit.Framework;
@@ -49,18 +48,8 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
 
         private static async Task<ProcessOutput> RunExternalProcess(string command, string args, bool ensureSuccess)
         {
-            var process = ExternalProcess();
+            IExternalProcess process = new ExternalProcess();
             return await process.Run(".", command, args, ensureSuccess);
-        }
-
-        private static IExternalProcess ExternalProcess()
-        {
-            return new ExternalProcess();
-        }
-
-        private static bool IsWindows()
-        {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
 
         private static void AssertSuccess(ProcessOutput result)

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -12,11 +12,17 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
         [Test]
         public async Task ValidCommandShouldSucceed()
         {
-            var result = await RunExternalProcess(DirCommand(), false);
+            var result = await RunExternalProcess("whoami", false);
 
-            Assert.That(result.ExitCode, Is.EqualTo(0));
-            Assert.That(result.Output, Is.Not.Empty);
-            Assert.That(result.Success, Is.True);
+            AssertSuccess(result);
+        }
+
+        [Test]
+        public async Task DotNetCanRun()
+        {
+            var result = await RunExternalProcess("dotnet", "--version", true);
+
+            AssertSuccess(result);
         }
 
         [Test]
@@ -38,8 +44,13 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
 
         private static async Task<ProcessOutput> RunExternalProcess(string command, bool ensureSuccess)
         {
+            return await RunExternalProcess(command, "", ensureSuccess);
+        }
+
+        private static async Task<ProcessOutput> RunExternalProcess(string command, string args, bool ensureSuccess)
+        {
             var process = ExternalProcess();
-            return await process.Run(".", command, "", ensureSuccess);
+            return await process.Run(".", command, args, ensureSuccess);
         }
 
         private static IExternalProcess ExternalProcess()
@@ -47,14 +58,17 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
             return new ExternalProcess();
         }
 
-        private static string DirCommand()
-        {
-            return IsWindows() ? "cmdkey" : "ls";
-        }
-
         private static bool IsWindows()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        private static void AssertSuccess(ProcessOutput result)
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(0), result.ErrorOutput);
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Output, Is.Not.Empty);
+            Assert.That(result.ErrorOutput, Is.Empty);
         }
     }
 }


### PR DESCRIPTION
Found a command that can be run with no args on Win and unix and expect output text and success: `whoami`. So there's no need to decide based on OS.
Also can assume during the test run that `dotnet` is present, so can use that as a test of a command with args.