### PR TITLE
Inspect dir

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -378,6 +378,19 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
         }
 
+        [Test]
+        public void InspectCommandLineWithDirIsParsed()
+        {
+            var commandLine = ValidInspectCommandLine()
+                .Append("dir=/foo/bar");
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.ModalSettings, Is.Not.Null);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
+            Assert.That(settings.UserSettings.Directory, Is.EqualTo("/foo/bar"));
+        }
+
         private static IEnumerable<string> ValidRepoCommandLine()
         {
             return new List<string>

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -62,7 +62,18 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
         }
 
+        [Test]
+        public void ValidInspectConfigWithDirIsParsed()
+        {
+            var raw = ValidInspectSettings();
+            raw.Dir = "c:\\temp";
 
+            var settings = SettingsParser.ParseToSettings(raw);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
+            Assert.That(settings.UserSettings.Directory, Is.EqualTo("c:\\temp"));
+        }
 
         private static RawConfiguration ValidRepoSettings()
         {

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -59,5 +59,8 @@ namespace NuKeeper.Configuration
         [JsonConfig("report_mode"), Default("Off")]
         [OverriddenBy(ConfigurationSources.CommandLine, "report")]
         public ReportMode ReportMode;
+
+        [CommandLine("dir")]
+        public string Dir { get; set; }
     }
 }

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -65,7 +65,8 @@ namespace NuKeeper.Configuration
                 NuGetSources = ReadNuGetSources(settings),
                 PackageIncludes = ParseRegex(settings.Include, nameof(settings.Include)),
                 PackageExcludes = ParseRegex(settings.Exclude, nameof(settings.Exclude)),
-                MinimumPackageAge = minPackageAge.Value
+                MinimumPackageAge = minPackageAge.Value,
+                Directory = settings.Dir
             };
 
             return new SettingsContainer
@@ -129,7 +130,7 @@ namespace NuKeeper.Configuration
                 {
                         return new ModalSettings
                         {
-                            Mode = RunMode.Inspect,
+                            Mode = RunMode.Inspect
                         };
                 }
 

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -25,5 +25,7 @@ namespace NuKeeper.Configuration
         public LogLevel LogLevel { get; set; }
 
         public ReportMode ReportMode { get; set; }
+
+        public string Directory { get; set; }
     }
 }

--- a/NuKeeper/Inspector.cs
+++ b/NuKeeper/Inspector.cs
@@ -4,6 +4,7 @@ using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Report;
 using System.IO;
 using System.Threading.Tasks;
+using NuKeeper.Configuration;
 
 namespace NuKeeper
 {
@@ -18,17 +19,23 @@ namespace NuKeeper
             _logger = logger;
         }
 
-        public async Task Run()
+        public async Task Run(UserSettings settings)
         {
-            var updates = await _updateFinder.FindPackageUpdateSets(CurrentFolder());
+            var folder = CurrentFolder(settings);
+            var updates = await _updateFinder.FindPackageUpdateSets(folder);
 
             var reporter = new ConsoleReporter();
             reporter.Report("ConsoleReport", updates);
         }
 
-        private IFolder CurrentFolder()
+        private IFolder CurrentFolder(UserSettings settings)
         {
-            var dir = Directory.GetCurrentDirectory();
+            string dir = settings.Directory;
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                dir = Directory.GetCurrentDirectory();
+            }
+
             return new Folder(_logger, new DirectoryInfo(dir));
         }
     }

--- a/NuKeeper/Inspector.cs
+++ b/NuKeeper/Inspector.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
@@ -5,6 +6,7 @@ using NuKeeper.Inspection.Report;
 using System.IO;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
+using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper
 {
@@ -21,14 +23,12 @@ namespace NuKeeper
 
         public async Task Run(UserSettings settings)
         {
-            var folder = CurrentFolder(settings);
+            var folder = TargetFolder(settings);
             var updates = await _updateFinder.FindPackageUpdateSets(folder);
-
-            var reporter = new ConsoleReporter();
-            reporter.Report("ConsoleReport", updates);
+            Report(updates);
         }
 
-        private IFolder CurrentFolder(UserSettings settings)
+        private IFolder TargetFolder(UserSettings settings)
         {
             string dir = settings.Directory;
             if (string.IsNullOrWhiteSpace(dir))
@@ -38,5 +38,12 @@ namespace NuKeeper
 
             return new Folder(_logger, new DirectoryInfo(dir));
         }
+
+        private static void Report(List<PackageUpdateSet> updates)
+        {
+            var reporter = new ConsoleReporter();
+            reporter.Report("ConsoleReport", updates);
+        }
+
     }
 }

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -22,13 +22,12 @@ namespace NuKeeper
             if (settings.ModalSettings.Mode == RunMode.Inspect)
             {
                 var inpector = container.GetInstance<Inspector>();
-                await inpector.Run();
+                await inpector.Run(settings.UserSettings);
             }
             else
             {
                 var engine = container.GetInstance<GithubEngine>();
                 await engine.Run();
-
             }
 
             return 0;


### PR DESCRIPTION
When inspecting, can point it at a specific directory
Fall back to curren behaviour, use the current dir
e.g. `dotnet run mode=inspect dir=C:\Code\AwsWatchman`