### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.6.2

### DIFF
--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="NUnit" Version="3.10.1">
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1">
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `15.6.2` from `15.6.1`
`Microsoft.NET.Test.Sdk 15.6.2` was published at `2018-03-28T05:53:26Z`, 7 days ago

2 project updates:
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `Microsoft.NET.Test.Sdk` `15.6.2` from `15.6.1`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `Microsoft.NET.Test.Sdk` `15.6.2` from `15.6.1`

This is an automated update. Merge only if it passes tests

[Microsoft.NET.Test.Sdk 15.6.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/15.6.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
