### PR TITLE
Automatic update of NuGet.CommandLine to 4.6.2

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
+    <PackageReference Include="NuGet.CommandLine" Version="4.6.2" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="SimpleInjector" Version="4.1.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.CommandLine` to `4.6.2` from `4.5.1`
`NuGet.CommandLine 4.6.2` was published at `2018-04-06T21:30:10Z`, 8 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.CommandLine` `4.6.2` from `4.5.1`

This is an automated update. Merge only if it passes tests

[NuGet.CommandLine 4.6.2 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/4.6.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
