### PR TITLE
Specify project file path for dotnet commands.

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -67,7 +67,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
         }
 
         [Test]
-        [Ignore("Known failure, issue #243")]
         public async Task ShouldUpdateDuplicateProject()
         {
             const string name = nameof(ShouldUpdateDuplicateProject);

--- a/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
@@ -27,9 +27,9 @@ namespace NuKeeper.NuGet.Process
             var dirName = currentPackage.Path.Info.DirectoryName;
             var sources = GetSourcesCommandLine(_sources);
 
-            await _externalProcess.Run(dirName, "dotnet", $"restore {sources}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"remove package {currentPackage.Id}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"add package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"restore {sources} {currentPackage.Path.RelativePath}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"remove {currentPackage.Path.RelativePath} package {currentPackage.Id}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"add {currentPackage.Path.RelativePath} package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
         }
 
         private static string GetSourcesCommandLine(IEnumerable<string> sources)


### PR DESCRIPTION
Fixes #243 (multiple projects in same folder breaks updates)