### PR TITLE
Updating dependencies in nuspec files

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
@@ -1,0 +1,144 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using NuGet.Versioning;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class NuspecFileReaderTests
+    {
+        const string PackagesFileWithSinglePackage =
+            @"<package><metadata><dependencies>
+<dependency id=""foo"" version=""1.2.3.4"" /></dependencies></metadata></package>";
+
+        private const string PackagesFileWithTwoPackages = @"<package><metadata><dependencies>
+<dependency id=""foo"" version=""1.2.3.4"" />
+<dependency id=""bar"" version=""2.3.4.5"" /></dependencies></metadata></package>";
+
+        [Test]
+        public void EmptyPackagesListShouldBeParsed()
+        {
+            const string emptyContents =
+                @"<package/>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(emptyContents), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Not.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeCorrect()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package.Id, Is.EqualTo("foo"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.Nuspec));
+        }
+
+        [Test]
+        public void TwoPackagesShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            PackageAssert.IsPopulated(packages[0]);
+            PackageAssert.IsPopulated(packages[1]);
+        }
+
+        [Test]
+        public void TwoPackagesShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+
+            Assert.That(packages[1].Id, Is.EqualTo("bar"));
+            Assert.That(packages[1].Version, Is.EqualTo(new NuGetVersion("2.3.4.5")));
+        }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            var path = TempPath();
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), path);
+
+            foreach (var package in packages)
+            {
+                PackageAssert.IsPopulated(package);
+            }
+
+            Assert.That(packages.Select(p => p.Path), Is.All.EqualTo(path));
+        }
+
+        [Test]
+        public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
+        {
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion");
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(badVersion), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(1));
+            PackageAssert.IsPopulated(packages[0]);
+        }
+
+        private PackagePath TempPath()
+        {
+            return new PackagePath(
+                OsSpecifics.GenerateBaseDirectory(),
+                Path.Combine("src", "sample.nuspec"),
+                PackageReferenceType.Nuspec);
+        }
+
+        private NuspecFileReader MakeReader()
+        {
+            return new NuspecFileReader(new NullNuKeeperLogger());
+        }
+
+        private Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/IPackageReferenceFinder.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/IPackageReferenceFinder.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public interface IPackageReferenceFinder
+    {
+        IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath);
+
+        IEnumerable<string> GetFilePatterns();
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuKeeper.Inspection.Logging;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public class NuspecFileReader : IPackageReferenceFinder
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public NuspecFileReader(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
+        {
+            var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.Nuspec);
+            using (var fileContents = File.OpenRead(packagePath.FullName))
+            {
+                return Read(fileContents, packagePath);
+            }
+        }
+
+        public IEnumerable<string> GetFilePatterns()
+        {
+            return new[] {"*.nuspec"};
+        }
+
+        public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)
+        {
+            var xml = XDocument.Load(fileContents);
+
+            var packagesNode = xml.Element("package")?.Element("metadata")?.Element("dependencies");
+            if (packagesNode == null)
+            {
+                return Enumerable.Empty<PackageInProject>();
+            }
+
+            var packageNodeList = packagesNode.Elements()
+                .Where(x => x.Name == "dependency");
+
+            return packageNodeList
+                .Select(el => XmlToPackage(el, path))
+                .Where(el => el != null)
+                .ToList();
+        }
+
+        private PackageInProject XmlToPackage(XElement el, PackagePath path)
+        {
+            try
+            {
+                var id = el.Attribute("id")?.Value;
+                var version = el.Attribute("version")?.Value;
+
+                return new PackageInProject(id, version, path);
+
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
@@ -4,6 +4,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
     {
         PackagesConfig,
         ProjectFile,
-        ProjectFileOldStyle
+        ProjectFileOldStyle,
+        Nuspec
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
@@ -7,7 +7,7 @@ using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.RepositoryInspection
 {
-    public class PackagesFileReader
+    public class PackagesFileReader : IPackageReferenceFinder
     {
         private readonly INuKeeperLogger _logger;
 
@@ -23,6 +23,11 @@ namespace NuKeeper.Inspection.RepositoryInspection
             {
                 return Read(fileContents, packagePath);
             }
+        }
+
+        public IEnumerable<string> GetFilePatterns()
+        {
+            return new[] {"packages.config"};
         }
 
         public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -7,7 +7,7 @@ using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.RepositoryInspection
 {
-    public class ProjectFileReader
+    public class ProjectFileReader : IPackageReferenceFinder
     {
         private const string VisualStudioLegacyProjectNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
         private readonly INuKeeperLogger _logger;
@@ -23,6 +23,11 @@ namespace NuKeeper.Inspection.RepositoryInspection
             {
                 return Read(fileContents, baseDirectory, relativePath);
             }
+        }
+
+        public IEnumerable<string> GetFilePatterns()
+        {
+            return new[] {"*.csproj", "*.vbproj"};
         }
 
         public IEnumerable<PackageInProject> Read(Stream fileContents, string baseDirectory, string relativePath)

--- a/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
@@ -9,9 +9,9 @@ namespace NuKeeper.Inspection.RepositoryInspection
     {
         private readonly IReadOnlyCollection<IPackageReferenceFinder> _finders;
 
-        public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader)
+        public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader, NuspecFileReader nuspecFileReader)
         {
-            _finders = new IPackageReferenceFinder[] {projectFileReader, packagesFileReader};
+            _finders = new IPackageReferenceFinder[] {projectFileReader, packagesFileReader, nuspecFileReader};
         }
 
         public IEnumerable<PackageInProject> FindAllNuGetPackages(IFolder workingFolder)

--- a/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
@@ -7,56 +7,34 @@ namespace NuKeeper.Inspection.RepositoryInspection
 {
     public class RepositoryScanner: IRepositoryScanner
     {
-        private readonly ProjectFileReader _projectFileReader;
-        private readonly PackagesFileReader _packagesFileReader;
+        private readonly IReadOnlyCollection<IPackageReferenceFinder> _finders;
 
         public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader)
         {
-            _projectFileReader = projectFileReader;
-            _packagesFileReader = packagesFileReader;
+            _finders = new IPackageReferenceFinder[] {projectFileReader, packagesFileReader};
         }
 
         public IEnumerable<PackageInProject> FindAllNuGetPackages(IFolder workingFolder)
         {
-
-            return PackageFiles(workingFolder)
-                .Concat(ProjectFiles(workingFolder))
+            return _finders
+                .SelectMany(f => FindPackages(workingFolder, f))
                 .ToList();
         }
 
-        private IEnumerable<PackageInProject> PackageFiles(IFolder workingFolder)
+        private IEnumerable<PackageInProject> FindPackages(IFolder workingFolder,
+            IPackageReferenceFinder packageReferenceFinder)
         {
-            var packagesFiles = workingFolder.Find("packages.config")
+            var files =  packageReferenceFinder
+                .GetFilePatterns()
+                .SelectMany(workingFolder.Find)
                 .Where(f => !DirectoryExclusions.PathIsExcluded(f.FullName));
 
-            var results = new List<PackageInProject>();
-
-            foreach (var packagesFile in packagesFiles)
-            {
-                var packages = _packagesFileReader.ReadFile(workingFolder.FullPath,
-                    GetRelativeFileName(workingFolder.FullPath, packagesFile.FullName));
-                results.AddRange(packages);
-            }
-
-            return results;
-        }
-
-        private IEnumerable<PackageInProject> ProjectFiles(IFolder workingFolder)
-        {
-            var projectFiles = workingFolder.Find("*.csproj")
-                .Concat(workingFolder.Find("*.vbproj"))
-                .Where(f => !DirectoryExclusions.PathIsExcluded(f.FullName));
-
-            var results = new List<PackageInProject>();
-
-            foreach (var projectFile in projectFiles)
-            {
-                var packages = _projectFileReader.ReadFile(workingFolder.FullPath,
-                    GetRelativeFileName(workingFolder.FullPath, projectFile.FullName));
-                results.AddRange(packages);
-            }
-
-            return results;
+            return files.SelectMany(f =>
+                packageReferenceFinder.ReadFile(
+                    workingFolder.FullPath,
+                    GetRelativeFileName(
+                        workingFolder.FullPath,
+                        f.FullName)));
         }
 
         private string GetRelativeFileName(string rootDir, string fileName)

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.NuGet.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.NuGet.Process
+{
+    [TestFixture]
+    public class UpdateNuspecCommandTests
+    {
+        private readonly string _testNuspec =
+@"<package><metadata><dependencies>
+      <dependency id=""foo"" version=""{packageVersion}"" />
+</dependencies></metadata></package>
+";
+
+        [Test]
+        public async Task ShouldUpdateValidNuspecFile()
+        {
+            await ExecuteValidUpdateTest(_testNuspec);
+        }
+
+        private async Task ExecuteValidUpdateTest(string testProjectContents, [CallerMemberName] string memberName = "")
+        {
+            const string oldPackageVersion = "5.2.3";
+            const string newPackageVersion = "5.2.4";
+            const string expectedPackageString =
+                "<dependency id=\"foo\" version=\"{packageVersion}\" />";
+
+            var testFolder = memberName;
+            var testNuspec = $"{memberName}.nuspec";
+            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            Directory.CreateDirectory(workDirectory);
+            var projectContents = testProjectContents.Replace("{packageVersion}", oldPackageVersion);
+            var projectPath = Path.Combine(workDirectory, testNuspec);
+            await File.WriteAllTextAsync(projectPath, projectContents);
+
+            var command = new UpdateNuspecCommand();
+
+            await command.Invoke(new NuGetVersion(newPackageVersion), null,
+                new PackageInProject("foo", oldPackageVersion,
+                    new PackagePath(workDirectory, testNuspec, PackageReferenceType.Nuspec)));
+
+            var contents = await File.ReadAllTextAsync(projectPath);
+            Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));
+            Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion)));
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Integration.Tests.NuGet.Api;
 using NuKeeper.NuGet.Process;
 using NUnit.Framework;
 
@@ -38,7 +39,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var projectPath = Path.Combine(workDirectory, testNuspec);
             await File.WriteAllTextAsync(projectPath, projectContents);
 
-            var command = new UpdateNuspecCommand();
+            var command = new UpdateNuspecCommand(new NullNuKeeperLogger());
 
             await command.Invoke(new NuGetVersion(newPackageVersion), null,
                 new PackageInProject("foo", oldPackageVersion,

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -26,6 +26,10 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
   </ItemGroup>
 </Project>";
 
+        private const string NuspecWithDependency =
+            @"<package><metadata><dependencies>
+<dependency id=""foo"" version=""3.3.3.5"" /></dependencies></metadata></package>";
+
         [Test]
         public void ValidEmptyDirectoryWorks()
         {
@@ -95,6 +99,19 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
         }
 
         [Test]
+        public void FindsNuspec()
+        {
+            var scanner = MakeScanner();
+            var temporaryPath = GetUniqueTempFolder();
+
+            WriteFile(temporaryPath, "sample.nuspec", NuspecWithDependency);
+
+            var results = scanner.FindAllNuGetPackages(temporaryPath);
+
+            Assert.That(results, Has.Count.EqualTo(1));
+        }
+
+        [Test]
         public void CorrectItemInCsProjFile()
         {
             var scanner = MakeScanner();
@@ -150,7 +167,8 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             var logger = new NullNuKeeperLogger();
             return new RepositoryScanner(
                 new ProjectFileReader(logger),
-                new PackagesFileReader(logger));
+                new PackagesFileReader(logger),
+                new NuspecFileReader(logger));
         }
 
         private void WriteFile(IFolder path, string fileName, string contents)

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -95,6 +95,9 @@ namespace NuKeeper.Engine.Packages
                 case PackageReferenceType.ProjectFile:
                     return new[] {new DotNetUpdatePackageCommand(_logger, _settings)};
 
+                case PackageReferenceType.Nuspec:
+                    return new[] { new UpdateNuspecCommand() };
+
                 default: throw new ArgumentOutOfRangeException(nameof(packageReferenceType));
             }
         }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -96,7 +96,7 @@ namespace NuKeeper.Engine.Packages
                     return new[] {new DotNetUpdatePackageCommand(_logger, _settings)};
 
                 case PackageReferenceType.Nuspec:
-                    return new[] { new UpdateNuspecCommand() };
+                    return new[] { new UpdateNuspecCommand(_logger) };
 
                 default: throw new ArgumentOutOfRangeException(nameof(packageReferenceType));
             }

--- a/NuKeeper/NuGet/Process/UpdateNuspecCommand.cs
+++ b/NuKeeper/NuGet/Process/UpdateNuspecCommand.cs
@@ -4,12 +4,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Versioning;
+using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.NuGet.Process
 {
     public class UpdateNuspecCommand : IPackageCommand
     {
+        private readonly INuKeeperLogger _logger;
+
+        public UpdateNuspecCommand(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
         public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
         {
             using (var nuspecContents = File.Open(currentPackage.Path.FullName, FileMode.Open, FileAccess.ReadWrite))
@@ -34,6 +42,7 @@ namespace NuKeeper.NuGet.Process
 
             foreach (var dependencyToUpdate in packageNodeList)
             {
+                _logger.Verbose($"Updating nuspec depenencies: {currentPackage.Id} in path {currentPackage.Path.FullName}");
                 dependencyToUpdate.Attribute("version").Value = newVersion.ToString();
             }
 

--- a/NuKeeper/NuGet/Process/UpdateNuspecCommand.cs
+++ b/NuKeeper/NuGet/Process/UpdateNuspecCommand.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Versioning;
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.NuGet.Process
+{
+    public class UpdateNuspecCommand : IPackageCommand
+    {
+        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        {
+            using (var nuspecContents = File.Open(currentPackage.Path.FullName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                await UpdateNuspec(nuspecContents, newVersion, currentPackage);
+            }
+        }
+
+        private async Task UpdateNuspec(FileStream fileContents, NuGetVersion newVersion,
+            PackageInProject currentPackage)
+        {
+            var xml = XDocument.Load(fileContents);
+
+            var packagesNode = xml.Element("package")?.Element("metadata")?.Element("dependencies");
+            if (packagesNode == null)
+            {
+                return;
+            }
+
+            var packageNodeList = packagesNode.Elements()
+                .Where(x => x.Name == "dependency" && x.Attributes("id").Any(a => a.Value == currentPackage.Id));
+
+            foreach (var dependencyToUpdate in packageNodeList)
+            {
+                dependencyToUpdate.Attribute("version").Value = newVersion.ToString();
+            }
+
+            fileContents.Seek(0, SeekOrigin.Begin);
+            await xml.SaveAsync(fileContents, SaveOptions.None, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `.nuspec` as another recognised source of package dependencies (for cases where a non-floating version number is used). Those dependencies will be updated along `<PackageReferrence/>` or `packages.config` dependencies and reported in PR messages created by NuKeeper.

I've chosen this approach as opposed to having just the updater (without the dependencies finder), as projects are likely not to have a 1-to-1 relationship between project files and `.nuspec` files, thus the stand-alone updater would have to be more complex. Also, the alternative approach wouldn't include the update in the PR description.