### PR TITLE
PackageSearchMedatadata should keep the package's Dependencies

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -143,7 +143,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         private static void ApiHasNewVersionForPackage(IApiPackageLookup lookup, string packageName)
         {
             var responseMetaData = new PackageSearchMedatadata(
-                new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test", DateTimeOffset.Now);
+                new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test",
+                DateTimeOffset.Now, null);
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
                 .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData, responseMetaData));

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageLookupResultReporterTests.cs
@@ -36,7 +36,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var fooMetadata = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)), 
-                "someSource", DateTimeOffset.Now);
+                "someSource", DateTimeOffset.Now, null);
 
             var data = new PackageLookupResult(VersionChange.Major, fooMetadata, fooMetadata, fooMetadata);
 
@@ -57,7 +57,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var fooMetadata = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
-                "someSource", DateTimeOffset.Now);
+                "someSource", DateTimeOffset.Now, null);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMetadata, fooMetadata, fooMetadata);
 
@@ -79,10 +79,10 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var fooMajor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
-                "someSource", DateTimeOffset.Now);
+                "someSource", DateTimeOffset.Now, null);
             var fooMinor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
-                "someSource", DateTimeOffset.Now);
+                "someSource", DateTimeOffset.Now, null);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMajor, fooMinor, null);
 
@@ -103,7 +103,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var fooMajor = new PackageSearchMedatadata(
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
-                "someSource", DateTimeOffset.Now);
+                "someSource", DateTimeOffset.Now, null);
 
             var data = new PackageLookupResult(VersionChange.Minor, fooMajor, null, null);
 

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
@@ -85,7 +85,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         {
             var version = new NuGetVersion(major, minor, patch);
             var metadata = new PackageIdentity("TestPackage", version);
-            return new PackageSearchMedatadata(metadata, "someSource", DateTimeOffset.Now);
+            return new PackageSearchMedatadata(metadata, "someSource", DateTimeOffset.Now, null);
         }
     }
 }

--- a/NuKeeper.Inspection.Tests/Report/AvailableUpdatesReporterTests.cs
+++ b/NuKeeper.Inspection.Tests/Report/AvailableUpdatesReporterTests.cs
@@ -107,7 +107,7 @@ namespace NuKeeper.Inspection.Tests.Report
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(package, "someSource", publishedDate);
+            var latest = new PackageSearchMedatadata(package, "someSource", publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -65,7 +65,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         public void OneUpdate_IsValid()
         {
             var fooVersionFour = new PackageIdentity("foo", VersionFour());
-            var highest = new PackageSearchMedatadata(fooVersionFour, ASource, DateTimeOffset.Now);
+            var highest = new PackageSearchMedatadata(fooVersionFour, ASource, DateTimeOffset.Now, null);
 
             var currentPackages = new List<PackageInProject>
             {
@@ -243,7 +243,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             return new PackageSearchMedatadata(
                 LatestVersionOfPackageFoo(),
-                ASource, DateTimeOffset.Now);
+                ASource, DateTimeOffset.Now, null);
         }
 
         private NuGetVersion VersionFour()

--- a/NuKeeper.Inspection/NuGetApi/PackageSearchMedatadata.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageSearchMedatadata.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NuGet.Packaging.Core;
 using NuKeeper.Inspection.Formats;
 
@@ -9,7 +11,8 @@ namespace NuKeeper.Inspection.NuGetApi
         public PackageSearchMedatadata(
             PackageIdentity identity,
             string source,
-            DateTimeOffset? published)
+            DateTimeOffset? published,
+            IEnumerable<PackageDependency> dependencies)
         {
             if (identity == null)
             {
@@ -24,11 +27,15 @@ namespace NuKeeper.Inspection.NuGetApi
             Identity = identity;
             Source = source;
             Published = published;
+
+            Dependencies = dependencies?.ToList() ?? new List<PackageDependency>();
         }
 
         public PackageIdentity Identity { get; }
         public string Source { get; }
         public DateTimeOffset? Published { get; }
+
+        public IReadOnlyCollection<PackageDependency> Dependencies { get; }
 
         public override string ToString()
         {

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -34,7 +34,7 @@ namespace NuKeeper.Inspection.NuGetApi
             var sourceRepository = BuildSourceRepository(source);
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
             var metadatas = await FindPackage(metadataResource, packageName);
-            return metadatas.Select(m => new PackageSearchMedatadata(m.Identity, source, m.Published));
+            return metadatas.Select(m => BuildData(source, m));
         }
 
         private static SourceRepository BuildSourceRepository(string source)
@@ -52,6 +52,15 @@ namespace NuKeeper.Inspection.NuGetApi
         {
             return await metadataResource
                 .GetMetadataAsync(packageName, false, false, _logger, CancellationToken.None);
+        }
+
+        private PackageSearchMedatadata BuildData(string source, IPackageSearchMetadata metadata)
+        {
+            var deps = metadata.DependencySets
+                .SelectMany(set => set.Packages)
+                .Distinct();
+
+            return new PackageSearchMedatadata(metadata.Identity, source, metadata.Published, deps);
         }
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -34,7 +34,7 @@ namespace NuKeeper.Inspection.NuGetApi
             var sourceRepository = BuildSourceRepository(source);
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
             var metadatas = await FindPackage(metadataResource, packageName);
-            return metadatas.Select(m => BuildData(source, m));
+            return metadatas.Select(m => BuildPackageData(source, m));
         }
 
         private static SourceRepository BuildSourceRepository(string source)
@@ -54,7 +54,7 @@ namespace NuKeeper.Inspection.NuGetApi
                 .GetMetadataAsync(packageName, false, false, _logger, CancellationToken.None);
         }
 
-        private PackageSearchMedatadata BuildData(string source, IPackageSearchMetadata metadata)
+        private static PackageSearchMedatadata BuildPackageData(string source, IPackageSearchMetadata metadata)
         {
             var deps = metadata.DependencySets
                 .SelectMany(set => set.Packages)

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -47,6 +47,25 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
             Assert.That(latest.Published.HasValue, Is.True);
         }
 
+        [Test]
+        public async Task PackageShouldHaveDependencies()
+        {
+            var lookup = BuildPackageLookup();
+
+            var packages = await lookup.Lookup("Moq");
+
+            Assert.That(packages, Is.Not.Null);
+
+            var packageList = packages.ToList();
+            var latest = packageList
+                .OrderByDescending(p => p.Identity.Version)
+                .FirstOrDefault();
+
+            Assert.That(latest, Is.Not.Null);
+            Assert.That(latest.Dependencies, Is.Not.Null);
+            Assert.That(latest.Dependencies, Is.Not.Empty);
+        }
+
         private IPackageVersionsLookup BuildPackageLookup()
         {
             return new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings());

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -291,7 +291,7 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, NugetSource, publishedDate);
+            var latest = new PackageSearchMedatadata(newPackage, NugetSource, publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
@@ -301,7 +301,7 @@ namespace NuKeeper.Tests.Engine
         {
             var newPackage = NewPackageFooBar123();
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, "http://internalfeed.myco.com/api", publishedDate);
+            var latest = new PackageSearchMedatadata(newPackage, "http://internalfeed.myco.com/api", publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
@@ -316,10 +316,10 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, NugetSource, publishedAt);
+            var latest = new PackageSearchMedatadata(latestId, NugetSource, publishedAt, null);
 
             var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), NugetSource, null);
+                NewPackageFooBar123(), NugetSource, null, null);
 
             var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -270,7 +270,7 @@ namespace NuKeeper.Tests.Engine
                 new PackageInProject("foobar", "1.0.1", PathToProjectTwo())
             };
 
-            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now);
+            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, currentPackages);
@@ -287,7 +287,8 @@ namespace NuKeeper.Tests.Engine
             };
 
             var matchVersion = new NuGetVersion("4.0.0");
-            var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion), "ASource", pubDate);
+            var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
+                "ASource", pubDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
             return new PackageUpdateSet(updates, currentPackages);
@@ -304,7 +305,7 @@ namespace NuKeeper.Tests.Engine
             };
 
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
-            var match = new PackageSearchMedatadata(matchId, "ASource", pubDate);
+            var match = new PackageSearchMedatadata(matchId, "ASource", pubDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
             return new PackageUpdateSet(updates, currentPackages);

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdateSortTests.cs
@@ -203,7 +203,7 @@ namespace NuKeeper.Tests.Engine.Packages
 
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, DateTimeOffset published, params PackageInProject[] packages)
         {
-            var latest = new PackageSearchMedatadata(package, "someSource", published);
+            var latest = new PackageSearchMedatadata(package, "someSource", published, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/VersionChangesTests.cs
+++ b/NuKeeper.Tests/Engine/VersionChangesTests.cs
@@ -203,7 +203,7 @@ namespace NuKeeper.Tests.Engine
         {
             var version = new NuGetVersion(major, minor, patch);
             var packageId = new PackageIdentity("foo", version);
-            return new PackageSearchMedatadata(packageId, "aSource", DateTimeOffset.Now);
+            return new PackageSearchMedatadata(packageId, "aSource", DateTimeOffset.Now, null);
         }
     }
 }


### PR DESCRIPTION
keep some of the data that the nuget api gives us about what a package depends upon.
PackageSearchMedatadata should keep the package's Dependencies
This will allow sorting where the dependency is update first,
and may be necessary for batching