### PR TITLE
Automatic update of Newtonsoft.Json to 11.0.2

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0081" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Newtonsoft.Json` to `11.0.2` from `11.0.1`
`Newtonsoft.Json 11.0.2` was published at `2018-03-24T20:18:14Z`, 10 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Newtonsoft.Json` `11.0.2` from `11.0.1`

This is an automated update. Merge only if it passes tests

[Newtonsoft.Json 11.0.2 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/11.0.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
