### PR TITLE
Infer nuget package sources for nuget.config

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var updates = await lookup.FindVersionUpdate(
                 CurrentVersion123("TestPackage"),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(updates, Is.Not.Null);
@@ -43,7 +43,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var updates = await lookup.FindVersionUpdate(
                 CurrentVersion123("TestPackage"),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(updates, Is.Not.Null);
@@ -68,7 +68,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var updates = await lookup.FindVersionUpdate(
                 CurrentVersion123("TestPackage"),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
@@ -91,7 +91,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var updates = await lookup.FindVersionUpdate(
                 CurrentVersion123("TestPackage"),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Minor);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
@@ -114,7 +114,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var updates = await lookup.FindVersionUpdate(
                 CurrentVersion123("TestPackage"),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Patch);
 
             AssertPackagesIdentityIs(updates, "TestPackage");

--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
 
 namespace NuKeeper.Inspection.Tests.NuGetApi
@@ -18,7 +19,10 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var allVersionsLookup = MockVersionLookup(new List<PackageSearchMedatadata>());
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), VersionChange.Major);
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage"),
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.Major, Is.Null);
@@ -37,7 +41,10 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), VersionChange.Major);
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage"),
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
             Assert.That(updates, Is.Not.Null);
 
@@ -59,7 +66,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"), 
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage"),
+                new NuGetSources("aSource"),
                 VersionChange.Major);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
@@ -80,7 +89,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"),
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage"),
+                new NuGetSources("aSource"),
                 VersionChange.Minor);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
@@ -101,7 +112,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
-            var updates = await lookup.FindVersionUpdate(CurrentVersion123("TestPackage"),
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage"),
+                new NuGetSources("aSource"),
                 VersionChange.Patch);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
@@ -112,7 +125,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadata> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();
-            allVersions.Lookup(Arg.Any<string>())
+            allVersions.Lookup(Arg.Any<string>(), Arg.Any<NuGetSources>())
                 .Returns(actualResults);
             return allVersions;
         }

--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
 
 namespace NuKeeper.Inspection.Tests.NuGetApi
@@ -19,12 +20,16 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var apiLookup = Substitute.For<IApiPackageLookup>();
             var bulkLookup = BuildBulkPackageLookup(apiLookup);
 
-            var results = await bulkLookup.FindVersionUpdates(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(
+                Enumerable.Empty<PackageIdentity>(),
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
 
-            await apiLookup.DidNotReceive().FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
+            await apiLookup.DidNotReceive().FindVersionUpdate(
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>());
         }
 
         [Test]
@@ -41,7 +46,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries,
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Not.Empty);
@@ -63,9 +70,12 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
+            await bulkLookup.FindVersionUpdates(queries,
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
-            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
+            await apiLookup.Received(1).FindVersionUpdate(
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>());
         }
 
         [Test]
@@ -84,7 +94,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries,
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
             Assert.That(results.Count, Is.EqualTo(2));
             Assert.That(results.ContainsKey("foo"), Is.True);
@@ -108,11 +120,13 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("bar", new NuGetVersion(1, 2, 3))
             };
 
-            await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
+            await bulkLookup.FindVersionUpdates(queries,
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
-            await apiLookup.Received(2).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
+            await apiLookup.Received(2).FindVersionUpdate(
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>());
         }
-
 
         [Test]
         public async Task WhenThereAreMultipleVersionOfTheSamePackage()
@@ -129,11 +143,15 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(1, 3, 4))
             };
 
-            var results = await bulkLookup.FindVersionUpdates(queries, VersionChange.Major);
+            var results = await bulkLookup.FindVersionUpdates(queries,
+                new NuGetSources("aSource"),
+                VersionChange.Major);
 
-            await apiLookup.Received(1).FindVersionUpdate(Arg.Any<PackageIdentity>(), Arg.Any<VersionChange>());
+            await apiLookup.Received(1).FindVersionUpdate(
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>());
             await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(
-                pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)), Arg.Any<VersionChange>());
+                pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)),
+                Arg.Any<NuGetSources>(), Arg.Any<VersionChange>());
 
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results.ContainsKey("foo"), Is.True);
@@ -146,7 +164,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity(packageName, new NuGetVersion(2, 3, 4)), "test",
                 DateTimeOffset.Now, null);
 
-            lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName), Arg.Any<VersionChange>())
+            lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName),
+                    Arg.Any<NuGetSources>(), Arg.Any<VersionChange>())
                 .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData, responseMetaData));
         }
 

--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             var results = await bulkLookup.FindVersionUpdates(
                 Enumerable.Empty<PackageIdentity>(),
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
@@ -47,7 +47,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
 
             var results = await bulkLookup.FindVersionUpdates(queries,
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
@@ -71,7 +71,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
 
             await bulkLookup.FindVersionUpdates(queries,
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(
@@ -95,7 +95,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
 
             var results = await bulkLookup.FindVersionUpdates(queries,
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(results.Count, Is.EqualTo(2));
@@ -121,7 +121,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
 
             await bulkLookup.FindVersionUpdates(queries,
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             await apiLookup.Received(2).FindVersionUpdate(
@@ -144,7 +144,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
 
             var results = await bulkLookup.FindVersionUpdates(queries,
-                new NuGetSources("aSource"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             await apiLookup.Received(1).FindVersionUpdate(

--- a/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
@@ -1,6 +1,8 @@
 using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace NuKeeper.Inspection.Tests.Sources
 {
@@ -14,7 +16,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
 
-            var sources = parser.Parse(data);
+            var sources = parser.Parse(ToStream(data));
 
             Assert.That(sources, Is.Null);
         }
@@ -26,7 +28,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
 
-            var sources = parser.Parse(data);
+            var sources = parser.Parse(ToStream(data));
 
             Assert.That(sources, Is.Null);
         }
@@ -44,7 +46,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
 
-            var sources = parser.Parse(data);
+            var sources = parser.Parse(ToStream(data));
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(1));
@@ -65,7 +67,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
 
-            var sources = parser.Parse(data);
+            var sources = parser.Parse(ToStream(data));
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(2));
@@ -85,10 +87,16 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
 
-            var sources = parser.Parse(data);
+            var sources = parser.Parse(ToStream(data));
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(1));
+        }
+
+        private static Stream ToStream(string str, Encoding enc = null)
+        {
+            enc = enc ?? Encoding.UTF8;
+            return new MemoryStream(enc.GetBytes(str ?? ""));
         }
     }
 }

--- a/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
@@ -40,7 +40,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+    <add key=""NuGet official"" value=""https://api.nuget.org/v3/index.json"" />
   </packageSources>
 </configuration>";
 
@@ -50,7 +50,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(1));
-            Assert.That(sources.Items.First(), Is.EqualTo("https://nuget.org/api/v2/"));
+            Assert.That(sources.Items.First(), Is.EqualTo(NuGetSources.GlobalFeedUrl));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+    <add key=""NuGet official"" value=""https://api.nuget.org/v3/index.json"" />
     <add key=""Custom"" value=""https://some.other.feed"" />
   </packageSources>
 </configuration>";
@@ -71,6 +71,8 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(2));
+            Assert.That(sources.Items.First(), Is.EqualTo(NuGetSources.GlobalFeedUrl));
+            Assert.That(sources.Items.Last(), Is.EqualTo("https://some.other.feed"));
         }
 
         [Test]
@@ -80,7 +82,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+    <add key=""NuGet official"" value=""https://api.nuget.org/v3/index.json"" />
     <add key=""Custom"" />
   </packageSources>
 </configuration>";
@@ -91,6 +93,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 
             Assert.That(sources, Is.Not.Null);
             Assert.That(sources.Items.Count, Is.EqualTo(1));
+            Assert.That(sources.Items.First(), Is.EqualTo(NuGetSources.GlobalFeedUrl));
         }
 
         private static Stream ToStream(string str, Encoding enc = null)

--- a/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
@@ -1,0 +1,94 @@
+using NuKeeper.Inspection.Sources;
+using NUnit.Framework;
+using System.Linq;
+
+namespace NuKeeper.Inspection.Tests.Sources
+{
+    [TestFixture]
+    public class NugetConfigFileParserTests
+    {
+        [Test]
+        public void EmptyStringReturnsNull()
+        {
+            var data = string.Empty;
+
+            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+
+            var sources = parser.Parse(data);
+
+            Assert.That(sources, Is.Null);
+        }
+
+        [Test]
+        public void InvalidStringReturnsNull()
+        {
+            var data = "not valid markup";
+
+            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+
+            var sources = parser.Parse(data);
+
+            Assert.That(sources, Is.Null);
+        }
+
+        [Test]
+        public void ValidDataWithOneItemReturnsThatItem()
+        {
+            var data =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+  </packageSources>
+</configuration>";
+
+            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+
+            var sources = parser.Parse(data);
+
+            Assert.That(sources, Is.Not.Null);
+            Assert.That(sources.Items.Count, Is.EqualTo(1));
+            Assert.That(sources.Items.First(), Is.EqualTo("https://nuget.org/api/v2/"));
+        }
+
+        [Test]
+        public void ValidDataWithTwoItemsReturnsBoth()
+        {
+            var data =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+    <add key=""Custom"" value=""https://some.other.feed"" />
+  </packageSources>
+</configuration>";
+
+            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+
+            var sources = parser.Parse(data);
+
+            Assert.That(sources, Is.Not.Null);
+            Assert.That(sources.Items.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void InvalidSourcesAreOmitted()
+        {
+            var data =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""NuGet official"" value=""https://nuget.org/api/v2/"" />
+    <add key=""Custom"" />
+  </packageSources>
+</configuration>";
+
+            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+
+            var sources = parser.Parse(data);
+
+            Assert.That(sources, Is.Not.Null);
+            Assert.That(sources.Items.Count, Is.EqualTo(1));
+        }
+    }
+}

--- a/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Sources;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.Sources
+{
+    public class NugetSourcesReaderTests
+    {
+        [Test]
+        public void OverrideSourcesAreUsedWhenSupplied()
+        {
+            var overrrideSources = new NuGetSources("overrideA");
+            var reader = MakeNuGetSourcesReader(overrrideSources);
+
+            var ff = new FolderFactory(new NullNuKeeperLogger());
+
+            var result = reader.Read(ff.UniqueTemporaryFolder());
+
+            Assert.That(result, Is.EqualTo(overrrideSources));
+        }
+
+        [Test]
+        public void GlobalFeedIsUsedAsLastResort()
+        {
+            var reader = MakeNuGetSourcesReader(null);
+
+            var ff = new FolderFactory(new NullNuKeeperLogger());
+
+            var result = reader.Read(ff.UniqueTemporaryFolder());
+
+            Assert.That(result.Items.Count, Is.EqualTo(1));
+            Assert.That(result.Items.First(), Is.EqualTo(NuGetSources.GlobalFeedUrl));
+        }
+
+        private static INugetSourcesReader MakeNuGetSourcesReader(NuGetSources fallbackSources)
+        {
+            var logger = new NullNuKeeperLogger();
+            return new NugetSourcesReader(fallbackSources,
+                new NugetConfigFileReader
+                    (new NugetConfigFileParser(logger), logger), logger);
+        }
+    }
+}

--- a/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Sources;
@@ -25,12 +26,55 @@ namespace NuKeeper.Inspection.Tests.Sources
         {
             var reader = MakeNuGetSourcesReader(null);
 
-            var ff = new FolderFactory(new NullNuKeeperLogger());
-
-            var result = reader.Read(ff.UniqueTemporaryFolder());
+            var result = reader.Read(TemporaryFolder());
 
             Assert.That(result.Items.Count, Is.EqualTo(1));
             Assert.That(result.Items.First(), Is.EqualTo(NuGetSources.GlobalFeedUrl));
+        }
+
+        private const string ConfigFileContents =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""From A file"" value=""https://fromFile1.com"" />
+  </packageSources>
+</configuration>";
+
+        [Test]
+        public void ConfigFileIsUsed()
+        {
+            var reader = MakeNuGetSourcesReader(null);
+
+            var folder = TemporaryFolder();
+            var path = Path.Join(folder.FullPath, "nuget.config");
+            File.WriteAllText(path, ConfigFileContents);
+
+            var result = reader.Read(folder);
+
+            Assert.That(result.Items.Count, Is.EqualTo(1));
+            Assert.That(result.Items.First(), Is.EqualTo("https://fromFile1.com"));
+        }
+
+
+        [Test]
+        public void SettingsOverridesConfigFile()
+        {
+            var reader = MakeNuGetSourcesReader(new NuGetSources("https://fromConfigA.com"));
+
+            var folder = TemporaryFolder();
+            var path = Path.Join(folder.FullPath, "nuget.config");
+            File.WriteAllText(path, ConfigFileContents);
+
+            var result = reader.Read(folder);
+
+            Assert.That(result.Items.Count, Is.EqualTo(1));
+            Assert.That(result.Items.First(), Is.EqualTo("https://fromConfigA.com"));
+        }
+
+        private static IFolder TemporaryFolder()
+        {
+            var ff = new FolderFactory(new NullNuKeeperLogger());
+            return ff.UniqueTemporaryFolder();
         }
 
         private static INugetSourcesReader MakeNuGetSourcesReader(NuGetSources fallbackSources)

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -1,12 +1,14 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.Inspection
 {
     public interface IUpdateFinder
     {
-        Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder);
+        Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
+            IFolder workingFolder, VersionChange allowedChange);
     }
 }

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -3,12 +3,14 @@ using System.Threading.Tasks;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection
 {
     public interface IUpdateFinder
     {
         Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
-            IFolder workingFolder, VersionChange allowedChange);
+            IFolder workingFolder,
+            VersionChange allowedChange, NuGetSources overrideSources);
     }
 }

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -11,6 +11,7 @@ namespace NuKeeper.Inspection
     {
         Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
             IFolder workingFolder,
-            VersionChange allowedChange, NuGetSources overrideSources);
+            NuGetSources sources,
+            VersionChange allowedChange);
     }
 }

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -7,6 +7,6 @@ namespace NuKeeper.Inspection
 {
     public interface IUpdateFinder
     {
-        Task<List<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder);
+        Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
@@ -13,9 +14,11 @@ namespace NuKeeper.Inspection.NuGetApi
         }
 
         public async Task<PackageLookupResult> FindVersionUpdate(
-            PackageIdentity package, VersionChange allowedChange)
+            PackageIdentity package,
+            NuGetSources sources,
+            VersionChange allowedChange)
         {
-            var foundVersions = await _packageVersionsLookup.Lookup(package.Id);
+            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, sources);
             return VersionChanges.MakeVersions(package.Version, foundVersions, allowedChange);
         }
     }

--- a/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
@@ -19,14 +20,16 @@ namespace NuKeeper.Inspection.NuGetApi
         }
 
         public async Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
-            IEnumerable<PackageIdentity> packages, VersionChange allowedChange)
+            IEnumerable<PackageIdentity> packages,
+            NuGetSources sources,
+            VersionChange allowedChange)
         {
             var latestOfEach = packages
                 .GroupBy(pi => pi.Id)
                 .Select(HighestVersion);
 
             var lookupTasks = latestOfEach
-                .Select(id => _packageLookup.FindVersionUpdate(id, allowedChange))
+                .Select(id => _packageLookup.FindVersionUpdate(id, sources, allowedChange))
                 .ToList();
 
             await Task.WhenAll(lookupTasks);

--- a/NuKeeper.Inspection/NuGetApi/IApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IApiPackageLookup.cs
@@ -1,10 +1,14 @@
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
     public interface IApiPackageLookup
     {
-        Task<PackageLookupResult> FindVersionUpdate(PackageIdentity package, VersionChange allowedChange);
+        Task<PackageLookupResult> FindVersionUpdate(
+            PackageIdentity package,
+            NuGetSources sources,
+            VersionChange allowedChange);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
@@ -8,6 +9,7 @@ namespace NuKeeper.Inspection.NuGetApi
     {
         Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
+            NuGetSources sources,
             VersionChange allowedChange);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
     public interface IPackageUpdatesLookup
     {
-        Task<List<PackageUpdateSet>> FindUpdatesForPackages(IReadOnlyCollection<PackageInProject> packages);
+        Task<IReadOnlyCollection<PackageUpdateSet>> FindUpdatesForPackages(
+            IReadOnlyCollection<PackageInProject> packages,
+            NuGetSources sources);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
@@ -9,6 +9,7 @@ namespace NuKeeper.Inspection.NuGetApi
     {
         Task<IReadOnlyCollection<PackageUpdateSet>> FindUpdatesForPackages(
             IReadOnlyCollection<PackageInProject> packages,
-            NuGetSources sources);
+            NuGetSources sources,
+            VersionChange allowedChange);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
     public interface IPackageVersionsLookup
     {
-        Task<IEnumerable<PackageSearchMedatadata>> Lookup(string packageName);
+        Task<IReadOnlyCollection<PackageSearchMedatadata>> Lookup(
+            string packageName, NuGetSources sources);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
@@ -1,7 +1,0 @@
-namespace NuKeeper.Inspection.NuGetApi
-{
-    public class PackageUpdateLookupSettings
-    {
-        public VersionChange AllowedChange { get; set; }
-    }
-}

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
@@ -6,6 +6,6 @@ namespace NuKeeper.Inspection.NuGetApi
     {
         public VersionChange AllowedChange { get; set; }
 
-        public IReadOnlyCollection<string> NugetSources { get; set; }
+        public NuGetSources NuGetSources { get; set; }
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdateLookupSettings.cs
@@ -1,11 +1,7 @@
-using NuKeeper.Inspection.Sources;
-
 namespace NuKeeper.Inspection.NuGetApi
 {
     public class PackageUpdateLookupSettings
     {
         public VersionChange AllowedChange { get; set; }
-
-        public NuGetSources NuGetSources { get; set; }
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
@@ -9,25 +9,23 @@ namespace NuKeeper.Inspection.NuGetApi
     public class PackageUpdatesLookup : IPackageUpdatesLookup
     {
         private readonly IBulkPackageLookup _bulkPackageLookup;
-        private readonly VersionChange _allowedChange;
 
-        public PackageUpdatesLookup(IBulkPackageLookup bulkPackageLookup, PackageUpdateLookupSettings settings)
+        public PackageUpdatesLookup(IBulkPackageLookup bulkPackageLookup)
         {
             _bulkPackageLookup = bulkPackageLookup;
-            _allowedChange = settings.AllowedChange;
         }
 
         public async Task<IReadOnlyCollection<PackageUpdateSet>> FindUpdatesForPackages(
             IReadOnlyCollection<PackageInProject> packages,
-            NuGetSources sources
-            )
+            NuGetSources sources,
+            VersionChange allowedChange)
         {
             var packageIds = packages
                 .Select(p => p.Identity)
                 .Distinct();
 
             var latestVersions = await _bulkPackageLookup.FindVersionUpdates(
-                packageIds, sources, _allowedChange);
+                packageIds, sources, allowedChange);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
@@ -16,13 +17,17 @@ namespace NuKeeper.Inspection.NuGetApi
             _allowedChange = settings.AllowedChange;
         }
 
-        public async Task<List<PackageUpdateSet>> FindUpdatesForPackages(IReadOnlyCollection<PackageInProject> packages)
+        public async Task<IReadOnlyCollection<PackageUpdateSet>> FindUpdatesForPackages(
+            IReadOnlyCollection<PackageInProject> packages,
+            NuGetSources sources
+            )
         {
             var packageIds = packages
                 .Select(p => p.Identity)
                 .Distinct();
 
-            var latestVersions = await _bulkPackageLookup.FindVersionUpdates(packageIds, _allowedChange);
+            var latestVersions = await _bulkPackageLookup.FindVersionUpdates(
+                packageIds, sources, _allowedChange);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -14,23 +14,24 @@ namespace NuKeeper.Inspection.NuGetApi
     public class PackageVersionsLookup : IPackageVersionsLookup
     {
         private readonly ILogger _logger;
-        private readonly NuGetSources _sources;
 
-        public PackageVersionsLookup(ILogger logger, PackageUpdateLookupSettings settings)
+        public PackageVersionsLookup(ILogger logger)
         {
             _logger = logger;
-            _sources = settings.NuGetSources;
         }
 
-        public async Task<IEnumerable<PackageSearchMedatadata>> Lookup(string packageName)
+        public async Task<IReadOnlyCollection<PackageSearchMedatadata>> Lookup(
+            string packageName,
+            NuGetSources sources)
         {
-            var tasks = _sources.Items.Select(s => RunFinderForSource(packageName, s));
+            var tasks = sources.Items.Select(s => RunFinderForSource(packageName, s));
 
             var results = await Task.WhenAll(tasks);
 
             return results
                 .SelectMany(r => r)
-                .Where(p => p?.Identity?.Version != null);
+                .Where(p => p?.Identity?.Version != null)
+                .ToList();
         }
 
         private async Task<IEnumerable<PackageSearchMedatadata>> RunFinderForSource(string packageName, string source)

--- a/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
@@ -1,9 +1,0 @@
-using NuKeeper.Inspection.Files;
-
-namespace NuKeeper.Inspection.Sources
-{
-    public interface INugetSourcesFactory
-    {
-        NuGetSources ReadNugetSources(IFolder workingFolder);
-    }
-}

--- a/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
@@ -1,0 +1,9 @@
+﻿using NuKeeper.Inspection.Files;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public interface INugetSourcesFactory
+    {
+        NuGetSources ReadNugetSources(IFolder workingFolder);
+    }
+}

--- a/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/INugetSourcesFactory.cs
@@ -1,4 +1,4 @@
-﻿using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Files;
 
 namespace NuKeeper.Inspection.Sources
 {

--- a/NuKeeper.Inspection/Sources/INugetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/INugetSourcesReader.cs
@@ -4,6 +4,6 @@ namespace NuKeeper.Inspection.Sources
 {
     public interface INugetSourcesReader
     {
-        NuGetSources Read(IFolder workingFolder);
+        NuGetSources Read(IFolder workingFolder, NuGetSources overrideValues);
     }
 }

--- a/NuKeeper.Inspection/Sources/INugetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/INugetSourcesReader.cs
@@ -1,0 +1,9 @@
+using NuKeeper.Inspection.Files;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public interface INugetSourcesReader
+    {
+        NuGetSources Read(IFolder workingFolder);
+    }
+}

--- a/NuKeeper.Inspection/Sources/NuGetSources.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSources.cs
@@ -22,6 +22,8 @@ namespace NuKeeper.Inspection.Sources
             Items = items.ToList();
         }
 
+        public static NuGetSources GlobalFeed => new NuGetSources("https://api.nuget.org/v3/index.json");
+
         public IReadOnlyCollection<string> Items { get; }
 
         public string CommandLine(string prefix)

--- a/NuKeeper.Inspection/Sources/NuGetSources.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSources.cs
@@ -22,7 +22,9 @@ namespace NuKeeper.Inspection.Sources
             Items = items.ToList();
         }
 
-        public static NuGetSources GlobalFeed => new NuGetSources("https://api.nuget.org/v3/index.json");
+        public static string GlobalFeedUrl = "https://api.nuget.org/v3/index.json";
+
+        public static NuGetSources GlobalFeed => new NuGetSources(GlobalFeedUrl);
 
         public IReadOnlyCollection<string> Items { get; }
 

--- a/NuKeeper.Inspection/Sources/NuGetSources.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSources.cs
@@ -14,6 +14,11 @@ namespace NuKeeper.Inspection.Sources
                 throw new ArgumentNullException(nameof(items));
             }
 
+            if (!items.Any())
+            {
+                throw new ArgumentException(nameof(items));
+            }
+
             Items = items.ToList();
         }
 

--- a/NuKeeper.Inspection/Sources/NuGetSources.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSources.cs
@@ -3,7 +3,7 @@ using NuKeeper.Inspection.Formats;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NuKeeper.Update
+namespace NuKeeper.Inspection.Sources
 {
     public class NuGetSources
     {

--- a/NuKeeper.Inspection/Sources/NugetConfigFileParser.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileParser.cs
@@ -1,5 +1,6 @@
 using NuKeeper.Inspection.Logging;
 using System;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -14,18 +15,13 @@ namespace NuKeeper.Inspection.Sources
             _logger = logger;
         }
 
-        public NuGetSources Parse(string data)
+        public NuGetSources Parse(Stream fileContents)
         {
-            if (string.IsNullOrWhiteSpace(data))
-            {
-                return null;
-            }
-
             XDocument xml;
 
             try
             {
-                xml = XDocument.Parse(data);
+                xml = XDocument.Load(fileContents);
             }
             catch (Exception ex)
             {

--- a/NuKeeper.Inspection/Sources/NugetConfigFileParser.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileParser.cs
@@ -1,0 +1,64 @@
+using NuKeeper.Inspection.Logging;
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public class NugetConfigFileParser
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public NugetConfigFileParser(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public NuGetSources Parse(string data)
+        {
+            if (string.IsNullOrWhiteSpace(data))
+            {
+                return null;
+            }
+
+            XDocument xml;
+
+            try
+            {
+                xml = XDocument.Parse(data);
+            }
+            catch (Exception ex)
+            {
+                _logger.Verbose($"failed to parse nuget.config file: {ex} {ex.Message}");
+                return null;
+            }
+
+            var config = xml.Element("configuration");
+            if (config == null)
+            {
+                return null;
+            }
+
+
+            var sources = config.Element("packageSources");
+            if (sources == null)
+            {
+                return null;
+            }
+
+            var adds = sources.Elements("add");
+
+            var values = adds
+                .Select(a => a.Attribute("value")?.Value)
+                .Where(v => ! string.IsNullOrWhiteSpace(v))
+                .ToList();
+
+            if (values.Count == 0)
+            {
+                return null;
+            }
+
+            return new NuGetSources(values);
+        }
+    }
+}

--- a/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
@@ -28,12 +28,18 @@ namespace NuKeeper.Inspection.Sources
                 return null;
             }
 
+            return ReadFromFile(configFile);
+        }
+
+        private NuGetSources ReadFromFile(FileInfo configFile)
+        {
             using (var fileContents = File.OpenRead(configFile.FullName))
             {
+                _logger.Verbose($"Reading nuget.config file {configFile.FullName}");
                 var fromFile = _parser.Parse(fileContents);
-                if (fromFile != null && fromFile.Items.Count > 0)
+                if (fromFile != null)
                 {
-                    _logger.Verbose($"Read {fromFile.Items.Count} NuGet sources from file {configFile.FullName}");
+                    _logger.Verbose($"Read {fromFile.Items.Count} NuGet sources from file");
                     return fromFile;
                 }
             }

--- a/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
@@ -35,11 +35,12 @@ namespace NuKeeper.Inspection.Sources
         {
             using (var fileContents = File.OpenRead(configFile.FullName))
             {
-                _logger.Verbose($"Reading nuget.config file {configFile.FullName}");
+                _logger.Verbose($"Reading nuget.config file {configFile.FullName} for package sources");
                 var fromFile = _parser.Parse(fileContents);
                 if (fromFile != null)
                 {
-                    _logger.Verbose($"Read {fromFile.Items.Count} NuGet sources from file");
+                    var itemsText = string.Join(',', fromFile.Items);
+                    _logger.Verbose($"Read {fromFile.Items.Count} package sources from file: {itemsText}");
                     return fromFile;
                 }
             }

--- a/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
@@ -1,16 +1,21 @@
 using System.IO;
 using System.Linq;
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.Sources
 {
     public class NugetConfigFileReader
     {
-        private NugetConfigFileParser _parser;
+        private readonly NugetConfigFileParser _parser;
+        private readonly INuKeeperLogger _logger;
 
-        public NugetConfigFileReader(NugetConfigFileParser parser)
+        public NugetConfigFileReader(
+            NugetConfigFileParser parser,
+            INuKeeperLogger logger)
         {
             _parser = parser;
+            _logger = logger;
         }
 
         public NuGetSources ReadNugetSources(IFolder workingFolder)
@@ -25,8 +30,15 @@ namespace NuKeeper.Inspection.Sources
 
             using (var fileContents = File.OpenRead(configFile.FullName))
             {
-                return _parser.Parse(fileContents);
+                var fromFile = _parser.Parse(fileContents);
+                if (fromFile != null && fromFile.Items.Count > 0)
+                {
+                    _logger.Verbose($"Read {fromFile.Items.Count} NuGet sources from file {configFile.FullName}");
+                    return fromFile;
+                }
             }
+
+            return null;
         }
     }
 }

--- a/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetConfigFileReader.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+using NuKeeper.Inspection.Files;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public class NugetConfigFileReader
+    {
+        private NugetConfigFileParser _parser;
+
+        public NugetConfigFileReader(NugetConfigFileParser parser)
+        {
+            _parser = parser;
+        }
+
+        public NuGetSources ReadNugetSources(IFolder workingFolder)
+        {
+            var configFile = workingFolder.Find("nuget.config")
+                .FirstOrDefault();
+
+            if (configFile == null)
+            {
+                return null;
+            }
+
+            using (var fileContents = File.OpenRead(configFile.FullName))
+            {
+                return _parser.Parse(fileContents);
+            }
+        }
+    }
+}

--- a/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
@@ -7,8 +7,6 @@ namespace NuKeeper.Inspection.Sources
         private readonly NuGetSources _fromSettings;
         private readonly NugetConfigFileReader _reader;
 
-        private const string DefaultFeed = "https://api.nuget.org/v3/index.json";
-
         public NugetSourcesFactory(
             NuGetSources fromSettings,
             NugetConfigFileReader reader)
@@ -31,7 +29,7 @@ namespace NuKeeper.Inspection.Sources
                 return fromConfigFile;
             }
 
-            return new NuGetSources(DefaultFeed);
+            return NuGetSources.GlobalFeed;
         }
     }
 }

--- a/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
@@ -1,0 +1,42 @@
+
+
+using NuKeeper.Inspection.Files;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public class NugetSourcesFactory : INugetSourcesFactory
+    {
+        private readonly NuGetSources _fromSettings;
+        private readonly NugetConfigFileReader _reader;
+
+        public NugetSourcesFactory(
+            NuGetSources fromSettings,
+            NugetConfigFileReader reader)
+        {
+            _fromSettings = fromSettings;
+            _reader = reader;
+        }
+
+        public NuGetSources ReadNugetSources(IFolder workingFolder)
+        {
+            if (_fromSettings != null)
+            {
+                return _fromSettings;
+            }
+
+            var fromConfigFile = _reader.ReadNugetSources(workingFolder);
+
+            if (fromConfigFile != null)
+            {
+                return fromConfigFile;
+            }
+
+            return DefaultFeed();
+        }
+
+        private NuGetSources DefaultFeed()
+        {
+            return new NuGetSources("https://api.nuget.org/v3/index.json");
+        }
+    }
+}

--- a/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
+++ b/NuKeeper.Inspection/Sources/NugetSourcesFactory.cs
@@ -1,5 +1,3 @@
-
-
 using NuKeeper.Inspection.Files;
 
 namespace NuKeeper.Inspection.Sources
@@ -8,6 +6,8 @@ namespace NuKeeper.Inspection.Sources
     {
         private readonly NuGetSources _fromSettings;
         private readonly NugetConfigFileReader _reader;
+
+        private const string DefaultFeed = "https://api.nuget.org/v3/index.json";
 
         public NugetSourcesFactory(
             NuGetSources fromSettings,
@@ -31,12 +31,7 @@ namespace NuKeeper.Inspection.Sources
                 return fromConfigFile;
             }
 
-            return DefaultFeed();
-        }
-
-        private NuGetSources DefaultFeed()
-        {
-            return new NuGetSources("https://api.nuget.org/v3/index.json");
+            return new NuGetSources(DefaultFeed);
         }
     }
 }

--- a/NuKeeper.Inspection/Sources/NugetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetSourcesReader.cs
@@ -5,25 +5,22 @@ namespace NuKeeper.Inspection.Sources
 {
     public class NugetSourcesReader : INugetSourcesReader
     {
-        private readonly NuGetSources _fromSettings;
         private readonly NugetConfigFileReader _reader;
         private readonly INuKeeperLogger _logger;
 
         public NugetSourcesReader(
-            NuGetSources fromSettings,
             NugetConfigFileReader reader,
             INuKeeperLogger logger)
         {
-            _fromSettings = fromSettings;
             _reader = reader;
             _logger = logger;
         }
 
-        public NuGetSources Read(IFolder workingFolder)
+        public NuGetSources Read(IFolder workingFolder, NuGetSources overrideValues)
         {
-            if (_fromSettings != null)
+            if (overrideValues != null)
             {
-                return _fromSettings;
+                return overrideValues;
             }
 
             var fromConfigFile = _reader.ReadNugetSources(workingFolder);

--- a/NuKeeper.Inspection/Sources/NugetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/NugetSourcesReader.cs
@@ -1,21 +1,25 @@
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public class NugetSourcesFactory : INugetSourcesFactory
+    public class NugetSourcesReader : INugetSourcesReader
     {
         private readonly NuGetSources _fromSettings;
         private readonly NugetConfigFileReader _reader;
+        private readonly INuKeeperLogger _logger;
 
-        public NugetSourcesFactory(
+        public NugetSourcesReader(
             NuGetSources fromSettings,
-            NugetConfigFileReader reader)
+            NugetConfigFileReader reader,
+            INuKeeperLogger logger)
         {
             _fromSettings = fromSettings;
             _reader = reader;
+            _logger = logger;
         }
 
-        public NuGetSources ReadNugetSources(IFolder workingFolder)
+        public NuGetSources Read(IFolder workingFolder)
         {
             if (_fromSettings != null)
             {
@@ -29,6 +33,7 @@ namespace NuKeeper.Inspection.Sources
                 return fromConfigFile;
             }
 
+            _logger.Verbose("Using default global NuGet feed");
             return NuGetSources.GlobalFeed;
         }
     }

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -14,23 +14,21 @@ namespace NuKeeper.Inspection
         private readonly IRepositoryScanner _repositoryScanner;
         private readonly IPackageUpdatesLookup _packageUpdatesLookup;
         private readonly INuKeeperLogger _logger;
-        private readonly INugetSourcesReader _nugetSourcesReader;
 
         public UpdateFinder(
             IRepositoryScanner repositoryScanner,
             IPackageUpdatesLookup packageUpdatesLookup,
-            INugetSourcesReader nugetSourcesReader,
             INuKeeperLogger logger)
         {
             _repositoryScanner = repositoryScanner;
             _packageUpdatesLookup = packageUpdatesLookup;
-            _nugetSourcesReader = nugetSourcesReader;
             _logger = logger;
         }
 
         public async Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
             IFolder workingFolder,
-            VersionChange allowedChange, NuGetSources overrideSources)
+            NuGetSources sources,
+            VersionChange allowedChange)
         {
             // scan for nuget packages
             var packages = _repositoryScanner.FindAllNuGetPackages(workingFolder)
@@ -38,11 +36,9 @@ namespace NuKeeper.Inspection
 
             _logger.Log(PackagesFoundLogger.Log(packages));
 
-            var nugetSources = _nugetSourcesReader.Read(workingFolder, overrideSources);
-
             // look for updates to these packages
             var updates = await _packageUpdatesLookup.FindUpdatesForPackages(
-                packages, nugetSources, allowedChange);
+                packages, sources, allowedChange);
 
             _logger.Log(UpdatesLogger.Log(updates));
             return updates;

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -5,6 +5,7 @@ using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection
 {
@@ -13,18 +14,21 @@ namespace NuKeeper.Inspection
         private readonly IRepositoryScanner _repositoryScanner;
         private readonly IPackageUpdatesLookup _packageUpdatesLookup;
         private readonly INuKeeperLogger _logger;
+        private readonly INugetSourcesFactory _nugetSourcesFactory;
 
         public UpdateFinder(
             IRepositoryScanner repositoryScanner,
             IPackageUpdatesLookup packageUpdatesLookup,
+            INugetSourcesFactory nugetSourcesFactory,
             INuKeeperLogger logger)
         {
             _repositoryScanner = repositoryScanner;
             _packageUpdatesLookup = packageUpdatesLookup;
+            _nugetSourcesFactory = nugetSourcesFactory;
             _logger = logger;
         }
 
-        public async Task<List<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder)
+        public async Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder)
         {
             // scan for nuget packages
             var packages = _repositoryScanner.FindAllNuGetPackages(workingFolder)
@@ -32,8 +36,10 @@ namespace NuKeeper.Inspection
 
             _logger.Log(PackagesFoundLogger.Log(packages));
 
+            var nugetSources = _nugetSourcesFactory.ReadNugetSources(workingFolder);
+
             // look for updates to these packages
-            var updates = await _packageUpdatesLookup.FindUpdatesForPackages(packages);
+            var updates = await _packageUpdatesLookup.FindUpdatesForPackages(packages, nugetSources);
             _logger.Log(UpdatesLogger.Log(updates));
             return updates;
         }

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -29,7 +29,8 @@ namespace NuKeeper.Inspection
         }
 
         public async Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
-            IFolder workingFolder, VersionChange allowedChange)
+            IFolder workingFolder,
+            VersionChange allowedChange, NuGetSources overrideSources)
         {
             // scan for nuget packages
             var packages = _repositoryScanner.FindAllNuGetPackages(workingFolder)
@@ -37,7 +38,7 @@ namespace NuKeeper.Inspection
 
             _logger.Log(PackagesFoundLogger.Log(packages));
 
-            var nugetSources = _nugetSourcesReader.Read(workingFolder);
+            var nugetSources = _nugetSourcesReader.Read(workingFolder, overrideSources);
 
             // look for updates to these packages
             var updates = await _packageUpdatesLookup.FindUpdatesForPackages(

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -14,17 +14,17 @@ namespace NuKeeper.Inspection
         private readonly IRepositoryScanner _repositoryScanner;
         private readonly IPackageUpdatesLookup _packageUpdatesLookup;
         private readonly INuKeeperLogger _logger;
-        private readonly INugetSourcesFactory _nugetSourcesFactory;
+        private readonly INugetSourcesReader _nugetSourcesReader;
 
         public UpdateFinder(
             IRepositoryScanner repositoryScanner,
             IPackageUpdatesLookup packageUpdatesLookup,
-            INugetSourcesFactory nugetSourcesFactory,
+            INugetSourcesReader nugetSourcesReader,
             INuKeeperLogger logger)
         {
             _repositoryScanner = repositoryScanner;
             _packageUpdatesLookup = packageUpdatesLookup;
-            _nugetSourcesFactory = nugetSourcesFactory;
+            _nugetSourcesReader = nugetSourcesReader;
             _logger = logger;
         }
 
@@ -37,7 +37,7 @@ namespace NuKeeper.Inspection
 
             _logger.Log(PackagesFoundLogger.Log(packages));
 
-            var nugetSources = _nugetSourcesFactory.ReadNugetSources(workingFolder);
+            var nugetSources = _nugetSourcesReader.Read(workingFolder);
 
             // look for updates to these packages
             var updates = await _packageUpdatesLookup.FindUpdatesForPackages(

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -28,7 +28,8 @@ namespace NuKeeper.Inspection
             _logger = logger;
         }
 
-        public async Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(IFolder workingFolder)
+        public async Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
+            IFolder workingFolder, VersionChange allowedChange)
         {
             // scan for nuget packages
             var packages = _repositoryScanner.FindAllNuGetPackages(workingFolder)
@@ -39,7 +40,9 @@ namespace NuKeeper.Inspection
             var nugetSources = _nugetSourcesFactory.ReadNugetSources(workingFolder);
 
             // look for updates to these packages
-            var updates = await _packageUpdatesLookup.FindUpdatesForPackages(packages, nugetSources);
+            var updates = await _packageUpdatesLookup.FindUpdatesForPackages(
+                packages, nugetSources, allowedChange);
+
             _logger.Log(UpdatesLogger.Log(updates));
             return updates;
         }

--- a/NuKeeper.Inspection/UpdatesLogger.cs
+++ b/NuKeeper.Inspection/UpdatesLogger.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Inspection
 {
     public static class UpdatesLogger
     {
-        public static LogData Log(List<PackageUpdateSet> updates)
+        public static LogData Log(IReadOnlyCollection<PackageUpdateSet> updates)
         {
             var headline = $"Found {updates.Count} possible updates";
             var details = new StringBuilder();

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.NuGet.Api
@@ -106,10 +106,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             return new PackageUpdateLookupSettings
             {
-                NugetSources = new List<string>
-                {
-                    "https://api.nuget.org/v3/index.json"
-                }
+                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
             };
         }
     }

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -16,7 +16,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildPackageLookup();
 
-            var package = await lookup.FindVersionUpdate(Current("AWSSDK"), VersionChange.Major);
+            var package = await lookup.FindVersionUpdate(Current("AWSSDK"),
+                NuGetSources.GlobalFeed,
+                VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Major, Is.Not.Null);
@@ -34,7 +36,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             var lookup = BuildPackageLookup();
 
             var package = await lookup.FindVersionUpdate(
-                Current(Guid.NewGuid().ToString()), 
+                Current(Guid.NewGuid().ToString()),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
@@ -48,7 +51,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             var lookup = BuildPackageLookup();
 
             var package = await lookup.FindVersionUpdate(
-                Current("Newtonsoft.Json"), 
+                Current("Newtonsoft.Json"),
+                NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
             Assert.That(package, Is.Not.Null);
@@ -71,6 +75,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             // and later major versions 9.0.1, 10.0.3 etc
             var package = await lookup.FindVersionUpdate(
                 new PackageIdentity("Newtonsoft.Json", new NuGetVersion(8, 0, 1)),
+                NuGetSources.GlobalFeed,
                 VersionChange.Minor);
 
             Assert.That(package, Is.Not.Null);
@@ -94,20 +99,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         private IApiPackageLookup BuildPackageLookup()
         {
             return new ApiPackageLookup(
-                new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
+                new PackageVersionsLookup(new NullNuGetLogger()));
         }
 
         private PackageIdentity Current(string packageId)
         {
             return new PackageIdentity(packageId, new NuGetVersion(1,2,3));
-        }
-
-        private static PackageUpdateLookupSettings BuildDefaultSettings()
-        {
-            return new PackageUpdateLookupSettings
-            {
-                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
-            };
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -20,7 +20,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(
+                packages, NuGetSources.GlobalFeed, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -38,7 +39,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(
+                packages, NuGetSources.GlobalFeed, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
@@ -56,7 +58,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(
+                packages, NuGetSources.GlobalFeed, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -67,7 +70,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.FindVersionUpdates(Enumerable.Empty<PackageIdentity>(), VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(
+                Enumerable.Empty<PackageIdentity>(), NuGetSources.GlobalFeed, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -86,7 +90,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var lookup = BuildBulkPackageLookup();
 
-            var results = await lookup.FindVersionUpdates(packages, VersionChange.Major);
+            var results = await lookup.FindVersionUpdates(
+                packages, NuGetSources.GlobalFeed, VersionChange.Major);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
@@ -97,16 +102,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         private static BulkPackageLookup BuildBulkPackageLookup()
         {
             var nuKeeperLogger = new NullNuKeeperLogger();
-            var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings()));
+            var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger()));
             return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger));
-        }
-
-        private static PackageUpdateLookupSettings BuildDefaultSettings()
-        {
-            return new PackageUpdateLookupSettings
-            {
-                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
-            };
         }
 
         private PackageIdentity Current(string packageId)

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.NuGet.Api
@@ -104,10 +105,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         {
             return new PackageUpdateLookupSettings
             {
-                NugetSources = new List<string>
-                {
-                    "https://api.nuget.org/v3/index.json"
-                }
+                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
             };
         }
 

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -15,7 +15,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json");
+            var packages = await lookup.Lookup("Newtonsoft.Json", NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -29,7 +29,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json");
+            var packages = await lookup.Lookup("Newtonsoft.Json", NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -52,7 +52,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Moq");
+            var packages = await lookup.Lookup("Moq", NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -68,15 +68,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
 
         private IPackageVersionsLookup BuildPackageLookup()
         {
-            return new PackageVersionsLookup(new NullNuGetLogger(), BuildDefaultSettings());
-        }
-
-        private static PackageUpdateLookupSettings BuildDefaultSettings()
-        {
-            return new PackageUpdateLookupSettings
-            {
-                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
-            };
+            return new PackageVersionsLookup(new NullNuGetLogger());
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Integration.Tests.NuGet.Api;
 using NUnit.Framework;
 
@@ -75,10 +75,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             return new PackageUpdateLookupSettings
             {
-                NugetSources = new List<string>
-                {
-                    "https://api.nuget.org/v3/index.json"
-                }
+                NuGetSources = new NuGetSources("https://api.nuget.org/v3/index.json")
             };
         }
     }

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -2,11 +2,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NuGet.Versioning;
-using NuKeeper.Configuration;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Integration.Tests.NuGet.Api;
-using NuKeeper.Update;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
 

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -76,12 +76,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
         public async Task ShouldUpdateDuplicateProject()
         {
             const string name = nameof(ShouldUpdateDuplicateProject);
-            var projectPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, name, $"AnotherProject.csproj");
+            var projectPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, name, "AnotherProject.csproj");
             Directory.CreateDirectory(Path.GetDirectoryName(projectPath));
             using (File.Create(projectPath))
             {
                 // close file stream automatically
-            };
+            }
 
             await ExecuteValidUpdateTest(_testDotNetCoreProject);
         }
@@ -94,7 +94,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
         private async Task ExecuteValidUpdateTest(string testProjectContents, [CallerMemberName] string memberName = "")
         {
-            const string packageSource = "https://api.nuget.org/v3/index.json";
             const string oldPackageVersion = "5.2.3";
             const string newPackageVersion = "5.2.4";
             const string expectedPackageString =
@@ -113,12 +112,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var command = new DotNetUpdatePackageCommand(
                     new NullNuKeeperLogger(),
-                    new NuGetSources(packageSource));
+                    NuGetSources.GlobalFeed);
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                     new PackagePath(workDirectory, testProject, PackageReferenceType.ProjectFile));
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource, packageToUpdate);
+            await command.Invoke(new NuGetVersion(newPackageVersion), NuGetSources.GlobalFeedUrl, packageToUpdate);
 
             var contents = await File.ReadAllTextAsync(projectPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -111,13 +111,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await File.WriteAllTextAsync(projectPath, projectContents);
 
             var command = new DotNetUpdatePackageCommand(
-                    new NullNuKeeperLogger(),
-                    NuGetSources.GlobalFeed);
+                    new NullNuKeeperLogger());
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                     new PackagePath(workDirectory, testProject, PackageReferenceType.ProjectFile));
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), NuGetSources.GlobalFeedUrl, packageToUpdate);
+            await command.Invoke(packageToUpdate, new NuGetVersion(newPackageVersion), NuGetSources.GlobalFeedUrl, NuGetSources.GlobalFeed);
 
             var contents = await File.ReadAllTextAsync(projectPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -31,7 +31,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
         [Test]
         public async Task ShouldUpdateDotnetClassicProject()
         {
-            const string packageSource = "https://api.nuget.org/v3/index.json";
             const string oldPackageVersion = "5.2.3";
             const string newPackageVersion = "5.2.4";
             const string expectedPackageString =
@@ -59,12 +58,12 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var command =
                 new Update.Process.NuGetUpdatePackageCommand(
                     new NullNuKeeperLogger(),
-                    new NuGetSources(packageSource));
+                    NuGetSources.GlobalFeed);
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                     new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), packageSource, packageToUpdate);
+            await command.Invoke(new NuGetVersion(newPackageVersion), NuGetSources.GlobalFeedUrl, packageToUpdate);
 
             var contents = await File.ReadAllTextAsync(packagesConfigPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -1,12 +1,11 @@
 using System.IO;
 using System.Threading.Tasks;
 using NuGet.Versioning;
-using NuKeeper.Configuration;
+using NUnit.Framework;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Integration.Tests.NuGet.Api;
-using NuKeeper.Update;
-using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -55,15 +55,13 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             await File.WriteAllTextAsync(Path.Combine(workDirectory, "nuget.config"), _nugetConfig);
 
-            var command =
-                new Update.Process.NuGetUpdatePackageCommand(
-                    new NullNuKeeperLogger(),
-                    NuGetSources.GlobalFeed);
+            var command = new Update.Process.NuGetUpdatePackageCommand(new NullNuKeeperLogger());
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                     new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), NuGetSources.GlobalFeedUrl, packageToUpdate);
+            await command.Invoke(packageToUpdate, new NuGetVersion(newPackageVersion),
+                NuGetSources.GlobalFeedUrl, NuGetSources.GlobalFeed);
 
             var contents = await File.ReadAllTextAsync(packagesConfigPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Integration.Tests.NuGet.Api;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
@@ -41,9 +42,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var command = new UpdateNuspecCommand(new NullNuKeeperLogger());
 
-            await command.Invoke(new NuGetVersion(newPackageVersion), null,
-                new PackageInProject("foo", oldPackageVersion,
-                    new PackagePath(workDirectory, testNuspec, PackageReferenceType.Nuspec)));
+            var package = new PackageInProject("foo", oldPackageVersion,
+                new PackagePath(workDirectory, testNuspec, PackageReferenceType.Nuspec));
+
+            await command.Invoke(package, new NuGetVersion(newPackageVersion), null, NuGetSources.GlobalFeed);
 
             var contents = await File.ReadAllTextAsync(projectPath);
             Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion)));

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
 
@@ -39,9 +40,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var subject = new UpdateProjectImportsCommand();
 
-            await subject.Invoke(null, null,
-                new PackageInProject("acme", "1",
-                    new PackagePath(workDirectory, projectName, PackageReferenceType.ProjectFileOldStyle)));
+            var package = new PackageInProject("acme", "1",
+                new PackagePath(workDirectory, projectName, PackageReferenceType.ProjectFileOldStyle));
+
+            await subject.Invoke(package, null, null, NuGetSources.GlobalFeed);
 
             var updatedContents = await File.ReadAllTextAsync(projectPath);
 
@@ -72,9 +74,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var subject = new UpdateProjectImportsCommand();
 
-            await subject.Invoke(null, null,
-                new PackageInProject("acme", "1",
-                    new PackagePath(workDirectory, "RootProject.csproj", PackageReferenceType.ProjectFileOldStyle)));
+            var package = new PackageInProject("acme", "1",
+                new PackagePath(workDirectory, "RootProject.csproj", PackageReferenceType.ProjectFileOldStyle));
+
+            await subject.Invoke(package, null, null, NuGetSources.GlobalFeed);
 
             var updatedContents = await File.ReadAllTextAsync(projectPath);
 

--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -72,8 +72,7 @@ namespace NuKeeper.Tests.Configuration
             var settings = SettingsParser.ReadSettings(commandLine);
 
             AssertSettingsNotNull(settings);
-            Assert.That(settings.UserSettings.NuGetSources.Items.Count, Is.EqualTo(1));
-            Assert.That(settings.UserSettings.NuGetSources.Items.First(), Is.EqualTo("https://api.nuget.org/v3/index.json"));
+            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
             Assert.That(settings.UserSettings.PackageIncludes, Is.Null);
             Assert.That(settings.UserSettings.PackageExcludes, Is.Null);
         }
@@ -134,8 +133,7 @@ namespace NuKeeper.Tests.Configuration
 
             AssertSettingsNotNull(settings);
             var sources = settings.UserSettings.NuGetSources;
-            Assert.That(sources.Items.Count, Is.EqualTo(1));
-            Assert.That(sources.Items.First(), Is.EqualTo("https://api.nuget.org/v3/index.json"));
+            Assert.That(sources, Is.Null);
         }
 
         [Test]
@@ -355,8 +353,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
             Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.FromDays(7)));
-            Assert.That(settings.UserSettings.NuGetSources.Items.Count, Is.EqualTo(1));
-            Assert.That(settings.UserSettings.NuGetSources.Items.First(), Is.EqualTo("https://api.nuget.org/v3/index.json"));
+            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
         }
 
         [Test]
@@ -445,8 +442,6 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Update));
             Assert.That(settings.UserSettings.Directory, Is.EqualTo("/foo/bar"));
         }
-
-
         private static IEnumerable<string> ValidRepoCommandLine()
         {
             return new List<string>
@@ -491,7 +486,6 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings, Is.Not.Null);
         }
     }
-
     static class StringAppend
     {
         public static IEnumerable<string> Append(this IEnumerable<string> values, string value)

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -125,7 +125,7 @@ namespace NuKeeper.Tests.Configuration
             return new RawConfiguration
             {
                 GithubApiEndpoint = new Uri("https://api.github.com"),
-                NuGetSources = "https://api.nuget.org/v3/index.json",
+                NuGetSources = null,
                 Mode = "repository",
                 GithubRepositoryUri = new Uri("https://github.com/NuKeeperDotNet/NuKeeper"),
                 GithubToken = "abc123",
@@ -142,7 +142,7 @@ namespace NuKeeper.Tests.Configuration
             return new RawConfiguration
             {
                 GithubApiEndpoint = new Uri("https://api.github.com"),
-                NuGetSources = "https://api.nuget.org/v3/index.json",
+                NuGetSources = null,
                 Mode = "organisation",
                 GithubOrganisationName = "NuKeeperDotNet",
                 GithubToken = "abc123",
@@ -158,7 +158,7 @@ namespace NuKeeper.Tests.Configuration
         {
             return new RawConfiguration
             {
-                NuGetSources = "https://api.nuget.org/v3/index.json",
+                NuGetSources = null,
                 Mode = "inspect",
                 LogLevel = LogLevel.Info,
                 ReportMode = ReportMode.Off,
@@ -170,7 +170,7 @@ namespace NuKeeper.Tests.Configuration
         {
             return new RawConfiguration
             {
-                NuGetSources = "https://api.nuget.org/v3/index.json",
+                NuGetSources = null,
                 Mode = "update",
                 LogLevel = LogLevel.Info,
                 ReportMode = ReportMode.Off,

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -85,9 +85,7 @@ namespace NuKeeper.Tests.Configuration
 
             AssertSettingsNotNull(settings);
             Assert.That(settings.ModalSettings.Mode, Is.EqualTo(RunMode.Inspect));
-            var sources = settings.UserSettings.NuGetSources;
-            Assert.That(sources.Items.Count, Is.EqualTo(1));
-            Assert.That(sources.Items.First(), Is.EqualTo("https://api.nuget.org/v3/index.json"));
+            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
         }
 
         [Test]

--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Tests
             settings.GithubAuthSettings = new GithubAuthSettings(new Uri("http://foo.com/bar"), "abc123");
             settings.UserSettings = new UserSettings
                 {
-                    NuGetSources = new NuGetSources("a.source")
+                    NuGetSources = NuGetSources.GlobalFeed
                 };
             return settings;
         }

--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -1,9 +1,9 @@
 using System;
+using NUnit.Framework;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Local;
-using NuKeeper.Update;
-using NUnit.Framework;
 
 namespace NuKeeper.Tests
 {

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -4,6 +4,7 @@ using NuGet.Versioning;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NUnit.Framework;
 
 namespace NuKeeper.Tests.Engine
@@ -11,8 +12,6 @@ namespace NuKeeper.Tests.Engine
     [TestFixture]
     public class CommitWordingTests
     {
-        private const string NugetSource = "https://api.nuget.org/v3/index.json";
-
         [Test]
         public void MarkPullRequestTitle_UpdateIsCorrect()
         {
@@ -291,7 +290,7 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, NugetSource, publishedDate, null);
+            var latest = new PackageSearchMedatadata(newPackage, NuGetSources.GlobalFeedUrl, publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
@@ -316,10 +315,10 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, NugetSource, publishedAt, null);
+            var latest = new PackageSearchMedatadata(latestId, NuGetSources.GlobalFeedUrl, publishedAt, null);
 
             var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), NugetSource, null, null);
+                NewPackageFooBar123(), NuGetSources.GlobalFeedUrl, null, null);
 
             var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
 
@@ -18,9 +19,10 @@ namespace NuKeeper.Tests.Engine
 
             var solutionResture = new SolutionsRestore(cmd);
 
-            await solutionResture.Restore(folder);
+            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
 
-            await cmd.DidNotReceiveWithAnyArgs().Invoke(Arg.Any<FileInfo>());
+            await cmd.DidNotReceiveWithAnyArgs()
+                .Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
         }
 
         [Test]
@@ -34,10 +36,10 @@ namespace NuKeeper.Tests.Engine
 
             var solutionResture = new SolutionsRestore(cmd);
 
-            await solutionResture.Restore(folder);
+            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
 
-            await cmd.Received(1).Invoke(Arg.Any<FileInfo>());
-            await cmd.Received().Invoke(sln);
+            await cmd.Received(1).Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
+            await cmd.Received().Invoke(sln, Arg.Any<NuGetSources>());
         }
 
         [Test]
@@ -52,11 +54,11 @@ namespace NuKeeper.Tests.Engine
 
             var solutionResture = new SolutionsRestore(cmd);
 
-            await solutionResture.Restore(folder);
+            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
 
-            await cmd.Received(2).Invoke(Arg.Any<FileInfo>());
-            await cmd.Received().Invoke(sln1);
-            await cmd.Received().Invoke(sln2);
+            await cmd.Received(2).Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
+            await cmd.Received().Invoke(sln1, Arg.Any<NuGetSources>());
+            await cmd.Received().Invoke(sln2, Arg.Any<NuGetSources>());
         }
     }
 }

--- a/NuKeeper.Update/IUpdateRunner.cs
+++ b/NuKeeper.Update/IUpdateRunner.cs
@@ -1,10 +1,11 @@
 using System.Threading.Tasks;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update
 {
     public interface IUpdateRunner
     {
-        Task Update(PackageUpdateSet updateSet);
+        Task Update(PackageUpdateSet updateSet, NuGetSources sources);
     }
 }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -11,26 +11,24 @@ namespace NuKeeper.Update.Process
     {
         private readonly IExternalProcess _externalProcess;
         private readonly INuKeeperLogger _logger;
-        private readonly NuGetSources _sources;
 
         public DotNetUpdatePackageCommand(
             INuKeeperLogger logger,
-            NuGetSources sources,
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _sources = sources;
             _externalProcess = externalProcess ?? new ExternalProcess();
         }
 
-        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        public async Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources)
         {
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
 
-            var sources = _sources.CommandLine("-s");
+            var sources = allSources.CommandLine("-s");
 
-            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {projectPath} {projectFileName} from sources {sources}");
+            _logger.Verbose($"dotnet update package {currentPackage.Id} in path {projectPath} {projectFileName} from source {packageSource}");
 
             await _externalProcess.Run(projectPath, "dotnet", $"restore {projectFileName} {sources}", true);
             await _externalProcess.Run(projectPath, "dotnet", $"remove {projectFileName} package {currentPackage.Id}", true);

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -1,9 +1,8 @@
-using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Versioning;
-using NuKeeper.Inspection.Formats;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.ProcessRunner;
 
 namespace NuKeeper.Update.Process

--- a/NuKeeper.Update/Process/IFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/IFileRestoreCommand.cs
@@ -1,10 +1,11 @@
 using System.IO;
 using System.Threading.Tasks;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update.Process
 {
     public interface IFileRestoreCommand : IPackageCommand
     {
-        Task Invoke(FileInfo file);
+        Task Invoke(FileInfo file, NuGetSources sources);
     }
 }

--- a/NuKeeper.Update/Process/IPackageCommand.cs
+++ b/NuKeeper.Update/Process/IPackageCommand.cs
@@ -1,11 +1,13 @@
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update.Process
 {
     public interface IPackageCommand
     {
-        Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage);
+        Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources);
     }
 }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -1,12 +1,10 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NuGet.Versioning;
-using NuKeeper.Inspection.Formats;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.ProcessRunner;
 
 namespace NuKeeper.Update.Process

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -11,21 +11,18 @@ namespace NuKeeper.Update.Process
 {
     public class NuGetFileRestoreCommand : IFileRestoreCommand
     {
-        private readonly NuGetSources _sources;
         private readonly INuKeeperLogger _logger;
         private readonly IExternalProcess _externalProcess;
 
         public NuGetFileRestoreCommand(
             INuKeeperLogger logger,
-            NuGetSources sources,
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _sources = sources;
             _externalProcess = externalProcess ?? new ExternalProcess();
         }
 
-        public async Task Invoke(FileInfo file)
+        public async Task Invoke(FileInfo file, NuGetSources sources)
         {
             _logger.Info($"Nuget restore on {file.DirectoryName} {file.Name}");
 
@@ -43,9 +40,9 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
-            var sources = _sources.CommandLine("-Source");
+            var sourcesCommandLine = sources.CommandLine("-Source");
 
-            var arguments = $"restore {file.Name} {sources}";
+            var arguments = $"restore {file.Name} {sourcesCommandLine}";
             _logger.Verbose($"{nuget} {arguments}");
 
             var processOutput = await _externalProcess.Run(file.DirectoryName, nuget, arguments, ensureSuccess: false);
@@ -62,7 +59,7 @@ namespace NuKeeper.Update.Process
 
         public async Task Invoke(NuGetVersion selectedVersion, string source, PackageInProject current)
         {
-            await Invoke(current.Path.Info);
+            await Invoke(current.Path.Info, new NuGetSources(source));
         }
     }
 }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -57,9 +57,10 @@ namespace NuKeeper.Update.Process
             }
         }
 
-        public async Task Invoke(NuGetVersion selectedVersion, string source, PackageInProject current)
+        public async Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources)
         {
-            await Invoke(current.Path.Info, new NuGetSources(source));
+            await Invoke(currentPackage.Path.Info, allSources);
         }
     }
 }

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -12,19 +12,17 @@ namespace NuKeeper.Update.Process
     {
         private readonly IExternalProcess _externalProcess;
         private readonly INuKeeperLogger _logger;
-        private readonly NuGetSources _sources;
 
         public NuGetUpdatePackageCommand(
             INuKeeperLogger logger,
-            NuGetSources sources,
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _sources = sources;
             _externalProcess = externalProcess ?? new ExternalProcess();
         }
 
-        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        public async Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -41,7 +39,7 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
-            var sources = _sources.CommandLine("-Source");
+            var sources = allSources.CommandLine("-Source");
             var arguments = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
             _logger.Verbose(arguments);
 

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.ProcessRunner;
 
 namespace NuKeeper.Update.Process

--- a/NuKeeper.Update/Process/SolutionsRestore.cs
+++ b/NuKeeper.Update/Process/SolutionsRestore.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update.Process
 {
@@ -12,13 +13,13 @@ namespace NuKeeper.Update.Process
             _fileRestoreCommand = fileRestoreCommand;
         }
 
-        public async Task Restore(IFolder workingFolder)
+        public async Task Restore(IFolder workingFolder, NuGetSources sources)
         {
             var solutionFiles = workingFolder.Find("*.sln");
 
             foreach (var sln in solutionFiles)
             {
-                await _fileRestoreCommand.Invoke(sln);
+                await _fileRestoreCommand.Invoke(sln, sources);
             }
         }
     }

--- a/NuKeeper.Update/Process/UpdateNuspecCommand.cs
+++ b/NuKeeper.Update/Process/UpdateNuspecCommand.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 using NuGet.Versioning;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update.Process
 {
@@ -18,7 +19,8 @@ namespace NuKeeper.Update.Process
             _logger = logger;
         }
 
-        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        public async Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources)
         {
             using (var nuspecContents = File.Open(currentPackage.Path.FullName, FileMode.Open, FileAccess.ReadWrite))
             {

--- a/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Versioning;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Update.Process
 {
     public class UpdateProjectImportsCommand : IPackageCommand
     {
-        public async Task Invoke(NuGetVersion newVersion, string packageSource, PackageInProject currentPackage)
+        public async Task Invoke(PackageInProject currentPackage,
+            NuGetVersion newVersion, string packageSource, NuGetSources allSources)
         {
             var projectsToUpdate = new Stack<string>();
             projectsToUpdate.Push(currentPackage.Path.FullName);

--- a/NuKeeper.Update/UpdateRunner.cs
+++ b/NuKeeper.Update/UpdateRunner.cs
@@ -24,7 +24,7 @@ namespace NuKeeper.Update
                 var updateCommands = GetUpdateCommands(current.Path.PackageReferenceType, sources);
                 foreach (var updateCommand in updateCommands)
                 {
-                    await updateCommand.Invoke(updateSet.SelectedVersion, updateSet.Selected.Source, current);
+                    await updateCommand.Invoke(current, updateSet.SelectedVersion, updateSet.Selected.Source, sources);
                 }
             }
         }
@@ -39,7 +39,7 @@ namespace NuKeeper.Update
                     return new IPackageCommand[]
                     {
                         new NuGetFileRestoreCommand(_logger),
-                        new NuGetUpdatePackageCommand(_logger, sources)
+                        new NuGetUpdatePackageCommand(_logger)
                     };
 
                 case PackageReferenceType.ProjectFileOldStyle:
@@ -47,11 +47,11 @@ namespace NuKeeper.Update
                     {
                         new UpdateProjectImportsCommand(),
                         new NuGetFileRestoreCommand(_logger),
-                        new DotNetUpdatePackageCommand(_logger, sources)
+                        new DotNetUpdatePackageCommand(_logger)
                     };
 
                 case PackageReferenceType.ProjectFile:
-                    return new[] {new DotNetUpdatePackageCommand(_logger, sources) };
+                    return new[] {new DotNetUpdatePackageCommand(_logger) };
 
                 case PackageReferenceType.Nuspec:
                     return new[] { new UpdateNuspecCommand(_logger) };

--- a/NuKeeper.Update/UpdateRunner.cs
+++ b/NuKeeper.Update/UpdateRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.Process;
 
 namespace NuKeeper.Update

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -34,7 +34,7 @@ namespace NuKeeper.Configuration
         [OverriddenBy(ConfigurationSources.CommandLine, "log")]
         public LogLevel LogLevel;
 
-        [JsonConfig("nuget_sources"), Default("https://api.nuget.org/v3/index.json")]
+        [JsonConfig("nuget_sources")]
         [OverriddenBy(ConfigurationSources.CommandLine, "sources")]
         public string NuGetSources;
 

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -209,6 +209,11 @@ namespace NuKeeper.Configuration
 
         private static NuGetSources ReadNuGetSources(RawConfiguration settings)
         {
+            if (string.IsNullOrWhiteSpace(settings.NuGetSources))
+            {
+                return null;
+            }
+
             var items = ReadMultilineSetting(settings.NuGetSources);
             return new NuGetSources(items);
         }

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using EasyConfig;
 using EasyConfig.Exceptions;
-using NuKeeper.Update;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Configuration
 {

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.Report;
-using NuKeeper.Update;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Configuration
 {

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -15,14 +15,6 @@ namespace NuKeeper
     {
         public static void Register(Container container, SettingsContainer settings)
         {
-            var packageLookupSettings = new PackageUpdateLookupSettings
-            {
-                AllowedChange = settings.UserSettings.AllowedChange,
-                NuGetSources = settings.UserSettings.NuGetSources
-            };
-
-            container.RegisterInstance(packageLookupSettings);
-
             container.RegisterInstance<INuKeeperLogger>(
                 new ConsoleLogger(settings.UserSettings.LogLevel));
 

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -8,6 +8,7 @@ using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.Report;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sort;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper
 {
@@ -30,6 +31,7 @@ namespace NuKeeper
             container.Register<IRepositoryScanner, RepositoryScanner>();
 
             container.Register<IUpdateFinder, UpdateFinder>();
+            container.Register<INugetSourcesReader, NugetSourcesReader>();
 
             container.Register<IReportStreamSource, ReportStreamSource>();
             container.Register<IAvailableUpdatesReporter, CsvFileReporter>();

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -18,7 +18,7 @@ namespace NuKeeper
             var packageLookupSettings = new PackageUpdateLookupSettings
             {
                 AllowedChange = settings.UserSettings.AllowedChange,
-                NugetSources = settings.UserSettings.NuGetSources.Items
+                NuGetSources = settings.UserSettings.NuGetSources
             };
 
             container.RegisterInstance(packageLookupSettings);

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -11,7 +11,6 @@ namespace NuKeeper
     {
         public static void Register(Container container, SettingsContainer settings)
         {
-            container.Register(() => settings.UserSettings.NuGetSources, Lifestyle.Singleton);
             container.Register(() => MakeFilterSettings(settings.UserSettings), Lifestyle.Singleton);
 
             container.Register<IUpdateSelection, UpdateSelection>();

--- a/NuKeeper/Engine/Packages/IPackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/IPackageUpdater.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using NuKeeper.Git;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Engine.Packages
 {
@@ -9,6 +10,7 @@ namespace NuKeeper.Engine.Packages
         Task MakeUpdatePullRequest(
             IGitDriver git,
             PackageUpdateSet updateSet,
+            NuGetSources sources,
             RepositoryData repository);
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -6,6 +6,7 @@ using NuKeeper.Git;
 using NuKeeper.Github;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update;
 using Octokit;
 
@@ -33,6 +34,7 @@ namespace NuKeeper.Engine.Packages
         public async Task MakeUpdatePullRequest(
             IGitDriver git,
             PackageUpdateSet updateSet,
+            NuGetSources sources,
             RepositoryData repository)
         {
             try
@@ -46,7 +48,7 @@ namespace NuKeeper.Engine.Packages
                 _logger.Verbose($"Using branch name: '{branchName}'");
                 git.CheckoutNewBranch(branchName);
 
-                await _updateRunner.Update(updateSet);
+                await _updateRunner.Update(updateSet, sources);
 
                 var commitMessage = CommitWording.MakeCommitMessage(updateSet);
                 git.Commit(commitMessage);

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.Engine
         {
             GitInit(git, repository);
 
-            var updates = await _updateFinder.FindPackageUpdateSets(git.WorkingFolder);
+            var updates = await _updateFinder.FindPackageUpdateSets(git.WorkingFolder, _settings.AllowedChange);
 
             _logger.Verbose($"Report mode is {_settings.ReportMode}");
             switch (_settings.ReportMode)

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -44,7 +44,8 @@ namespace NuKeeper.Engine
         {
             GitInit(git, repository);
 
-            var updates = await _updateFinder.FindPackageUpdateSets(git.WorkingFolder, _settings.AllowedChange);
+            var updates = await _updateFinder.FindPackageUpdateSets(
+                git.WorkingFolder, _settings.AllowedChange, _settings.NuGetSources);
 
             _logger.Verbose($"Report mode is {_settings.ReportMode}");
             switch (_settings.ReportMode)

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -102,14 +102,26 @@ namespace NuKeeper.Github
 
         private async Task AddLabelsToIssue(ForkData target, int issueNumber, IEnumerable<string> labels)
         {
-            var labelsToApply = labels?.Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+            var labelsToApply = labels?
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .ToArray();
+
             if (labelsToApply != null && labelsToApply.Any())
             {
                 _logger.Info(
                     $"Adding label(s) '{labelsToApply.JoinWithCommas()}' to issue "
                     + $"'{_apiBase} {target.Owner}/{target.Name} {issueNumber}'");
-                await _client.Issue.Labels.AddToIssue(target.Owner, target.Name, issueNumber,
-                    labelsToApply);
+
+                try
+                {
+                    await _client.Issue.Labels.AddToIssue(target.Owner, target.Name, issueNumber,
+                        labelsToApply);
+
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error("Failed to add labels. Continuing", ex);
+                }
             }
         }
     }

--- a/NuKeeper/Local/ILocalUpdater.cs
+++ b/NuKeeper/Local/ILocalUpdater.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Local
 {
     public interface ILocalUpdater
     {
-        Task ApplyAnUpdate(IReadOnlyCollection<PackageUpdateSet> updates);
+        Task ApplyAnUpdate(
+            IReadOnlyCollection<PackageUpdateSet> updates,
+            NuGetSources sources);
     }
 }

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -50,7 +50,7 @@ namespace NuKeeper.Local
         private async Task<IReadOnlyCollection<PackageUpdateSet>> GetSortedUpdates(UserSettings settings)
         {
             var folder = TargetFolder(settings);
-            var updates = await _updateFinder.FindPackageUpdateSets(folder);
+            var updates = await _updateFinder.FindPackageUpdateSets(folder, settings.AllowedChange);
 
             return _sorter.Sort(updates)
                 .ToList();

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -50,7 +50,8 @@ namespace NuKeeper.Local
         private async Task<IReadOnlyCollection<PackageUpdateSet>> GetSortedUpdates(UserSettings settings)
         {
             var folder = TargetFolder(settings);
-            var updates = await _updateFinder.FindPackageUpdateSets(folder, settings.AllowedChange);
+            var updates = await _updateFinder.FindPackageUpdateSets(
+                folder, settings.AllowedChange, settings.NuGetSources);
 
             return _sorter.Sort(updates)
                 .ToList();

--- a/NuKeeper/Local/LocalUpdater.cs
+++ b/NuKeeper/Local/LocalUpdater.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Report;
 using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
 using NuKeeper.Update;
 using NuKeeper.Update.Selection;
 
@@ -25,7 +26,9 @@ namespace NuKeeper.Local
             _logger = logger;
         }
 
-        public async Task ApplyAnUpdate(IReadOnlyCollection<PackageUpdateSet> updates)
+        public async Task ApplyAnUpdate(
+            IReadOnlyCollection<PackageUpdateSet> updates,
+            NuGetSources sources)
         {
             if (!updates.Any())
             {
@@ -46,7 +49,7 @@ namespace NuKeeper.Local
             var reporter = new ConsoleReporter();
             _logger.Terse("Updating " + reporter.Describe(candidate));
 
-            await _updateRunner.Update(candidate);
+            await _updateRunner.Update(candidate, sources);
         }
     }
 }


### PR DESCRIPTION
#278 

Infer nuget package sources from the file `nuget.config` when it is present and not overridden on the commandline.

The fallback sequence is now:
 * If you specify nuget sources on the command line options, they will be used. User override wins.
 * if a `nuget.config` file is found and can be parsed for sources, those sources will be used.
 * The global feed on `nuget.org` is the fallback option. This will actually be 100% correct for many public projects, and will give some meaningful results for even internal code.

The new classes start with `NugetSourcesReader` that does the above logic.  And reader classes called by that to parse the file.

Most of the changes are because the `NuGetSources`  cannot now be determined from config and then put into the IoC container upfront. Instead, when there is a Folder containing the code, it does the `NugetSourcesReader` logic, and thereafter passes along the `NuGetSources` object. `NuGetSources` is no longer a constructor param, now it's a method param. This touches a lot of classes [in order to to pass it to where it is used](https://en.wiktionary.org/wiki/tramp_data).