### PR TITLE
Sources can be unreliable

### DIFF
--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,14 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Sources;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace NuKeeper.Inspection.NuGetApi
 {

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,23 +1,26 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.Sources;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
-using NuKeeper.Inspection.Sources;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
     public class PackageVersionsLookup : IPackageVersionsLookup
     {
-        private readonly ILogger _logger;
+        private readonly ILogger _nuGetLogger;
+        private readonly INuKeeperLogger _nuKeeperLogger;
 
-        public PackageVersionsLookup(ILogger logger)
+        public PackageVersionsLookup(ILogger nuGetLogger, INuKeeperLogger nuKeeperLogger)
         {
-            _logger = logger;
+            _nuGetLogger = nuGetLogger;
+            _nuKeeperLogger = nuKeeperLogger;
         }
 
         public async Task<IReadOnlyCollection<PackageSearchMedatadata>> Lookup(
@@ -37,9 +40,17 @@ namespace NuKeeper.Inspection.NuGetApi
         private async Task<IEnumerable<PackageSearchMedatadata>> RunFinderForSource(string packageName, string source)
         {
             var sourceRepository = BuildSourceRepository(source);
-            var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
-            var metadatas = await FindPackage(metadataResource, packageName);
-            return metadatas.Select(m => BuildPackageData(source, m));
+            try
+            {
+                var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>();
+                var metadatas = await FindPackage(metadataResource, packageName);
+                return metadatas.Select(m => BuildPackageData(source, m));
+            }
+            catch (Exception ex)
+            {
+                _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
+                return Enumerable.Empty<PackageSearchMedatadata>();
+            }
         }
 
         private static SourceRepository BuildSourceRepository(string source)
@@ -56,7 +67,7 @@ namespace NuKeeper.Inspection.NuGetApi
             PackageMetadataResource metadataResource, string packageName)
         {
             return await metadataResource
-                .GetMetadataAsync(packageName, false, false, _logger, CancellationToken.None);
+                .GetMetadataAsync(packageName, false, false, _nuGetLogger, CancellationToken.None);
         }
 
         private static PackageSearchMedatadata BuildPackageData(string source, IPackageSearchMetadata metadata)

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -99,7 +99,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         private IApiPackageLookup BuildPackageLookup()
         {
             return new ApiPackageLookup(
-                new PackageVersionsLookup(new NullNuGetLogger()));
+                new PackageVersionsLookup(new NullNuGetLogger(), new NullNuKeeperLogger()));
         }
 
         private PackageIdentity Current(string packageId)

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -102,7 +102,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         private static BulkPackageLookup BuildBulkPackageLookup()
         {
             var nuKeeperLogger = new NullNuKeeperLogger();
-            var lookup = new ApiPackageLookup(new PackageVersionsLookup(new NullNuGetLogger()));
+            var lookup = new ApiPackageLookup(new PackageVersionsLookup(
+                new NullNuGetLogger(), new NullNuKeeperLogger()));
             return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger));
         }
 

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -68,7 +68,8 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
 
         private IPackageVersionsLookup BuildPackageLookup()
         {
-            return new PackageVersionsLookup(new NullNuGetLogger());
+            return new PackageVersionsLookup(
+                new NullNuGetLogger(), new NullNuKeeperLogger());
         }
     }
 }


### PR DESCRIPTION
Carry on when a source fails.

Observed this today when inspecting a project 
Which has a `nuget.config` file
Which specifies a private source 
Which I can't reach because I am at home.
NuKeeper should not fail at that point. Instead, log the error and carry on.