### PR TITLE
Inspect mode

### DIFF
--- a/NuKeeper.Inspection.Tests/Report/CsvFileReporterTests.cs
+++ b/NuKeeper.Inspection.Tests/Report/CsvFileReporterTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace NuKeeper.Inspection.Tests.Report
 {
     [TestFixture]
-    public class AvailableUpdatesReporterTests
+    public class CsvFileReporterTests
     {
         [Test]
         public void NoRowsHasHeaderLineInOutput()
@@ -91,7 +91,7 @@ namespace NuKeeper.Inspection.Tests.Report
             streamSource.GetStream(Arg.Any<string>())
                 .Returns(writer);
 
-            var reporter = new AvailableUpdatesReporter(streamSource, new NullNuKeeperLogger());
+            var reporter = new CsvFileReporter(streamSource, new NullNuKeeperLogger());
 
             reporter.Report("test", rows);
 

--- a/NuKeeper.Inspection/Report/AvailableUpdatesReporter.cs
+++ b/NuKeeper.Inspection/Report/AvailableUpdatesReporter.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Inspection.Report
             _logger = logger;
         }
 
-        public void Report(string name, List<PackageUpdateSet> updates)
+        public void Report(string name, IReadOnlyCollection<PackageUpdateSet> updates)
         {
             using (var writer = _reportStreamSource.GetStream(name))
             {

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuKeeper.Inspection.Formats;
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.Inspection.Report
+{
+    public class ConsoleReporter : IAvailableUpdatesReporter
+    {
+        public void Report(string name, IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            Console.WriteLine();
+            if (updates.Count == 0)
+            {
+                Console.WriteLine("No package updates found");
+            }
+
+            foreach (var update in updates)
+            {
+                Console.WriteLine(Describe(update));
+            }
+        }
+
+        private string Describe(PackageUpdateSet update)
+        {
+            var occurences = update.CurrentPackages.Count;
+            var versionsInUse = update.CurrentPackages
+                .Select(p => p.Version)
+                .ToList();
+
+            var lowest = versionsInUse.Min();
+            var highest = versionsInUse.Max();
+
+            string versionInUse;
+            if (lowest == highest)
+            {
+                versionInUse = highest.ToString();
+            }
+            else
+            {
+                versionInUse = $"{lowest} - {highest}";
+            }
+
+            var pubDate = update.Selected.Published.Value.UtcDateTime;
+            var ago = TimeSpanFormat.Ago(pubDate, DateTime.UtcNow);
+
+            var optS = occurences > 1 ? "s" : string.Empty;
+
+            return  $"{update.SelectedId} to {update.SelectedVersion} from {versionInUse} in {occurences} place{optS} since {ago}.";
+        }
+    }
+}

--- a/NuKeeper.Inspection/Report/CsvFileReporter.cs
+++ b/NuKeeper.Inspection/Report/CsvFileReporter.cs
@@ -9,12 +9,12 @@ using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.Inspection.Report
 {
-    public class AvailableUpdatesReporter: IAvailableUpdatesReporter
+    public class CsvFileReporter: IAvailableUpdatesReporter
     {
         private readonly IReportStreamSource _reportStreamSource;
         private readonly INuKeeperLogger _logger;
 
-        public AvailableUpdatesReporter(IReportStreamSource reportStreamSource, INuKeeperLogger logger)
+        public CsvFileReporter(IReportStreamSource reportStreamSource, INuKeeperLogger logger)
         {
             _reportStreamSource = reportStreamSource;
             _logger = logger;

--- a/NuKeeper.Inspection/Report/IAvailableUpdatesReporter.cs
+++ b/NuKeeper.Inspection/Report/IAvailableUpdatesReporter.cs
@@ -5,6 +5,6 @@ namespace NuKeeper.Inspection.Report
 {
     public interface IAvailableUpdatesReporter
     {
-        void Report(string name, List<PackageUpdateSet> updates);
+        void Report(string name, IReadOnlyCollection<PackageUpdateSet> updates);
     }
 }

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -13,12 +13,32 @@ namespace NuKeeper.Tests.Configuration
     public class SettingsParserCommandlineTests
     {
         [Test]
+        public void EmptyListIsNotParsed()
+        {
+            var commandLine = new List<string>();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Null);
+        }
+
+        [Test]
         public void ValidRepoCommandLineIsParsed()
         {
             var commandLine = ValidRepoCommandLine();
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
+        }
+
+        [Test]
+        public void RepoCommandLineWithoutGithubTokenIsNotParsed()
+        {
+            var commandLine = ValidRepoCommandLine()
+                .Where(i => ! i.StartsWith("t="));
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Null);
         }
 
         [Test]
@@ -261,6 +281,17 @@ namespace NuKeeper.Tests.Configuration
         }
 
         [Test]
+        public void OrgCommandLineWithoutGithubTokenIsNotParsed()
+        {
+            var commandLine = ValidOrgCommandLine()
+                .Where(i => !i.StartsWith("t="));
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Null);
+        }
+
+        [Test]
         public void ValidOrgCommandLineHasSpecifiedValues()
         {
             var commandLine = ValidOrgCommandLine();
@@ -336,6 +367,17 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.Zero));
         }
 
+        [Test]
+        public void ValidInspectCommandLineIsParsed()
+        {
+            var commandLine = ValidInspectCommandLine();
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.ModalSettings, Is.Not.Null);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Inspect));
+        }
+
         private static IEnumerable<string> ValidRepoCommandLine()
         {
             return new List<string>
@@ -353,6 +395,14 @@ namespace NuKeeper.Tests.Configuration
                 "mode=organisation",
                 "org=NuKeeperDotNet",
                 "t=abc123"
+            };
+        }
+
+        private static IEnumerable<string> ValidInspectCommandLine()
+        {
+            return new List<string>
+            {
+                "mode=inspect"
             };
         }
 

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -48,7 +48,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Repository));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Repository));
             Assert.That(settings.ModalSettings.Repository, Is.Not.Null);
             Assert.That(settings.ModalSettings.Repository.RepositoryName, Is.EqualTo("NuKeeper"));
             Assert.That(settings.GithubAuthSettings.Token, Is.EqualTo("abc123"));
@@ -201,7 +201,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Organisation));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Organisation));
         }
 
         [Test]
@@ -217,7 +217,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Organisation));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Organisation));
         }
 
         [Test]
@@ -233,7 +233,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Repository));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Repository));
         }
 
         [Test]
@@ -298,7 +298,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Organisation));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Organisation));
             Assert.That(settings.ModalSettings.OrganisationName, Is.EqualTo("NuKeeperDotNet"));
             Assert.That(settings.GithubAuthSettings.Token, Is.EqualTo("abc123"));
         }
@@ -375,7 +375,7 @@ namespace NuKeeper.Tests.Configuration
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.ModalSettings, Is.Not.Null);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Inspect));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
         }
 
         private static IEnumerable<string> ValidRepoCommandLine()

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -27,7 +27,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Repository));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Repository));
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
@@ -42,7 +42,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Organisation));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Organisation));
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
@@ -57,7 +57,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ParseToSettings(raw);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Inspect));
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
         }

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -49,6 +49,21 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
         }
 
+        [Test]
+        public void ValidInspectConfigIsParsed()
+        {
+            var raw = ValidInspectSettings();
+
+            var settings = SettingsParser.ParseToSettings(raw);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(GithubMode.Inspect));
+            Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
+            Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
+        }
+
+
+
         private static RawConfiguration ValidRepoSettings()
         {
             return new RawConfiguration
@@ -57,6 +72,7 @@ namespace NuKeeper.Tests.Configuration
                 NuGetSources = "https://api.nuget.org/v3/index.json",
                 Mode = "repository",
                 GithubRepositoryUri = new Uri("https://github.com/NuKeeperDotNet/NuKeeper"),
+                GithubToken = "abc123",
                 AllowedChange = VersionChange.Major,
                 LogLevel = LogLevel.Info,
                 ForkMode = ForkMode.PreferFork,
@@ -72,12 +88,25 @@ namespace NuKeeper.Tests.Configuration
                 NuGetSources = "https://api.nuget.org/v3/index.json",
                 Mode = "organisation",
                 GithubOrganisationName = "NuKeeperDotNet",
+                GithubToken = "abc123",
                 AllowedChange = VersionChange.Major,
                 LogLevel = LogLevel.Info,
                 ForkMode = ForkMode.PreferFork,
                 ReportMode = ReportMode.Off
             };
         }
+
+        private static RawConfiguration ValidInspectSettings()
+        {
+            return new RawConfiguration
+            {
+                NuGetSources = "https://api.nuget.org/v3/index.json",
+                Mode = "inspect",
+                LogLevel = LogLevel.Info,
+                ReportMode = ReportMode.Off
+            };
+        }
+
 
         private static void AssertSettingsNotNull(SettingsContainer settings)
         {

--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -18,6 +18,16 @@ namespace NuKeeper.Tests
             Assert.That(engine, Is.Not.Null);
         }
 
+        [Test]
+        public void InspectorCanBeResolved()
+        {
+            var container = ContainerRegistration.Init(MakeValidSettings());
+
+            var inspector = container.GetInstance<Inspector>();
+
+            Assert.That(inspector, Is.Not.Null);
+        }
+
         private static SettingsContainer MakeValidSettings()
         {
             var settings = new SettingsContainer();

--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Tests
             var settings = new SettingsContainer();
             settings.ModalSettings = new ModalSettings
                 {
-                    Mode = GithubMode.Organisation,
+                    Mode = RunMode.Organisation,
                     OrganisationName = "test1"
                 };
             settings.GithubAuthSettings = new GithubAuthSettings(new Uri("http://foo.com/bar"), "abc123");

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Tests.Engine
             var github = Substitute.For<IGithub>();
             var settings = new ModalSettings
             {
-                Mode = GithubMode.Repository,
+                Mode = RunMode.Repository,
                 Repository = new RepositorySettings()
             };
 
@@ -109,7 +109,7 @@ namespace NuKeeper.Tests.Engine
         {
             return new ModalSettings
             {
-                Mode = GithubMode.Organisation,
+                Mode = RunMode.Organisation,
                 OrganisationName = "testOrg"
             };
         }

--- a/NuKeeper/Configuration/GithubMode.cs
+++ b/NuKeeper/Configuration/GithubMode.cs
@@ -1,8 +1,9 @@
-﻿namespace NuKeeper.Configuration
+namespace NuKeeper.Configuration
 {
     public enum GithubMode
     {
         Repository,
-        Organisation
+        Organisation,
+        Inspect
     }
 }

--- a/NuKeeper/Configuration/ModalSettings.cs
+++ b/NuKeeper/Configuration/ModalSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace NuKeeper.Configuration
+namespace NuKeeper.Configuration
 {
     public class ModalSettings
     {

--- a/NuKeeper/Configuration/ModalSettings.cs
+++ b/NuKeeper/Configuration/ModalSettings.cs
@@ -2,7 +2,7 @@ namespace NuKeeper.Configuration
 {
     public class ModalSettings
     {
-        public GithubMode Mode { get; set;  }
+        public RunMode Mode { get; set;  }
         public string OrganisationName { get; set; }
         public RepositorySettings Repository { get; set; }
     }

--- a/NuKeeper/Configuration/ModeNames.cs
+++ b/NuKeeper/Configuration/ModeNames.cs
@@ -1,4 +1,4 @@
-﻿namespace NuKeeper.Configuration
+namespace NuKeeper.Configuration
 {
     public static class ModeNames
     {
@@ -7,5 +7,7 @@
 
         public const string Organisation = "organisation";
         public const string Org = "org";
+
+        public const string Inspect = "inspect";
     }
 }

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -12,7 +12,7 @@ namespace NuKeeper.Configuration
         [CommandLine("mode", "m"), Required]
         public string Mode;
 
-        [Environment("NuKeeper_github_token"), Required, SensitiveInformation]
+        [Environment("NuKeeper_github_token"), SensitiveInformation]
         [OverriddenBy(ConfigurationSources.CommandLine, "t")]
         public string GithubToken;
 

--- a/NuKeeper/Configuration/RunMode.cs
+++ b/NuKeeper/Configuration/RunMode.cs
@@ -1,6 +1,6 @@
 namespace NuKeeper.Configuration
 {
-    public enum GithubMode
+    public enum RunMode
     {
         Repository,
         Organisation,

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -88,7 +88,7 @@ namespace NuKeeper.Configuration
 
             switch (mode.Value)
             {
-                case GithubMode.Repository:
+                case RunMode.Repository:
                     if (settings.GithubToken == null)
                     {
                         Console.WriteLine("Missing required github token");
@@ -103,11 +103,11 @@ namespace NuKeeper.Configuration
 
                     return new ModalSettings
                     {
-                        Mode = GithubMode.Repository,
+                        Mode = RunMode.Repository,
                         Repository = ReadRepositorySettings(settings)
                     };
 
-                case GithubMode.Organisation:
+                case RunMode.Organisation:
                     if (settings.GithubToken == null)
                     {
                         Console.WriteLine("Missing required github token");
@@ -121,15 +121,15 @@ namespace NuKeeper.Configuration
                     }
                     return new ModalSettings
                     {
-                        Mode = GithubMode.Organisation,
+                        Mode = RunMode.Organisation,
                         OrganisationName = settings.GithubOrganisationName
                     };
 
-                case GithubMode.Inspect:
+                case RunMode.Inspect:
                 {
                         return new ModalSettings
                         {
-                            Mode = GithubMode.Inspect
+                            Mode = RunMode.Inspect,
                         };
                 }
 
@@ -139,7 +139,7 @@ namespace NuKeeper.Configuration
             }
         }
 
-        private static GithubMode? ParseMode(string mode)
+        private static RunMode? ParseMode(string mode)
         {
             var modeString = mode?.ToLowerInvariant() ?? string.Empty;
 
@@ -147,14 +147,14 @@ namespace NuKeeper.Configuration
             {
                 case ModeNames.Repo:
                 case ModeNames.Repository:
-                    return  GithubMode.Repository;
+                    return  RunMode.Repository;
 
                 case ModeNames.Org:
                 case ModeNames.Organisation:
-                    return GithubMode.Organisation;
+                    return RunMode.Organisation;
 
                 case ModeNames.Inspect:
-                    return GithubMode.Inspect;
+                    return RunMode.Inspect;
 
                 default:
                     return null;

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -89,11 +89,18 @@ namespace NuKeeper.Configuration
             switch (mode.Value)
             {
                 case GithubMode.Repository:
+                    if (settings.GithubToken == null)
+                    {
+                        Console.WriteLine("Missing required github token");
+                        return null;
+                    }
+
                     if (settings.GithubRepositoryUri == null)
                     {
                         Console.WriteLine("Missing required repository uri");
                         return null;
                     }
+
                     return new ModalSettings
                     {
                         Mode = GithubMode.Repository,
@@ -101,6 +108,12 @@ namespace NuKeeper.Configuration
                     };
 
                 case GithubMode.Organisation:
+                    if (settings.GithubToken == null)
+                    {
+                        Console.WriteLine("Missing required github token");
+                        return null;
+                    }
+
                     if (string.IsNullOrWhiteSpace(settings.GithubOrganisationName))
                     {
                         Console.WriteLine("Missing required organisation name");
@@ -111,6 +124,14 @@ namespace NuKeeper.Configuration
                         Mode = GithubMode.Organisation,
                         OrganisationName = settings.GithubOrganisationName
                     };
+
+                case GithubMode.Inspect:
+                {
+                        return new ModalSettings
+                        {
+                            Mode = GithubMode.Inspect
+                        };
+                }
 
                 default:
                     Console.WriteLine($"Mode parse went wrong: {settings.Mode}");
@@ -131,6 +152,9 @@ namespace NuKeeper.Configuration
                 case ModeNames.Org:
                 case ModeNames.Organisation:
                     return GithubMode.Organisation;
+
+                case ModeNames.Inspect:
+                    return GithubMode.Inspect;
 
                 default:
                     return null;

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -40,7 +40,7 @@ namespace NuKeeper
             container.Register<IUpdateFinder, UpdateFinder>();
 
             container.Register<IReportStreamSource, ReportStreamSource>();
-            container.Register<IAvailableUpdatesReporter, AvailableUpdatesReporter>();
+            container.Register<IAvailableUpdatesReporter, CsvFileReporter>();
         }
     }
 }

--- a/NuKeeper/Engine/GithubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GithubRepositoryDiscovery.cs
@@ -27,10 +27,10 @@ namespace NuKeeper.Engine
         {
             switch (_settings.Mode)
             {
-                case GithubMode.Organisation:
+                case RunMode.Organisation:
                     return await FromOrganisation(_settings.OrganisationName);
 
-                case GithubMode.Repository:
+                case RunMode.Repository:
                     return new[] { _settings.Repository };
 
                 default:

--- a/NuKeeper/Inspector.cs
+++ b/NuKeeper/Inspector.cs
@@ -1,0 +1,31 @@
+using NuKeeper.Inspection;
+using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Logging;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace NuKeeper
+{
+    public class Inspector
+    {
+        private readonly IUpdateFinder _updateFinder;
+        private readonly INuKeeperLogger _logger;
+
+        public Inspector(IUpdateFinder updateFinder, INuKeeperLogger logger)
+        {
+            _updateFinder = updateFinder;
+            _logger = logger;
+        }
+
+        public async Task Run()
+        {
+            var updates = await _updateFinder.FindPackageUpdateSets(CurrentFolder());
+        }
+
+        private IFolder CurrentFolder()
+        {
+            var dir = Directory.GetCurrentDirectory();
+            return new Folder(_logger, new DirectoryInfo(dir));
+        }
+    }
+}

--- a/NuKeeper/Inspector.cs
+++ b/NuKeeper/Inspector.cs
@@ -1,6 +1,7 @@
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.Report;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -20,6 +21,9 @@ namespace NuKeeper
         public async Task Run()
         {
             var updates = await _updateFinder.FindPackageUpdateSets(CurrentFolder());
+
+            var reporter = new ConsoleReporter();
+            reporter.Report("ConsoleReport", updates);
         }
 
         private IFolder CurrentFolder()

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
@@ -18,8 +18,18 @@ namespace NuKeeper
             }
 
             var container = ContainerRegistration.Init(settings);
-            var engine = container.GetInstance<GithubEngine>();
-            await engine.Run();
+
+            if (settings.ModalSettings.Mode == GithubMode.Inspect)
+            {
+                var inpector = container.GetInstance<Inspector>();
+                await inpector.Run();
+            }
+            else
+            {
+                var engine = container.GetInstance<GithubEngine>();
+                await engine.Run();
+
+            }
 
             return 0;
         }

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -19,7 +19,7 @@ namespace NuKeeper
 
             var container = ContainerRegistration.Init(settings);
 
-            if (settings.ModalSettings.Mode == GithubMode.Inspect)
+            if (settings.ModalSettings.Mode == RunMode.Inspect)
             {
                 var inpector = container.GetInstance<Inspector>();
                 await inpector.Run();


### PR DESCRIPTION
This is further step on #236 to make the `NuKeeper.Inspection` code callable from the command line.

Introduce a new mode `Inspect` alongside `Repo` and `Organisation`. In this mode, only part of the main run is performed, the part that inspects the code as it exists in a local folder. No pull or PR is done.

Initially only the current folder is used. The csv report may also be generated as before. In fact, this might be a good use-case - generate the csv report on existing code.

This will become more useful when NETCore 2.1 is released, and NuKeeper is a global tool. And when a target folder can be given on the command line.

Example of a run with this PR:

`dotnet run -p ..\NuKeeper\NuKeeper\NuKeeper.csproj mode=inspect log=terse`

````
Running NuKeeper in inspect mode
Found 60 packages in use, 23 distinct, in 13 projects.
Found 3 possible updates

AWSSDK.Core to 3.3.22.3 from 3.3.22.2 in 3 places since 3 days ago.
AWSSDK.DynamoDBv2 to 3.3.8 from 3.3.7.3 in 2 places since 6 days ago.
AWSSDK.EC2 to 3.3.49 from 3.3.48.2 in 1 place since 4 days ago.
````