### PR TITLE
Use a Directory.Build.props file to hold common things

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+    <PackageVersion>0.0.2</PackageVersion>
+    <Copyright>Copyright (c) NuKeeper 20157-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <PackageProjectUrl>https://github.com/NuKeeperDotNet/NuKeeper/</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageTags>NuGet;Packag;update</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageProjectUrl>https://github.com/NuKeeperDotNet/NuKeeper/</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>NuGet;Packag;update</PackageTags>
+    <PackageTags>NuGet;Package;Update</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <PackageVersion>0.0.2</PackageVersion>
-    <Copyright>Copyright (c) NuKeeper 20157-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
+    <Copyright>Copyright (c) NuKeeper 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageProjectUrl>https://github.com/NuKeeperDotNet/NuKeeper/</PackageProjectUrl>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
   </ItemGroup>

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -131,7 +131,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
         {
             var factory = new FolderFactory(new NullNuKeeperLogger());
             return factory.UniqueTemporaryFolder();
-
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Configuration;
+using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Integration.Tests.NuGet.Api;
 using NuKeeper.NuGet.Process;
@@ -101,8 +102,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var testFolder = memberName;
             var testProject = $"{memberName}.csproj";
-            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            var tempFolder = UniqueTemporaryFolder();
+
+            var workDirectory = Path.Combine(tempFolder.FullPath, testFolder);
             Directory.CreateDirectory(workDirectory);
+
             var projectContents = testProjectContents.Replace("{packageVersion}", oldPackageVersion);
             var projectPath = Path.Combine(workDirectory, testProject);
             await File.WriteAllTextAsync(projectPath, projectContents);
@@ -111,13 +115,23 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
                     new NullNuKeeperLogger(),
                     new UserSettings { NuGetSources = new[] { packageSource } });
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource,
-                new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
-                    new PackagePath(workDirectory, testProject, PackageReferenceType.ProjectFile)));
+            var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
+                    new PackagePath(workDirectory, testProject, PackageReferenceType.ProjectFile));
+
+            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource, packageToUpdate);
 
             var contents = await File.ReadAllTextAsync(projectPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));
             Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion)));
+
+            tempFolder.TryDelete();
+        }
+
+        private IFolder UniqueTemporaryFolder()
+        {
+            var factory = new FolderFactory(new NullNuKeeperLogger());
+            return factory.UniqueTemporaryFolder();
+
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Configuration;
+using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Integration.Tests.NuGet.Api;
 using NuKeeper.NuGet.Process;
@@ -39,7 +40,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             const string testFolder = nameof(ShouldUpdateDotnetClassicProject);
 
             var testProject = $"{testFolder}.csproj";
-            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            var tempFolder = UniqueTemporaryFolder();
+
+            var workDirectory = Path.Combine(tempFolder.FullPath, testFolder);
             Directory.CreateDirectory(workDirectory);
             var packagesFolder = Path.Combine(workDirectory, "packages");
             Directory.CreateDirectory(packagesFolder);
@@ -59,13 +62,22 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
                     new NullNuKeeperLogger(),
                     new UserSettings { NuGetSources = new[] { packageSource } });
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource,
-                new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
-                    new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig)));
+            var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
+                    new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));
+
+            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource, packageToUpdate);
 
             var contents = await File.ReadAllTextAsync(packagesConfigPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));
             Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion)));
+
+            tempFolder.TryDelete();
+        }
+
+        private IFolder UniqueTemporaryFolder()
+        {
+            var factory = new FolderFactory(new NullNuKeeperLogger());
+            return factory.UniqueTemporaryFolder();
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit" Version="3.10.1">

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1">
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -2,15 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.0.1</PackageVersion>
     <PackAsTool>true</PackAsTool>
-    <PackageProjectUrl>https://github.com/NuKeeperDotNet/NuKeeper/</PackageProjectUrl>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>NuKeeper</RootNamespace>
     <AssemblyName>NuKeeper</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />


### PR DESCRIPTION
Use a `Directory.Build.props` file to hold common things
Like framework version
As they should be all the same

This file is automatically imported into all projects under it: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build