### PR TITLE
Automatic update of SimpleInjector to 4.1.1

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="Octokit" Version="0.29.0" />
-    <PackageReference Include="SimpleInjector" Version="4.1.0" />
+    <PackageReference Include="SimpleInjector" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="config.json">


### PR DESCRIPTION
NuKeeper has generated a patch update of `SimpleInjector` to `4.1.1` from `4.1.0`
`SimpleInjector 4.1.1` was published at `2018-04-04T16:08:48Z`, 7 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector` `4.1.1` from `4.1.0`

This is an automated update. Merge only if it passes tests

[SimpleInjector 4.1.1 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/4.1.1)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
