### PR TITLE
Verbose errors

### DIFF
--- a/NuKeeper.Inspection/Logging/ConsoleLogger.cs
+++ b/NuKeeper.Inspection/Logging/ConsoleLogger.cs
@@ -20,6 +20,10 @@ namespace NuKeeper.Inspection.Logging
             else
             {
                 Console.Error.WriteLine($"{message} {ex.GetType().Name} : {ex.Message}");
+                if (_logLevel == LogLevel.Verbose)
+                {
+                    Console.Error.WriteLine(ex.StackTrace);
+                }
             }
         }
 


### PR DESCRIPTION
When logging is verbose and an error is logged, dump the stack trace
There are times when you want that stack trace
I have one of those times