### PR TITLE
That total age

### DIFF
--- a/NuKeeper.Inspection/Formats/TimeSpanFormat.cs
+++ b/NuKeeper.Inspection/Formats/TimeSpanFormat.cs
@@ -7,6 +7,7 @@ namespace NuKeeper.Inspection.Formats
         public static string Ago(DateTime start, DateTime end)
         {
             var duration = end.Subtract(start);
+
             if (start.Year == end.Year && start.Month == end.Month)
             {
                 return Ago(duration);

--- a/NuKeeper.Inspection/Report/Age.cs
+++ b/NuKeeper.Inspection/Report/Age.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Inspection.Report
 {
     public static class Age
     {
-        public static TimeSpan Sum(IReadOnlyCollection<PackageUpdateSet> updates)
+        public static TimeSpan Sum(IEnumerable<PackageUpdateSet> updates)
         {
             var now = DateTimeOffset.UtcNow;
 

--- a/NuKeeper.Inspection/Report/Age.cs
+++ b/NuKeeper.Inspection/Report/Age.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.Inspection.Report
+{
+    public static class Age
+    {
+        public static TimeSpan Sum(IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            var sum = updates
+                .Select(u => u.Selected.Published)
+                .Where(p => p.HasValue)
+                .Select(p => now.Subtract(p.Value))
+                .Aggregate(TimeSpan.Zero, (t1, t2) => t1.Add(t2));
+
+            return sum;
+        }
+    }
+}

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -38,8 +38,13 @@ namespace NuKeeper.Inspection.Report
         private string MessageForAgeSum(IReadOnlyCollection<PackageUpdateSet> updates)
         {
             var totalAge = Age.Sum(updates);
-            var ageString = totalAge.ToString("%d");
-            return $"Total package age:{ageString} days";
+            var years = totalAge.TotalDays / 365;
+
+            var result =
+             "Total package age:\n" +
+             $" Days: {totalAge:%d}\n" +
+             $" LibYears: {years:0.0}";
+            return result;
         }
 
         private string Describe(PackageUpdateSet update)

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -12,6 +12,7 @@ namespace NuKeeper.Inspection.Report
         {
             Console.WriteLine();
             Console.WriteLine(MessageForCount(updates.Count));
+            Console.WriteLine(MessageForAgeSum(updates));
             Console.WriteLine();
 
             foreach (var update in updates)
@@ -34,6 +35,13 @@ namespace NuKeeper.Inspection.Report
             return $"Found {count} package updates";
         }
 
+        private string MessageForAgeSum(IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            var totalAge = Age.Sum(updates);
+            var ageString = totalAge.ToString("%d");
+            return $"Total package age:{ageString} days";
+        }
+
         private string Describe(PackageUpdateSet update)
         {
             var occurences = update.CurrentPackages.Count;
@@ -54,8 +62,12 @@ namespace NuKeeper.Inspection.Report
                 versionInUse = $"{lowest} - {highest}";
             }
 
-            var pubDate = update.Selected.Published.Value.UtcDateTime;
-            var ago = TimeSpanFormat.Ago(pubDate, DateTime.UtcNow);
+            var ago = "?";
+            if (update.Selected.Published.HasValue)
+            {
+                var pubDate = update.Selected.Published.Value.UtcDateTime;
+                ago = TimeSpanFormat.Ago(pubDate, DateTime.UtcNow);
+            }
 
             var optS = occurences > 1 ? "s" : string.Empty;
 


### PR DESCRIPTION
report total package age on command line report  …
Inspired by [libyear](https://stevedesmond.ca/blog/happy-libyear)
Total age is shown in both integer days and years to 1 decimal point.


sample output:
```
Found 69 package updates
Total package age:
 Days: 9865
 LibYears: 27.0
```