### PR TITLE
Use "inspect" mode as a default

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -13,12 +13,13 @@ namespace NuKeeper.Tests.Configuration
     public class SettingsParserCommandlineTests
     {
         [Test]
-        public void EmptyListIsNotParsed()
+        public void EmptyListIsParsedAsInspect()
         {
             var commandLine = new List<string>();
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings, Is.Null);
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
         }
 
         [Test]
@@ -175,17 +176,17 @@ namespace NuKeeper.Tests.Configuration
         }
 
         [Test]
-        public void MissingModeIsNotParsed()
+        public void MissingModeIsParsedAsInspect()
         {
             var commandLine = new List<string>
             {
-                "repo=https://github.com/NuKeeperDotNet/NuKeeper",
-                "t=abc123"
+                "log=verbose"
             };
 
             var settings = SettingsParser.ReadSettings(commandLine);
 
-            Assert.That(settings, Is.Null);
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
         }
 
         [Test]

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Configuration
 {
     public class RawConfiguration
     {
-        [CommandLine("mode", "m"), Required]
+        [CommandLine("mode", "m"), Required, Default("inspect")]
         public string Mode;
 
         [Environment("NuKeeper_github_token"), SensitiveInformation]


### PR DESCRIPTION
Use `inspect` mode as a default.
Inspect mode is a suitable default as it's a read-only operation.
This is mostly a user-experience thing for newbies, as just running NuKeeper without args might now do something interesting, but not change anything.
