### PR TITLE
Automatic update of SimpleInjector to 4.1.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0081" />
     <PackageReference Include="Octokit" Version="0.29.0" />
-    <PackageReference Include="SimpleInjector" Version="4.0.12" />
+    <PackageReference Include="SimpleInjector" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="config.json">


### PR DESCRIPTION
NuKeeper has generated a minor update of `SimpleInjector` to `4.1.0` from `4.0.12`
`SimpleInjector 4.1.0` was published at `2018-03-23T20:34:36Z`, 11 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector` `4.1.0` from `4.0.12`

This is an automated update. Merge only if it passes tests

[SimpleInjector 4.1.0 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/4.1.0)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
