### PR TITLE
Automatic update of LibGit2Sharp to 0.25.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0081" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="SimpleInjector" Version="4.0.12" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a out of beta update of `LibGit2Sharp` to `0.25.0` from `0.25.0-preview-0081`
`LibGit2Sharp 0.25.0` was published at `2018-03-26T17:33:18Z`, 8 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `LibGit2Sharp` `0.25.0` from `0.25.0-preview-0081`

This is an automated update. Merge only if it passes tests

[LibGit2Sharp 0.25.0 on NuGet.org](https://www.nuget.org/packages/LibGit2Sharp/0.25.0)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
