### PR TITLE
Update mode prefactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
   - dotnet build -c Release -f netcoreapp2.1 NuKeeper.sln /m:1
   - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Tests/NuKeeper.Tests.csproj --filter "TestCategory!=WindowsOnly"
   - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj --filter "TestCategory!=WindowsOnly"
-  - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"
+  - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj --filter "TestCategory!=WindowsOnly"
+- dotnet test -c Release -f netcoreapp2.1 NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"
 
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ script:
   - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Tests/NuKeeper.Tests.csproj --filter "TestCategory!=WindowsOnly"
   - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj --filter "TestCategory!=WindowsOnly"
   - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj --filter "TestCategory!=WindowsOnly"
-- dotnet test -c Release -f netcoreapp2.1 NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"
+  - dotnet test -c Release -f netcoreapp2.1 NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj --filter "TestCategory!=WindowsOnly"
 
  

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -23,7 +23,7 @@ namespace NuKeeper.Tests.Engine
         {
             var updateSets = new List<PackageUpdateSet>();
 
-            var target = OneTargetSelection();
+            var target = SelectionForFilter(BranchFilter(true));
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
@@ -34,9 +34,12 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereIsOneInput_ItIsTheTarget()
         {
-            var updateSets = new List<PackageUpdateSet> { UpdateFooFromOneVersion() };
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion()
+            };
 
-            var target = OneTargetSelection();
+            var target = SelectionForFilter(BranchFilter(true));
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
@@ -55,11 +58,11 @@ namespace NuKeeper.Tests.Engine
                 UpdateFooFromOneVersion()
             };
 
-            var target = OneTargetSelection();
+            var target = SelectionForFilter(BranchFilter(true));
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
-            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.Count, Is.EqualTo(2));
             Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
         }
 
@@ -73,11 +76,11 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var target = OneTargetSelection();
+            var target = SelectionForFilter(BranchFilter(true));
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
-            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.Count, Is.EqualTo(2));
             Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
         }
 
@@ -92,7 +95,7 @@ namespace NuKeeper.Tests.Engine
 
             var filter = BranchFilter(false);
 
-            var target = OneTargetSelection(filter);
+            var target = SelectionForFilter(filter);
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
@@ -144,14 +147,14 @@ namespace NuKeeper.Tests.Engine
             return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
         }
 
-        private static IPackageUpdateSelection OneTargetSelection()
+        private static IPackageUpdateSelection SelectionForFilter(IExistingBranchFilter filter)
         {
-            return OneTargetSelection(BranchFilter(true));
-        }
-
-        private static IPackageUpdateSelection OneTargetSelection(IExistingBranchFilter filter)
-        {
-            var updateSelection = new UpdateSelection(new FilterSettings(), new NullNuKeeperLogger());
+            var settings = new FilterSettings
+            {
+                MaxPullRequests = Int32.MaxValue,
+                MinimumAge = TimeSpan.Zero
+            };
+            var updateSelection = new UpdateSelection(settings, new NullNuKeeperLogger());
             return new PackageUpdateSelection(filter,
                 MakeSort(), updateSelection, new NullNuKeeperLogger());
         }

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -1,17 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
-using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Engine.Packages;
 using NuKeeper.Inspection.Sort;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Update.Selection;
 using NUnit.Framework;
 
 namespace NuKeeper.Tests.Engine
@@ -49,6 +48,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreTwoInputs_MoreVersionsFirst_FirstIsTheTarget()
         {
+            // sort should not change this ordering
             var updateSets = new List<PackageUpdateSet>
             {
                 UpdateBarFromTwoVersions(),
@@ -66,6 +66,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreTwoInputs_MoreVersionsSecond_SecondIsTheTarget()
         {
+            // sort should change this ordering
             var updateSets = new List<PackageUpdateSet>
             {
                 UpdateFooFromOneVersion(),
@@ -81,80 +82,6 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public async Task WhenThereAreIncludes_OnlyConsiderMatches()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new UserSettings
-            {
-                MaxPullRequestsPerRepository = 10,
-                PackageIncludes = new Regex("bar")
-            };
-
-            var target = new PackageUpdateSelection(settings, BranchFilter(),
-                MakeSort(), new NullNuKeeperLogger());
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
-        }
-
-        [Test]
-        public async Task WhenThereAreExcludes_OnlyConsiderNonMatching()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new UserSettings
-            {
-                MaxPullRequestsPerRepository = 10,
-                PackageExcludes = new Regex("bar")
-            };
-
-            var target = new PackageUpdateSelection(settings, BranchFilter(),
-                MakeSort(), new NullNuKeeperLogger());
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
-        }
-
-        [Test]
-        public async Task WhenThereAreIncludesAndExcludes_OnlyConsiderMatchesButRemoveNonMatching()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFoobarFromOneVersion(),
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new UserSettings 
-            {
-                MaxPullRequestsPerRepository = 10,
-                PackageExcludes = new Regex("bar"),
-                PackageIncludes = new Regex("foo")
-            };
-
-            var target = new PackageUpdateSelection(settings, BranchFilter(),
-                MakeSort(), new NullNuKeeperLogger());
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
-        }
-
-        [Test]
         public async Task WhenExistingBranchesAreFilteredOut()
         {
             var updateSets = new List<PackageUpdateSet>
@@ -163,118 +90,13 @@ namespace NuKeeper.Tests.Engine
                 UpdateBarFromTwoVersions()
             };
 
-            var filter = BranchFilter(new List<PackageUpdateSet>());
+            var filter = BranchFilter(false);
 
             var target = OneTargetSelection(filter);
 
             var results = await target.SelectTargets(PushFork(), updateSets);
 
             Assert.That(results.Count, Is.EqualTo(0));
-            await filter.Received(1).CanMakeBranchFor(
-                Arg.Any<ForkData>(),
-                Arg.Any<IEnumerable<PackageUpdateSet>>());
-        }
-
-        [Test]
-        public async Task WhenFirstPackageIsFilteredOutByBranch()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var filter = BranchFilter(updateSets.Skip(1).ToList());
-
-            var target = OneTargetSelection(filter);
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
-            await filter.Received(1).CanMakeBranchFor(
-                Arg.Any<ForkData>(),
-                Arg.Any<IEnumerable<PackageUpdateSet>>());
-        }
-
-        [Test]
-        public async Task WhenThePackageIsNotOldEnough()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion()
-            };
-
-            var target = MinAgeTargetSelection(TimeSpan.FromDays(7));
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task WhenTheFirstPackageIsNotOldEnough()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
-                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
-            };
-
-            var target = MinAgeTargetSelection(TimeSpan.FromDays(7));
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
-        }
-
-        [Test]
-        public async Task WhenMinAgeIsLowBothPackagesAreIncluded()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
-                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
-            };
-
-            var target = MinAgeTargetSelection(TimeSpan.FromHours(12));
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(2));
-        }
-
-        [Test]
-        public async Task WhenMinAgeIsHighNeitherPackagesAreIncluded()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
-                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
-            };
-
-            var target = MinAgeTargetSelection(TimeSpan.FromDays(10));
-
-            var results = await target.SelectTargets(PushFork(), updateSets);
-
-            Assert.That(results.Count, Is.EqualTo(0));
-        }
-
-        private PackageUpdateSet UpdateFoobarFromOneVersion()
-        {
-            var newPackage = LatestVersionOfPackageFoobar();
-
-            var currentPackages = new List<PackageInProject>
-            {
-                new PackageInProject("foobar", "1.0.1", PathToProjectOne()),
-                new PackageInProject("foobar", "1.0.1", PathToProjectTwo())
-            };
-
-            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, currentPackages);
         }
 
         private PackageUpdateSet UpdateFooFromOneVersion(TimeSpan? packageAge = null)
@@ -312,11 +134,6 @@ namespace NuKeeper.Tests.Engine
             return new PackageUpdateSet(updates, currentPackages);
         }
 
-        private PackageIdentity LatestVersionOfPackageFoobar()
-        {
-            return new PackageIdentity("foobar", new NuGetVersion("1.2.3"));
-        }
-
         private PackagePath PathToProjectOne()
         {
             return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);
@@ -329,33 +146,14 @@ namespace NuKeeper.Tests.Engine
 
         private static IPackageUpdateSelection OneTargetSelection()
         {
-            return OneTargetSelection(BranchFilter());
+            return OneTargetSelection(BranchFilter(true));
         }
 
         private static IPackageUpdateSelection OneTargetSelection(IExistingBranchFilter filter)
         {
-            const int maxPullRequests = 1;
-
-            var settings = new UserSettings
-            {
-                MaxPullRequestsPerRepository = maxPullRequests,
-                MinimumPackageAge = TimeSpan.Zero
-            };
-            return new PackageUpdateSelection(settings, filter,
-                MakeSort(), new NullNuKeeperLogger());
-        }
-
-        private static IPackageUpdateSelection MinAgeTargetSelection(TimeSpan minAge)
-        {
-            const int maxPullRequests = 1000;
-
-            var settings = new UserSettings
-            {
-                MaxPullRequestsPerRepository = maxPullRequests,
-                MinimumPackageAge = minAge
-            };
-            return new PackageUpdateSelection(settings, BranchFilter(),
-                MakeSort(), new NullNuKeeperLogger());
+            var updateSelection = new UpdateSelection(new FilterSettings(), new NullNuKeeperLogger());
+            return new PackageUpdateSelection(filter,
+                MakeSort(), updateSelection, new NullNuKeeperLogger());
         }
 
         private static ForkData PushFork()
@@ -363,24 +161,13 @@ namespace NuKeeper.Tests.Engine
             return new ForkData(new Uri("http://github.com/foo/bar"), "me", "test");
         }
 
-        private static IExistingBranchFilter BranchFilter()
+        private static IExistingBranchFilter BranchFilter(bool result)
         {
             var filter = Substitute.For<IExistingBranchFilter>();
             filter.CanMakeBranchFor(
-                    Arg.Any<ForkData>(),
-                    Arg.Any<IEnumerable<PackageUpdateSet>>())
-                .Returns(x => Task.FromResult(x.Arg<IReadOnlyCollection<PackageUpdateSet>>()));
-
-            return filter;
-        }
-
-        private static IExistingBranchFilter BranchFilter(IReadOnlyCollection<PackageUpdateSet> results)
-        {
-            var filter = Substitute.For<IExistingBranchFilter>();
-            filter.CanMakeBranchFor(
-                    Arg.Any<ForkData>(),
-                    Arg.Any<IEnumerable<PackageUpdateSet>>())
-                .Returns(x => Task.FromResult(results));
+                Arg.Any<PackageUpdateSet>(),
+                    Arg.Any<ForkData>())
+                .Returns(x => Task.FromResult(result));
 
             return filter;
         }

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuKeeper.Update\NuKeeper.Update.csproj">
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}">
+    </Service>
+  </ItemGroup>
+</Project>

--- a/NuKeeper.Update.Tests/NullNuKeeperLogger.cs
+++ b/NuKeeper.Update.Tests/NullNuKeeperLogger.cs
@@ -1,0 +1,24 @@
+using System;
+using NuKeeper.Inspection.Logging;
+
+namespace NuKeeper.Update.Tests
+{
+    internal class NullNuKeeperLogger : INuKeeperLogger
+    {
+        public void Error(string message, Exception ex)
+        {
+        }
+
+        public void Terse(string message)
+        {
+        }
+
+        public void Info(string message)
+        {
+        }
+
+        public void Verbose(string message)
+        {
+        }
+    }
+}

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Update.Selection;
+using NUnit.Framework;
+
+namespace NuKeeper.Update.Tests
+{
+    [TestFixture]
+    public class UpdateSelectionTests
+    {
+        [Test]
+        public async Task WhenThereAreNoInputs_NoTargetsOut()
+        {
+            var updateSets = new List<PackageUpdateSet>();
+
+            var target = OneTargetSelection();
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results, Is.Empty);
+        }
+
+        [Test]
+        public async Task WhenThereIsOneInput_ItIsTheTarget()
+        {
+            var updateSets = new List<PackageUpdateSet> { UpdateFooFromOneVersion() };
+
+            var target = OneTargetSelection();
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
+        }
+        [Test]
+        public async Task WhenThereAreTwoInputs_FirstIsTheTarget()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var target = OneTargetSelection();
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
+        }
+
+        [Test]
+        public async Task WhenThereAreIncludes_OnlyConsiderMatches()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var settings = new FilterSettings
+            {
+                MaxPullRequests = 10,
+                Includes = new Regex("bar")
+            };
+
+            var target = new UpdateSelection(settings, new NullNuKeeperLogger());
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public async Task WhenThereAreExcludes_OnlyConsiderNonMatching()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var settings = new FilterSettings
+            {
+                MaxPullRequests = 10,
+                Excludes = new Regex("bar")
+            };
+
+            var target = new UpdateSelection(settings, new NullNuKeeperLogger());
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
+        }
+
+        [Test]
+        public async Task WhenThereAreIncludesAndExcludes_OnlyConsiderMatchesButRemoveNonMatching()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFoobarFromOneVersion(),
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var settings = new FilterSettings 
+            {
+                MaxPullRequests = 10,
+                Excludes = new Regex("bar"),
+                Includes = new Regex("foo")
+            };
+
+            var target = new UpdateSelection(settings, new NullNuKeeperLogger());
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
+        }
+
+        [Test]
+        public async Task WhenExistingBranchesAreFilteredOut()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var target = OneTargetSelection();
+
+            var results = await target.Filter(updateSets, Fail);
+
+            Assert.That(results.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task WhenFirstPackageIsFilteredOutByBranch()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var target = OneTargetSelection();
+
+            var results = await target.Filter(updateSets, FilterToId("bar"));
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public async Task WhenThePackageIsNotOldEnough()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion()
+            };
+
+            var target = MinAgeTargetSelection(TimeSpan.FromDays(7));
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task WhenTheFirstPackageIsNotOldEnough()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
+                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
+            };
+
+            var target = MinAgeTargetSelection(TimeSpan.FromDays(7));
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public async Task WhenMinAgeIsLowBothPackagesAreIncluded()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
+                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
+            };
+
+            var target = MinAgeTargetSelection(TimeSpan.FromHours(12));
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task WhenMinAgeIsHighNeitherPackagesAreIncluded()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(TimeSpan.FromDays(6)),
+                UpdateBarFromTwoVersions(TimeSpan.FromDays(8))
+            };
+
+            var target = MinAgeTargetSelection(TimeSpan.FromDays(10));
+
+            var results = await target.Filter(updateSets, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(0));
+        }
+
+        private PackageUpdateSet UpdateFoobarFromOneVersion()
+        {
+            var newPackage = LatestVersionOfPackageFoobar();
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("foobar", "1.0.1", PathToProjectOne()),
+                new PackageInProject("foobar", "1.0.1", PathToProjectTwo())
+            };
+
+            var latest = new PackageSearchMedatadata(newPackage, "ASource", DateTimeOffset.Now, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        private PackageUpdateSet UpdateFooFromOneVersion(TimeSpan? packageAge = null)
+        {
+            var pubDate = DateTimeOffset.Now.Subtract(packageAge ?? TimeSpan.Zero);
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("foo", "1.0.1", PathToProjectOne()),
+                new PackageInProject("foo", "1.0.1", PathToProjectTwo())
+            };
+
+            var matchVersion = new NuGetVersion("4.0.0");
+            var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
+                "ASource", pubDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        private PackageUpdateSet UpdateBarFromTwoVersions(TimeSpan? packageAge = null)
+        {
+            var pubDate = DateTimeOffset.Now.Subtract(packageAge ?? TimeSpan.Zero);
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("bar", "1.0.1", PathToProjectOne()),
+                new PackageInProject("bar", "1.2.1", PathToProjectTwo())
+            };
+
+            var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
+            var match = new PackageSearchMedatadata(matchId, "ASource", pubDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        private PackageIdentity LatestVersionOfPackageFoobar()
+        {
+            return new PackageIdentity("foobar", new NuGetVersion("1.2.3"));
+        }
+
+        private PackagePath PathToProjectOne()
+        {
+            return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);
+        }
+
+        private PackagePath PathToProjectTwo()
+        {
+            return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
+        }
+
+        private static IUpdateSelection OneTargetSelection()
+        {
+            const int maxPullRequests = 1;
+
+            var settings = new FilterSettings
+            {
+                MaxPullRequests = maxPullRequests,
+                MinimumAge = TimeSpan.Zero
+            };
+            return new UpdateSelection(settings, new NullNuKeeperLogger());
+        }
+
+        private static IUpdateSelection MinAgeTargetSelection(TimeSpan minAge)
+        {
+            const int maxPullRequests = 1000;
+
+            var settings = new FilterSettings
+            {
+                MaxPullRequests = maxPullRequests,
+                MinimumAge = minAge
+            };
+            return new UpdateSelection(settings, new NullNuKeeperLogger());
+        }
+
+        private static Task<bool> Pass(PackageUpdateSet s) => Task.FromResult(true);
+        private static Task<bool> Fail(PackageUpdateSet s) => Task.FromResult(false);
+
+        private Func<PackageUpdateSet, Task<bool>> FilterToId(string id)
+        {
+            return p => Task.FromResult(p.SelectedId == id);
+        }
+    }
+}

--- a/NuKeeper.Update/LinqAsync.cs
+++ b/NuKeeper.Update/LinqAsync.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Update
+{
+    public static class LinqAsync
+    {
+        /// <summary>
+        /// Filter a list by an async operation on each element
+        /// Code from: https://codereview.stackexchange.com/a/32162
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public static async Task<IEnumerable<T>> WhereAsync<T>(this IEnumerable<T> items, Func<T, Task<bool>> predicate)
+        {
+            var itemTaskList = items
+                .Select(item => new { Item = item, PredTask = predicate.Invoke(item) })
+                .ToList();
+
+            await Task.WhenAll(itemTaskList.Select(x => x.PredTask));
+
+            return itemTaskList
+                .Where(x => x.PredTask.Result)
+                .Select(x => x.Item);
+        }
+    }
+}

--- a/NuKeeper.Update/Selection/FilterSettings.cs
+++ b/NuKeeper.Update/Selection/FilterSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace NuKeeper.Update.Selection
+{
+    public class FilterSettings
+    {
+        public TimeSpan MinimumAge { get; set; }
+        public int MaxPullRequests { get; set; }
+        public Regex Excludes { get; set; }
+        public Regex Includes { get; set; }
+    }
+}

--- a/NuKeeper.Update/Selection/IUpdateSelection.cs
+++ b/NuKeeper.Update/Selection/IUpdateSelection.cs
@@ -1,0 +1,14 @@
+using NuKeeper.Inspection.RepositoryInspection;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Update.Selection
+{
+    public interface IUpdateSelection
+    {
+        Task<IReadOnlyCollection<PackageUpdateSet>> Filter(
+            IReadOnlyCollection<PackageUpdateSet> potentialUpdates,
+            Func<PackageUpdateSet, Task<bool>> remoteCheck);
+    }
+}

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -29,9 +29,9 @@ namespace NuKeeper.Update.Selection
         {
             var filtered = ApplyFilters(candidates);
 
-            filtered = await ApplyRemoteFilter(filtered, remoteCheck);
+            var remoteFiltered = await ApplyRemoteFilter(filtered, remoteCheck);
 
-            List<PackageUpdateSet> capped = filtered
+            List<PackageUpdateSet> capped = remoteFiltered
                 .Take(_settings.MaxPullRequests)
                 .ToList();
 

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -29,16 +29,11 @@ namespace NuKeeper.Update.Selection
         {
             var filtered = await ApplyFilters(candidates, remoteCheck);
 
-            List<PackageUpdateSet> capped = filtered
+            var capped = filtered
                 .Take(_settings.MaxPullRequests)
                 .ToList();
 
             LogPackageCounts(candidates.Count, filtered.Count, capped.Count);
-
-            foreach (var updateSet in capped)
-            {
-                _logger.Info($"Selected package update of {updateSet.SelectedId} to {updateSet.SelectedVersion}");
-            }
 
             return capped;
         }

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.RepositoryInspection;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Update.Selection
+{
+    public class UpdateSelection : IUpdateSelection
+    {
+        private readonly INuKeeperLogger _logger;
+
+        private readonly FilterSettings _settings;
+        private readonly DateTime _maxPublishedDate;
+
+        public UpdateSelection(FilterSettings settings,
+            INuKeeperLogger logger)
+        {
+            _logger = logger;
+            _settings = settings;
+            _maxPublishedDate = DateTime.UtcNow.Subtract(settings.MinimumAge);
+        }
+
+        public async Task<IReadOnlyCollection<PackageUpdateSet>> Filter(
+            IReadOnlyCollection<PackageUpdateSet> candidates,
+            Func<PackageUpdateSet, Task<bool>> remoteCheck)
+        {
+            var filtered = ApplyFilters(candidates);
+
+            filtered = await ApplyRemoteFilter(filtered, remoteCheck);
+
+            List<PackageUpdateSet> capped = filtered
+                .Take(_settings.MaxPullRequests)
+                .ToList();
+
+            LogPackageCounts(candidates.Count, filtered.Count, capped.Count);
+
+            foreach (var updateSet in capped)
+            {
+                _logger.Info($"Selected package update of {updateSet.SelectedId} to {updateSet.SelectedVersion}");
+            }
+
+            return capped;
+        }
+
+        private IReadOnlyCollection<PackageUpdateSet> ApplyFilters(
+            IReadOnlyCollection<PackageUpdateSet> all)
+        {
+            var filteredLocally = all
+                .Where(MatchesIncludeExclude)
+                .Where(MatchesMinAge)
+                .ToList();
+
+            if (filteredLocally.Count < all.Count)
+            {
+                _logger.Verbose($"Filtered by rules from {all.Count} to {filteredLocally.Count}");
+            }
+
+            return filteredLocally;
+        }
+
+        public static async Task<IReadOnlyCollection<PackageUpdateSet>> ApplyRemoteFilter(
+            IEnumerable<PackageUpdateSet> packageUpdateSets,
+            Func<PackageUpdateSet, Task<bool>> remoteCheck)
+        {
+            var results = await packageUpdateSets
+                .WhereAsync(async p => await remoteCheck(p));
+
+            return results.ToList();
+        }
+
+        private void LogPackageCounts(int candidates, int filtered, int capped)
+        {
+            var message = $"Selection of package updates: {candidates} candiates";
+            if (filtered < candidates)
+            {
+                message += $", filtered to {filtered}";
+            }
+
+            if (capped < filtered)
+            {
+                message +=  $", capped at {capped}";
+            }
+
+            _logger.Terse(message);
+        }
+
+        private bool MatchesIncludeExclude(PackageUpdateSet packageUpdateSet)
+        {
+            return 
+                MatchesInclude(_settings.Includes, packageUpdateSet)
+                && ! MatchesExclude(_settings.Excludes, packageUpdateSet);
+        }
+
+        private static bool MatchesInclude(Regex regex, PackageUpdateSet packageUpdateSet)
+        {
+            return regex == null || regex.IsMatch(packageUpdateSet.SelectedId);
+        }
+
+        private static bool MatchesExclude(Regex regex, PackageUpdateSet packageUpdateSet)
+        {
+            return regex != null && regex.IsMatch(packageUpdateSet.SelectedId);
+        }
+
+        private bool MatchesMinAge(PackageUpdateSet packageUpdateSet)
+        {
+            var published = packageUpdateSet.Selected.Published;
+            if (!published.HasValue)
+            {
+                return true;
+            }
+
+            return published.Value.UtcDateTime <= _maxPublishedDate;
+        }
+    }
+}

--- a/NuKeeper.sln
+++ b/NuKeeper.sln
@@ -18,7 +18,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Inspection", "NuKe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Inspection.Tests", "NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj", "{79562D03-D39D-4822-9F4B-B1001F556EA4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Update", "NuKeeper.Update\NuKeeper.Update.csproj", "{E210D6EF-4EC3-44DD-8E18-269A3647688B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Update", "NuKeeper.Update\NuKeeper.Update.csproj", "{E210D6EF-4EC3-44DD-8E18-269A3647688B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Update.Tests", "NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj", "{1336C9CF-8B90-428B-904B-2C223010FD16}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +52,10 @@ Global
 		{E210D6EF-4EC3-44DD-8E18-269A3647688B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E210D6EF-4EC3-44DD-8E18-269A3647688B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E210D6EF-4EC3-44DD-8E18-269A3647688B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1336C9CF-8B90-428B-904B-2C223010FD16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1336C9CF-8B90-428B-904B-2C223010FD16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1336C9CF-8B90-428B-904B-2C223010FD16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1336C9CF-8B90-428B-904B-2C223010FD16}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -2,6 +2,7 @@ using NuKeeper.Configuration;
 using NuKeeper.Update;
 using NuKeeper.Update.Process;
 using NuKeeper.Update.ProcessRunner;
+using NuKeeper.Update.Selection;
 using SimpleInjector;
 
 namespace NuKeeper
@@ -11,10 +12,23 @@ namespace NuKeeper
         public static void Register(Container container, SettingsContainer settings)
         {
             container.Register(() => settings.UserSettings.NuGetSources, Lifestyle.Singleton);
+            container.Register(() => MakeFilterSettings(settings.UserSettings), Lifestyle.Singleton);
 
+            container.Register<IUpdateSelection, UpdateSelection>();
             container.Register<IFileRestoreCommand, NuGetFileRestoreCommand>();
             container.Register<IExternalProcess, ExternalProcess>();
             container.Register<IUpdateRunner, UpdateRunner>();
+        }
+
+        private static FilterSettings MakeFilterSettings(UserSettings settings)
+        {
+            return new FilterSettings
+            {
+                Excludes = settings.PackageExcludes,
+                Includes = settings.PackageIncludes,
+                MaxPullRequests = settings.MaxPullRequestsPerRepository,
+                MinimumAge = settings.MinimumPackageAge
+            };
         }
     }
 }

--- a/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Github;
 using NuKeeper.Inspection.Logging;
@@ -19,15 +17,8 @@ namespace NuKeeper.Engine.Packages
             _logger = logger;
         }
 
-        public async Task<IReadOnlyCollection<PackageUpdateSet>> CanMakeBranchFor(ForkData pushFork, IEnumerable<PackageUpdateSet> packageUpdateSets)
-        {
-            var results = await packageUpdateSets
-                .WhereAsync(async p => await CanMakeBranchFor(pushFork, p));
-
-            return results.ToList();
-        }
-
-        private async Task<bool> CanMakeBranchFor(ForkData pushFork, PackageUpdateSet packageUpdateSet)
+        public async Task<bool> CanMakeBranchFor(PackageUpdateSet packageUpdateSet,
+            ForkData pushFork)
         {
             try
             {

--- a/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
@@ -1,13 +1,12 @@
 using NuKeeper.Inspection.RepositoryInspection;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NuKeeper.Engine.Packages
 {
     public interface IExistingBranchFilter
     {
-        Task<IReadOnlyCollection<PackageUpdateSet>> CanMakeBranchFor(
-            ForkData pushFork,
-            IEnumerable<PackageUpdateSet> packageUpdateSets);
+        Task<bool> CanMakeBranchFor(
+            PackageUpdateSet packageUpdateSet,
+            ForkData pushFork);
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using NuKeeper.Configuration;
 using NuKeeper.Inspection.Sort;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Update.Selection;
 
 namespace NuKeeper.Engine.Packages
 {
@@ -15,115 +13,37 @@ namespace NuKeeper.Engine.Packages
         private readonly INuKeeperLogger _logger;
         private readonly IExistingBranchFilter _existingBranchFilter;
         private readonly IPackageUpdateSetSort _sort;
+        private readonly IUpdateSelection _updateSelection;
 
-        private readonly Regex _excludeFilter;
-        private readonly Regex _includeFilter;
-        private readonly int _maxPullRequests;
-        private readonly DateTime _maxPublishedDate;
-
-        public PackageUpdateSelection(UserSettings settings,
+ 
+        public PackageUpdateSelection(
             IExistingBranchFilter existingBranchFilter,
             IPackageUpdateSetSort sort,
+            IUpdateSelection updateSelection,
             INuKeeperLogger logger)
         {
             _logger = logger;
             _existingBranchFilter = existingBranchFilter;
             _sort = sort;
-
-            _maxPullRequests = settings.MaxPullRequestsPerRepository;
-            _includeFilter = settings.PackageIncludes;
-            _excludeFilter = settings.PackageExcludes;
-            _maxPublishedDate = DateTime.UtcNow.Subtract(settings.MinimumPackageAge);
+            _updateSelection = updateSelection;
         }
 
         public async Task<IReadOnlyCollection<PackageUpdateSet>> SelectTargets(
             ForkData pushFork,
             IReadOnlyCollection<PackageUpdateSet> potentialUpdates)
         {
-            var unfiltered = _sort.Sort(potentialUpdates)
+            var sorted = _sort.Sort(potentialUpdates)
                 .ToList();
 
-            var filtered = await ApplyFilters(pushFork, unfiltered);
+            var filtered = await _updateSelection.Filter(sorted,
+                p => _existingBranchFilter.CanMakeBranchFor(p, pushFork));
 
-            var capped = filtered
-                .Take(_maxPullRequests)
-                .ToList();
-
-            LogPackageCounts(unfiltered.Count, filtered.Count, capped.Count);
-
-            foreach (var updateSet in capped)
+            foreach (var updateSet in filtered)
             {
                 _logger.Info($"Selected package update of {updateSet.SelectedId} to {updateSet.SelectedVersion}");
             }
 
-            return capped;
-        }
-
-        private async Task<IReadOnlyCollection<PackageUpdateSet>> ApplyFilters(
-            ForkData pushFork, IReadOnlyCollection<PackageUpdateSet> all)
-        {
-            var filteredLocally = all
-                .Where(MatchesIncludeExclude)
-                .Where(MatchesMinAge)
-                .ToList();
-
-            if (filteredLocally.Count < all.Count)
-            {
-                _logger.Verbose($"Filtered by rules from {all.Count} to {filteredLocally.Count}");
-            }
-
-            var filteredByBranch = await _existingBranchFilter.CanMakeBranchFor(pushFork, filteredLocally);
-
-            if (filteredByBranch.Count < filteredLocally.Count)
-            {
-                _logger.Verbose($"Filtered by existing branch from {filteredLocally.Count} to {filteredByBranch.Count}");
-            }
-
-            return filteredByBranch;
-        }
-
-        private void LogPackageCounts(int potential, int filtered, int capped)
-        {
-            var message = $"Selection of package updates: {potential} potential";
-            if (filtered < potential)
-            {
-                message += $", filtered to {filtered}";
-            }
-
-            if (capped < filtered)
-            {
-                message +=  $", capped at {capped}";
-            }
-
-            _logger.Terse(message);
-        }
-
-        private bool MatchesIncludeExclude(PackageUpdateSet packageUpdateSet)
-        {
-            return 
-                MatchesInclude(_includeFilter, packageUpdateSet)
-                && ! MatchesExclude(_excludeFilter, packageUpdateSet);
-        }
-
-        private static bool MatchesInclude(Regex regex, PackageUpdateSet packageUpdateSet)
-        {
-            return regex == null || regex.IsMatch(packageUpdateSet.SelectedId);
-        }
-
-        private static bool MatchesExclude(Regex regex, PackageUpdateSet packageUpdateSet)
-        {
-            return regex != null && regex.IsMatch(packageUpdateSet.SelectedId);
-        }
-
-        private bool MatchesMinAge(PackageUpdateSet packageUpdateSet)
-        {
-            var published = packageUpdateSet.Selected.Published;
-            if (!published.HasValue)
-            {
-                return true;
-            }
-
-            return published.Value.UtcDateTime <= _maxPublishedDate;
+            return filtered;
         }
     }
 }


### PR DESCRIPTION
`UpdateSelection` , extracted from `PackageUpdateSelection` lives in the `NuKeeper.Update` namespace, so that it can be used without any source control dependencies. Will be necessary for local Update Mode.