### PR TITLE
Better branch filter

### DIFF
--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -35,6 +35,7 @@ namespace NuKeeper
             container.Register<IGithub, OctokitClient>();
             container.Register<IGithubRepositoryDiscovery, GithubRepositoryDiscovery>();
             container.Register<IPackageUpdateSelection, PackageUpdateSelection>();
+            container.Register<IExistingBranchFilter, ExistingBranchFilter>();
             container.Register<IPackageUpdatesLookup, PackageUpdatesLookup>();
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
             container.Register<IPackageVersionsLookup, PackageVersionsLookup>();

--- a/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
@@ -1,0 +1,23 @@
+using NuKeeper.Git;
+using NuKeeper.Github;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine.Packages
+{
+    public class ExistingBranchFilter : IExistingBranchFilter
+    {
+        private readonly IGithub _github;
+
+        public ExistingBranchFilter(IGithub github)
+        {
+            _github = github;
+        }
+
+        public bool HasExistingBranch(IGitDriver git, PackageUpdateSet packageUpdateSet)
+        {
+            var qualifiedBranchName = "origin/" + BranchNamer.MakeName(packageUpdateSet);
+            return git.BranchExists(qualifiedBranchName);
+        }
+
+    }
+}

--- a/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
@@ -1,0 +1,10 @@
+using NuKeeper.Git;
+using NuKeeper.RepositoryInspection;
+
+namespace NuKeeper.Engine.Packages
+{
+    public interface IExistingBranchFilter
+    {
+        bool HasExistingBranch(IGitDriver git, PackageUpdateSet packageUpdateSet);
+    }
+}

--- a/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
@@ -1,10 +1,13 @@
-using NuKeeper.Git;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine.Packages
 {
     public interface IExistingBranchFilter
     {
-        bool HasExistingBranch(IGitDriver git, PackageUpdateSet packageUpdateSet);
+        Task<IEnumerable<PackageUpdateSet>> CanMakeBranchFor(
+            ForkData pushFork,
+            IEnumerable<PackageUpdateSet> packageUpdateSets);
     }
 }

--- a/NuKeeper/Engine/Packages/IPackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/IPackageUpdateSelection.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Generic;
-using NuKeeper.Git;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NuKeeper.RepositoryInspection;
 
 namespace NuKeeper.Engine.Packages
 {
     public interface IPackageUpdateSelection
     {
-        List<PackageUpdateSet> SelectTargets(
-            IGitDriver git,
+        Task<List<PackageUpdateSet>> SelectTargets(
+            ForkData pushFork,
             IEnumerable<PackageUpdateSet> potentialUpdates);
     }
 }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -76,7 +76,7 @@ namespace NuKeeper.Engine
                 return;
             }
 
-            var targetUpdates = _updateSelection.SelectTargets(git, updates);
+            var targetUpdates = await _updateSelection.SelectTargets(repository.Push, updates);
 
             if (updates.Count == 0)
             {

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -139,6 +139,7 @@ namespace NuKeeper.Git
                 var localBranch = repo.Branches[branchName];
                 var remote = repo.Network.Remotes[remoteName];
 
+
                 repo.Branches.Update(localBranch,
                     b => b.Remote = remote.Name,
                     b => b.UpstreamBranch = localBranch.CanonicalName);

--- a/NuKeeper/Github/IGithub.cs
+++ b/NuKeeper/Github/IGithub.cs
@@ -16,5 +16,7 @@ namespace NuKeeper.Github
         Task<Repository> GetUserRepository(string userName, string repositoryName);
 
         Task<Repository> MakeUserFork(string owner, string repositoryName);
+
+        Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName);
     }
 }

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -74,9 +74,14 @@ namespace NuKeeper.Github
 
         public async Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName)
         {
-            var branch = await _client.Repository.Branch.Get(userName, repositoryName, branchName);
-
-            return branch;
+            try
+            {
+                return await _client.Repository.Branch.Get(userName, repositoryName, branchName);
+            }
+            catch (NotFoundException)
+            {
+                return null;
+            }
         }
 
         public async Task OpenPullRequest(ForkData target, NewPullRequest request)

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -76,10 +76,13 @@ namespace NuKeeper.Github
         {
             try
             {
-                return await _client.Repository.Branch.Get(userName, repositoryName, branchName);
+                var result = await _client.Repository.Branch.Get(userName, repositoryName, branchName);
+                _logger.Verbose($"Branch found for {userName} / {repositoryName} / {branchName}");
+                return result;
             }
             catch (NotFoundException)
             {
+                _logger.Verbose($"No branch found for {userName} / {repositoryName} / {branchName}");
                 return null;
             }
         }

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -70,7 +70,13 @@ namespace NuKeeper.Github
                 _logger.Error("User fork not created", ex);
                 return null;
             }
+        }
 
+        public async Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName)
+        {
+            var branch = await _client.Repository.Branch.Get(userName, repositoryName, branchName);
+
+            return branch;
         }
 
         public async Task OpenPullRequest(ForkData target, NewPullRequest request)

--- a/NuKeeper/LinqAsync.cs
+++ b/NuKeeper/LinqAsync.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuKeeper
+{
+    public static class LinqAsync
+    {
+        /// <summary>
+        /// Filter a list by an async operation on each element
+        /// Code from: https://codereview.stackexchange.com/a/32162
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public static async Task<IEnumerable<T>> WhereAsync<T>(this IEnumerable<T> items, Func<T, Task<bool>> predicate)
+        {
+            var itemTaskList = items
+                .Select(item => new { Item = item, PredTask = predicate.Invoke(item) })
+                .ToList();
+
+            await Task.WhenAll(itemTaskList.Select(x => x.PredTask));
+
+            return itemTaskList
+                .Where(x => x.PredTask.Result)
+                .Select(x => x.Item);
+        }
+    }
+}


### PR DESCRIPTION
Replace the git check for an existing local branch,  as it's no longer useful, with one that works. 

It should now be an inspection of the push fork to see if it already has an existing remote branch with that name, and move on to other updates in that case.

This is surprisingly not at all simple, as the old check was sync and the new check is async.  Each package checks for an existing branch on github, and these are async operations. You need to pass data around more, need new methods and an async list Filter.