### PR TITLE
Failure to update .NET AspNet WebApi projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,4 @@ _ReSharper*/
 
 # Custom
 NuKeeper/Properties/launchSettings.json
-
-
+*.orig

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ mono: none
 dist: trusty
 dotnet: 2.1.105
 script:
-  - dotnet build -c Release -f netcoreapp2.0
+  - dotnet build -c Release -f netcoreapp2.0 NuKeeper.sln /m:1
   - dotnet test -c Release -f netcoreapp2.0 NuKeeper.Tests/NuKeeper.Tests.csproj --filter "TestCategory!=WindowsOnly"
   - dotnet test -c Release -f netcoreapp2.0 NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj --filter "TestCategory!=WindowsOnly"
   - dotnet test -c Release -f netcoreapp2.0 NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -22,8 +22,13 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
     <VSToolsPath Condition=""'$(VSToolsPath)' == ''"">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- without the second package, 'dotnet add' will refuse to run -->
+    <!-- as the heuristic will consider this a packages.config project -->
+    <PackageReference Include=""Newtonsoft.Json"" Version=""11.0.2"" />
+  </ItemGroup>
   <Import Project=""$(MSBuildBinPath)\Microsoft.CSharp.targets"" />
-  <Import Project=""$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets"" Condition=""'$(VSToolsPath)' != ''"" />
+  <Import Project=""$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets"" Condition=""Exists('$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets')"" />
 </Project>";
 
         private readonly string _testDotNetCoreProject =
@@ -55,7 +60,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 </Project>";
 
         [Test]
-        [Ignore("Known failure, issue #239")]
         public async Task ShouldNotThrowOnWebProjectMixedStyleUpdates()
         {
             await ExecuteValidUpdateTest(_testWebApiProject);

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Threading.Tasks;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.NuGet.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.NuGet.Process
+{
+    [TestFixture]
+    public class UpdateProjectImportsCommandTests
+    {
+        private readonly string _testWebApiProject =
+            @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
+  <Import Project=""$(MSBuildBinPath)\Microsoft.CSharp.targets"" />
+  <Import Project=""$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets"" Condition=""'$(VSToolsPath)' != ''"" />
+  <Import Project=""$(VSToolsPath)\DummyImportWithoutCondition\Microsoft.WebApplication.targets"" />
+</Project>";
+
+        private readonly string _unpatchedImport =
+            @"<Import Project=""$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets"" Condition=""'$(VSToolsPath)' != ''"" />";
+
+        private readonly string _patchedImport =
+            @"<Import Project=""$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets"" Condition=""Exists('$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets')"" />";
+
+        [Test]
+        public async Task ShouldUpdateConditionOnTaskImport()
+        {
+            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory,
+                nameof(ShouldUpdateConditionOnTaskImport));
+
+            Directory.CreateDirectory(workDirectory);
+            var projectName = "WebApiProject.csproj";
+            var projectPath = Path.Combine(workDirectory, projectName);
+            await File.WriteAllTextAsync(projectPath, _testWebApiProject);
+
+            var subject = new UpdateProjectImportsCommand();
+
+            await subject.Invoke(null, null,
+                new PackageInProject("acme", "1",
+                    new PackagePath(workDirectory, projectName, PackageReferenceType.ProjectFileOldStyle)));
+
+            var updatedContents = await File.ReadAllTextAsync(projectPath);
+
+            Assert.That(updatedContents, Does.Not.Contain(_unpatchedImport));
+            Assert.That(updatedContents, Does.Contain(_patchedImport));
+        }
+    }
+}

--- a/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
@@ -10,7 +10,7 @@ using NuKeeper.ProcessRunner;
 
 namespace NuKeeper.NuGet.Process
 {
-    public class DotNetUpdatePackageCommand : IUpdatePackageCommand
+    public class DotNetUpdatePackageCommand : IPackageCommand
     {
         private readonly IExternalProcess _externalProcess;
         private readonly INuKeeperLogger _logger;

--- a/NuKeeper/NuGet/Process/IFileRestoreCommand.cs
+++ b/NuKeeper/NuGet/Process/IFileRestoreCommand.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace NuKeeper.NuGet.Process
 {
-    public interface IFileRestoreCommand
+    public interface IFileRestoreCommand : IPackageCommand
     {
         Task Invoke(FileInfo file);
     }

--- a/NuKeeper/NuGet/Process/IPackageCommand.cs
+++ b/NuKeeper/NuGet/Process/IPackageCommand.cs
@@ -4,7 +4,7 @@ using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.NuGet.Process
 {
-    public interface IUpdatePackageCommand
+    public interface IPackageCommand
     {
         Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage);
     }

--- a/NuKeeper/NuGet/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper/NuGet/Process/NuGetFileRestoreCommand.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using NuGet.Versioning;
 using NuKeeper.Configuration;
 using NuKeeper.Inspection.Formats;
 using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.ProcessRunner;
 
 namespace NuKeeper.NuGet.Process
@@ -59,6 +61,11 @@ namespace NuKeeper.NuGet.Process
             {
                 _logger.Verbose($"Nuget restore failed on {file.DirectoryName} {file.Name}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
             }
+        }
+
+        public async Task Invoke(NuGetVersion selectedVersion, string source, PackageInProject current)
+        {
+            await Invoke(current.Path.Info);
         }
 
         private static string GetSourcesCommandLine(IEnumerable<string> sources)

--- a/NuKeeper/NuGet/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/NuGetUpdatePackageCommand.cs
@@ -11,7 +11,7 @@ using NuKeeper.ProcessRunner;
 
 namespace NuKeeper.NuGet.Process
 {
-    public class NuGetUpdatePackageCommand : IUpdatePackageCommand
+    public class NuGetUpdatePackageCommand : IPackageCommand
     {
         private readonly IExternalProcess _externalProcess;
         private readonly INuKeeperLogger _logger;
@@ -45,7 +45,7 @@ namespace NuKeeper.NuGet.Process
             }
 
             var sources = GetSourcesCommandLine(_sources);
-            var arguments = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
+            var arguments = $"update {currentPackage.Path.RelativePath} -Id {currentPackage.Id} -Version {newVersion} {sources}";
             _logger.Verbose(arguments);
 
             await _externalProcess.Run(dirName, nuget, arguments, true);

--- a/NuKeeper/NuGet/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/NuGetUpdatePackageCommand.cs
@@ -45,7 +45,7 @@ namespace NuKeeper.NuGet.Process
             }
 
             var sources = GetSourcesCommandLine(_sources);
-            var arguments = $"update {currentPackage.Path.RelativePath} -Id {currentPackage.Id} -Version {newVersion} {sources}";
+            var arguments = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
             _logger.Verbose(arguments);
 
             await _externalProcess.Run(dirName, nuget, arguments, true);

--- a/NuKeeper/NuGet/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper/NuGet/Process/UpdateProjectImportsCommand.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Versioning;
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.NuGet.Process
+{
+    public class UpdateProjectImportsCommand : IPackageCommand
+    {
+        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        {
+            using (var projectContents = File.Open(currentPackage.Path.FullName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                await UpdateConditionsOnProjects(projectContents);
+            }
+        }
+
+        private async Task UpdateConditionsOnProjects(Stream fileContents)
+        {
+            var xml = XDocument.Load(fileContents);
+            var ns = xml.Root.GetDefaultNamespace();
+
+            var project = xml.Element(ns + "Project");
+
+            if (project == null)
+            {
+                return;
+            }
+
+            var imports = project.Elements(ns + "Import");
+            var importsWithToolsPath = imports.Where(i => i.Attributes("Project").Any(a => a.Value.Contains("$(VSToolsPath)"))).ToList();
+            var importsWithoutCondition = importsWithToolsPath.Where(i => !i.Attributes("Condition").Any());
+            var importsWithBrokenVsToolsCondition = importsWithToolsPath.Where(i =>
+                i.Attributes("Condition").Any(a => a.Value == "\'$(VSToolsPath)\' != \'\'"));
+
+            bool saveRequired = false;
+            foreach (var importToFix in importsWithBrokenVsToolsCondition.Concat(importsWithoutCondition))
+            {
+                saveRequired = true;
+                UpdateImportNode(importToFix);
+            }
+
+            if(saveRequired)
+            {
+                fileContents.Seek(0, SeekOrigin.Begin);
+                await xml.SaveAsync(fileContents, SaveOptions.None, CancellationToken.None);
+            }
+        }
+
+        private static void UpdateImportNode(XElement importToFix)
+        {
+            var importPath = importToFix.Attribute("Project").Value;
+            var condition = $"Exists('{importPath}')";
+            if (!importToFix.Attributes("Condition").Any())
+            {
+                importToFix.Add(new XAttribute("Condition", condition));
+            }
+            else
+            {
+                importToFix.Attribute("Condition").Value = condition;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When trying to run NuKeeper on a .NET "classic" WebApi project that has been updated to use PackageReference, attempting to update packages will fail.

> error MSB4019: The imported project "C:\Program Files\dotnet\sdk\2.1.104\Microsoft\VisualStudio\v15.0\WebApplications\Microsoft.WebApplication.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.

That's because a) we can't run NuGet on that (refuses to run without packages.config) and b) can't run dotnet add/remove as those will fail to import the webapi targets file. The workaround is to find Imports that have the problematic (unset) VSToolsPath variable reference and change them to conditional imports. They will work the same in VS build (as the import target is found then) but will be skipped by the dotnet core update commands, allowing NuKeeper to handle the project.