### PR TITLE
DotNetUpdatePackageCommand

### DIFF
--- a/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
@@ -29,13 +29,15 @@ namespace NuKeeper.NuGet.Process
         public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
         {
             var dirName = currentPackage.Path.Info.DirectoryName;
+            var projectPath = currentPackage.Path.RelativePath;
+
             var sources = GetSourcesCommandLine(_sources);
 
-            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {dirName} {currentPackage.Path.RelativePath} from sources {sources}");
+            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {dirName} {projectPath} from sources {sources}");
 
-            await _externalProcess.Run(dirName, "dotnet", $"restore {sources} {currentPackage.Path.RelativePath}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"remove {currentPackage.Path.RelativePath} package {currentPackage.Id}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"add {currentPackage.Path.RelativePath} package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"restore {projectPath} {sources}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"remove {projectPath} package {currentPackage.Id}", true);
+            await _externalProcess.Run(dirName, "dotnet", $"add {projectPath} package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
         }
 
         private static string GetSourcesCommandLine(IEnumerable<string> sources)

--- a/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper/NuGet/Process/DotNetUpdatePackageCommand.cs
@@ -28,16 +28,16 @@ namespace NuKeeper.NuGet.Process
 
         public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
         {
-            var dirName = currentPackage.Path.Info.DirectoryName;
-            var projectPath = currentPackage.Path.RelativePath;
+            var projectPath = currentPackage.Path.Info.DirectoryName;
+            var projectFileName = currentPackage.Path.Info.Name;
 
             var sources = GetSourcesCommandLine(_sources);
 
-            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {dirName} {projectPath} from sources {sources}");
+            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {projectPath} {projectFileName} from sources {sources}");
 
-            await _externalProcess.Run(dirName, "dotnet", $"restore {projectPath} {sources}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"remove {projectPath} package {currentPackage.Id}", true);
-            await _externalProcess.Run(dirName, "dotnet", $"add {projectPath} package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
+            await _externalProcess.Run(projectPath, "dotnet", $"restore {projectFileName} {sources}", true);
+            await _externalProcess.Run(projectPath, "dotnet", $"remove {projectFileName} package {currentPackage.Id}", true);
+            await _externalProcess.Run(projectPath, "dotnet", $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {packageSource}", true);
         }
 
         private static string GetSourcesCommandLine(IEnumerable<string> sources)


### PR DESCRIPTION
Investigating #257

* extract a`projectPath ` and `projectFileName` vars for repeated expression
* path comes before flags in `restore` as per other commands. Docs say so: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?tabs=netcore2x