### PR TITLE
Flow the success status

### DIFF
--- a/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetConfigFileParserTests.cs
@@ -14,7 +14,7 @@ namespace NuKeeper.Inspection.Tests.Sources
         {
             var data = string.Empty;
 
-            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+            var parser = new NuGetConfigFileParser(new NullNuKeeperLogger());
 
             var sources = parser.Parse(ToStream(data));
 
@@ -26,7 +26,7 @@ namespace NuKeeper.Inspection.Tests.Sources
         {
             var data = "not valid markup";
 
-            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+            var parser = new NuGetConfigFileParser(new NullNuKeeperLogger());
 
             var sources = parser.Parse(ToStream(data));
 
@@ -44,7 +44,7 @@ namespace NuKeeper.Inspection.Tests.Sources
   </packageSources>
 </configuration>";
 
-            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+            var parser = new NuGetConfigFileParser(new NullNuKeeperLogger());
 
             var sources = parser.Parse(ToStream(data));
 
@@ -65,7 +65,7 @@ namespace NuKeeper.Inspection.Tests.Sources
   </packageSources>
 </configuration>";
 
-            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+            var parser = new NuGetConfigFileParser(new NullNuKeeperLogger());
 
             var sources = parser.Parse(ToStream(data));
 
@@ -87,7 +87,7 @@ namespace NuKeeper.Inspection.Tests.Sources
   </packageSources>
 </configuration>";
 
-            var parser = new NugetConfigFileParser(new NullNuKeeperLogger());
+            var parser = new NuGetConfigFileParser(new NullNuKeeperLogger());
 
             var sources = parser.Parse(ToStream(data));
 

--- a/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
@@ -77,12 +77,12 @@ namespace NuKeeper.Inspection.Tests.Sources
             return ff.UniqueTemporaryFolder();
         }
 
-        private static INugetSourcesReader MakeNuGetSourcesReader()
+        private static INuGetSourcesReader MakeNuGetSourcesReader()
         {
             var logger = new NullNuKeeperLogger();
-            return new NugetSourcesReader(
-                new NugetConfigFileReader
-                    (new NugetConfigFileParser(logger), logger), logger);
+            return new NuGetSourcesReader(
+                new NuGetConfigFileReader
+                    (new NuGetConfigFileParser(logger), logger), logger);
         }
     }
 }

--- a/NuKeeper.Inspection/Sources/INuGetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/INuGetSourcesReader.cs
@@ -2,7 +2,7 @@ using NuKeeper.Inspection.Files;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public interface INugetSourcesReader
+    public interface INuGetSourcesReader
     {
         NuGetSources Read(IFolder workingFolder, NuGetSources overrideValues);
     }

--- a/NuKeeper.Inspection/Sources/NuGetConfigFileParser.cs
+++ b/NuKeeper.Inspection/Sources/NuGetConfigFileParser.cs
@@ -7,11 +7,11 @@ using System.Xml.Linq;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public class NugetConfigFileParser
+    public class NuGetConfigFileParser
     {
         private readonly INuKeeperLogger _logger;
 
-        public NugetConfigFileParser(INuKeeperLogger logger)
+        public NuGetConfigFileParser(INuKeeperLogger logger)
         {
             _logger = logger;
         }

--- a/NuKeeper.Inspection/Sources/NuGetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NuGetConfigFileReader.cs
@@ -5,13 +5,13 @@ using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public class NugetConfigFileReader
+    public class NuGetConfigFileReader
     {
-        private readonly NugetConfigFileParser _parser;
+        private readonly NuGetConfigFileParser _parser;
         private readonly INuKeeperLogger _logger;
 
-        public NugetConfigFileReader(
-            NugetConfigFileParser parser,
+        public NuGetConfigFileReader(
+            NuGetConfigFileParser parser,
             INuKeeperLogger logger)
         {
             _parser = parser;

--- a/NuKeeper.Inspection/Sources/NuGetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSourcesReader.cs
@@ -3,13 +3,13 @@ using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public class NugetSourcesReader : INugetSourcesReader
+    public class NuGetSourcesReader : INuGetSourcesReader
     {
-        private readonly NugetConfigFileReader _reader;
+        private readonly NuGetConfigFileReader _reader;
         private readonly INuKeeperLogger _logger;
 
-        public NugetSourcesReader(
-            NugetConfigFileReader reader,
+        public NuGetSourcesReader(
+            NuGetConfigFileReader reader,
             INuKeeperLogger logger)
         {
             _reader = reader;

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsUsedWhenItIsFound()
         {
             var fallbackFork = DefaultFork();
-            var fallbackRepoData = RespositoryBuilder.MakeRepository();
+            var fallbackRepoData = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
@@ -48,7 +48,7 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsNotUsedWhenItIsNotPushable()
         {
             var fallbackFork = DefaultFork();
-            var fallbackRepoData = RespositoryBuilder.MakeRepository(true, false);
+            var fallbackRepoData = RepositoryBuilder.MakeRepository(true, false);
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
@@ -67,7 +67,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -85,9 +85,9 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenSuitableUserForkIsFound_ThatMatchesParentHtmlUrl_ItIsUsedOverFallback()
         {
-            var fallbackFork = new ForkData(new Uri(RespositoryBuilder.ParentHtmlUrl), "testOrg", "someRepo");
+            var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentHtmlUrl), "testOrg", "someRepo");
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -107,7 +107,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = NoMatchFork();
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -126,7 +126,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -150,7 +150,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -171,11 +171,11 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGithub>();
 
-            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
+            var defaultRepo = RepositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
@@ -194,7 +194,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             var github = Substitute.For<IGithub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -216,11 +216,11 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGithub>();
 
-            var defaultRepo = RespositoryBuilder.MakeRepository(true, false);
+            var defaultRepo = RepositoryBuilder.MakeRepository(true, false);
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var userRepo = RespositoryBuilder.MakeRepository();
+            var userRepo = RepositoryBuilder.MakeRepository();
 
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
@@ -235,12 +235,12 @@ namespace NuKeeper.Tests.Engine
 
         private ForkData DefaultFork()
         {
-            return new ForkData(new Uri(RespositoryBuilder.ParentCloneUrl), "testOrg", "someRepo");
+            return new ForkData(new Uri(RepositoryBuilder.ParentCloneUrl), "testOrg", "someRepo");
         }
 
         private ForkData NoMatchFork()
         {
-            return new ForkData(new Uri(RespositoryBuilder.NoMatchUrl), "testOrg", "someRepo");
+            return new ForkData(new Uri(RepositoryBuilder.NoMatchUrl), "testOrg", "someRepo");
         }
 
         private UserSettings MakePreferForkSettings()

--- a/NuKeeper.Tests/Engine/GithubEngineTests.cs
+++ b/NuKeeper.Tests/Engine/GithubEngineTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Github;
+using NuKeeper.Inspection.Files;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class GithubEngineTests
+    {
+        [Test]
+        public async Task SuperHappyFunPath()
+        {
+            var github = Substitute.For<IGithub>();
+            var repoDiscovery = Substitute.For<IGithubRepositoryDiscovery>();
+            var repoEngine = Substitute.For<IGithubRepositoryEngine>();
+            var folders = Substitute.For<IFolderFactory>();
+
+            github.GetCurrentUser().Returns(
+                RepositoryBuilder.MakeUser("http://test.user.com"));
+
+            var setings = new GithubAuthSettings(new Uri("http://foo.com"), "token123");
+
+            var engine = new GithubEngine(github, repoDiscovery, repoEngine,
+                setings,
+                folders, new NullNuKeeperLogger());
+
+            var count = await engine.Run();
+
+            Assert.That(count, Is.EqualTo(0));
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GithubRepositoryDiscoveryTests.cs
@@ -52,7 +52,7 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RespositoryBuilder.MakeRepository()
+                RepositoryBuilder.MakeRepository()
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
             
@@ -78,8 +78,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RespositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
-                RespositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
+                RepositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
+                RepositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 

--- a/NuKeeper.Tests/Engine/RepositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RepositoryBuilder.cs
@@ -23,13 +23,7 @@ namespace NuKeeper.Tests.Engine
             bool canPull = true, bool canPush = true)
         {
             const string omniUrl = "http://somewhere.com/fork";
-            var owner = new User(omniUrl, "test user", null, 0, "test inc",
-                DateTimeOffset.Now, DateTimeOffset.Now, 
-                0, null, 0, 0, false, omniUrl, 1, 1,
-                "testville", "testUser", "Testy",
-                1, null, 0, 0,
-                1, omniUrl, null, false, "test", null);
-
+            var owner = MakeUser(omniUrl);
 
             var perms = new RepositoryPermissions(false, canPush, canPull);
             var parent = MakeParentRepo();
@@ -46,12 +40,7 @@ namespace NuKeeper.Tests.Engine
             string cloneUrl = ParentCloneUrl)
         {
             const string omniUrl = "http://somewhere.com/parent";
-            var owner = new User(omniUrl, "test user", null, 0, "test inc",
-                DateTimeOffset.Now, DateTimeOffset.Now,
-                0, null, 0, 0, false, omniUrl, 1, 1,
-                "testville", "testUser", "Testy",
-                1, null, 0, 0,
-                1, omniUrl, null, false, "test", null);
+            var owner = MakeUser(omniUrl);
 
             var perms = new RepositoryPermissions(false, true, true);
 
@@ -61,6 +50,16 @@ namespace NuKeeper.Tests.Engine
                 DateTimeOffset.Now, DateTimeOffset.Now,
                 perms, null, null, null,
                 false, false, false, false, 2, 122, true, true, true);
+        }
+
+        public static User MakeUser(string omniUrl)
+        {
+            return new User(omniUrl, "test user", null, 0, "test inc",
+                DateTimeOffset.Now, DateTimeOffset.Now,
+                0, null, 0, 0, false, omniUrl, 1, 1,
+                "testville", "testUser", "Testy",
+                1, null, 0, 0,
+                1, omniUrl, null, false, "test", null);
         }
     }
 }

--- a/NuKeeper.Tests/Engine/RepositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RepositoryBuilder.cs
@@ -3,7 +3,7 @@ using Octokit;
 
 namespace NuKeeper.Tests.Engine
 {
-    public class RespositoryBuilder
+    public class RepositoryBuilder
     {
         public const string ParentHtmlUrl = "http://repos.com/org/parent";
         public const string ParentCloneUrl = "http://repos.com/org/parent.git";

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Engine.Packages;
+using NuKeeper.Git;
+using NuKeeper.Inspection;
+using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.Report;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class RepositoryUpdaterTests
+    {
+        [Test]
+        public async Task WhenThereAreNoUpdates_CountIsZero()
+        {
+            var repoUpdater = MakeRepositoryUpdater();
+
+            var git = Substitute.For<IGitDriver>();
+            var repo = new RepositoryData(
+                new ForkData(new Uri("http://foo.com"), "me", "test"),
+                new ForkData(new Uri("http://foo.com"), "me", "test"));
+
+            var count = await repoUpdater.Run(git, repo);
+
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        private static IRepositoryUpdater MakeRepositoryUpdater()
+        {
+            var sources = Substitute.For<INuGetSourcesReader>();
+            var updateFinder = Substitute.For<IUpdateFinder>();
+            var updateSelection = Substitute.For<IPackageUpdateSelection>();
+            var packageUpdater = Substitute.For<IPackageUpdater>();
+            var fileRestore = Substitute.For<IFileRestoreCommand>();
+            var reporter = Substitute.For<IAvailableUpdatesReporter>();
+
+            updateFinder.FindPackageUpdateSets(
+                    Arg.Any<IFolder>(),
+                    Arg.Any<NuGetSources>(),
+                    Arg.Any<VersionChange>())
+                .Returns(new List<PackageUpdateSet>());
+
+            var repoUpdater = new RepositoryUpdater(
+                sources, updateFinder, updateSelection, packageUpdater,
+                new NullNuKeeperLogger(), new SolutionsRestore(fileRestore),
+                reporter, new UserSettings());
+
+            return repoUpdater;
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Engine.Packages;
@@ -23,19 +25,35 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreNoUpdates_CountIsZero()
         {
-            var repoUpdater = MakeRepositoryUpdater();
+            var repoUpdater = MakeRepositoryUpdater(new List<PackageUpdateSet>());
 
             var git = Substitute.For<IGitDriver>();
-            var repo = new RepositoryData(
-                new ForkData(new Uri("http://foo.com"), "me", "test"),
-                new ForkData(new Uri("http://foo.com"), "me", "test"));
+            var repo = MakeRepositoryData();
 
             var count = await repoUpdater.Run(git, repo);
 
             Assert.That(count, Is.EqualTo(0));
         }
 
-        private static IRepositoryUpdater MakeRepositoryUpdater()
+        [Test]
+        public async Task WhenThereIsAnUpdate_CountIsOne()
+        {
+            var repoUpdater = MakeRepositoryUpdater(
+                new List<PackageUpdateSet>
+                {
+                    UpdateSet()
+                });
+
+            var git = Substitute.For<IGitDriver>();
+            var repo = MakeRepositoryData();
+
+            var count = await repoUpdater.Run(git, repo);
+
+            Assert.That(count, Is.EqualTo(1));
+        }
+
+        private static IRepositoryUpdater MakeRepositoryUpdater(
+            List<PackageUpdateSet> updates)
         {
             var sources = Substitute.For<INuGetSourcesReader>();
             var updateFinder = Substitute.For<IUpdateFinder>();
@@ -48,7 +66,17 @@ namespace NuKeeper.Tests.Engine
                     Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>())
-                .Returns(new List<PackageUpdateSet>());
+                .Returns(updates);
+
+            updateSelection.SelectTargets(Arg.Any<ForkData>(), Arg.Any<IReadOnlyCollection<PackageUpdateSet>>())
+                .Returns(c => c.ArgAt<IReadOnlyCollection<PackageUpdateSet>>(1));
+
+            packageUpdater.MakeUpdatePullRequest(
+                Arg.Any<IGitDriver>(),
+                Arg.Any<PackageUpdateSet>(),
+                Arg.Any<NuGetSources>(),
+                Arg.Any<RepositoryData>())
+                .Returns(true);
 
             var repoUpdater = new RepositoryUpdater(
                 sources, updateFinder, updateSelection, packageUpdater,
@@ -56,6 +84,28 @@ namespace NuKeeper.Tests.Engine
                 reporter, new UserSettings());
 
             return repoUpdater;
+        }
+
+        private static RepositoryData MakeRepositoryData()
+        {
+            return new RepositoryData(
+                new ForkData(new Uri("http://foo.com"), "me", "test"),
+                new ForkData(new Uri("http://foo.com"), "me", "test"));
+        }
+
+        private static PackageUpdateSet UpdateSet()
+        {
+            PackageIdentity fooPackage = new PackageIdentity("foo", new NuGetVersion(1,2,3));
+            var packages = new[]
+            {
+                new PackageInProject(fooPackage, new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig))
+            };
+
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(fooPackage, NuGetSources.GlobalFeedUrl, publishedDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
         }
     }
 }

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="EasyConfig.Net.Core" Version="4.0.97" />
+    <PackageReference Include="LibGit2Sharp" Version="0.25.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1">

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -31,7 +31,7 @@ namespace NuKeeper
             container.Register<IRepositoryScanner, RepositoryScanner>();
 
             container.Register<IUpdateFinder, UpdateFinder>();
-            container.Register<INugetSourcesReader, NugetSourcesReader>();
+            container.Register<INuGetSourcesReader, NuGetSourcesReader>();
 
             container.Register<IReportStreamSource, ReportStreamSource>();
             container.Register<IAvailableUpdatesReporter, CsvFileReporter>();

--- a/NuKeeper/Engine/GithubEngine.cs
+++ b/NuKeeper/Engine/GithubEngine.cs
@@ -52,12 +52,22 @@ namespace NuKeeper.Engine
 
             var repositories = await _repositoryDiscovery.GetRepositories();
 
+            int reposUpdated = 0;
+
             foreach (var repository in repositories)
             {
-                await _repositoryEngine.Run(repository, gitCreds, userIdentity);
+                var updatesInThisRepo = await _repositoryEngine.Run(repository, gitCreds, userIdentity);
+                if (updatesInThisRepo > 0)
+                {
+                    reposUpdated++;
+                }
             }
 
-            _logger.Verbose($"{Now()}: Done");
+            if (reposUpdated > 1)
+            {
+                _logger.Verbose($"{reposUpdated} repositories were updated");
+            }
+            _logger.Verbose($"Done at {Now()}");
         }
 
         private Identity GetUserIdentity(Account githubUser)

--- a/NuKeeper/Engine/GithubEngine.cs
+++ b/NuKeeper/Engine/GithubEngine.cs
@@ -35,7 +35,7 @@ namespace NuKeeper.Engine
             _logger = logger;
         }
 
-        public async Task Run()
+        public async Task<int> Run()
         {
             _logger.Verbose($"{Now()}: Started");
 
@@ -52,7 +52,7 @@ namespace NuKeeper.Engine
 
             var repositories = await _repositoryDiscovery.GetRepositories();
 
-            int reposUpdated = 0;
+            var reposUpdated = 0;
 
             foreach (var repository in repositories)
             {
@@ -67,7 +67,9 @@ namespace NuKeeper.Engine
             {
                 _logger.Verbose($"{reposUpdated} repositories were updated");
             }
+
             _logger.Verbose($"Done at {Now()}");
+            return reposUpdated;
         }
 
         private Identity GetUserIdentity(Account githubUser)

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.Engine
             _logger = logger;
         }
 
-        public async Task Run(RepositorySettings repository, UsernamePasswordCredentials gitCreds,
+        public async Task<int> Run(RepositorySettings repository, UsernamePasswordCredentials gitCreds,
             Identity userIdentity)
         {
             try
@@ -36,19 +36,21 @@ namespace NuKeeper.Engine
                 var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
                 if (repo == null)
                 {
-                    return;
+                    return 0;
                 }
 
                 var tempFolder = _folderFactory.UniqueTemporaryFolder();
                 var git = new LibGit2SharpDriver(_logger, tempFolder, gitCreds, userIdentity);
 
-                await _repositoryUpdater.Run(git, repo);
+                var updatesDone = await _repositoryUpdater.Run(git, repo);
 
                 tempFolder.TryDelete();
+                return updatesDone;
             }
             catch (Exception ex)
             {
                 _logger.Error($"Failed on repo {repository.RepositoryName}", ex);
+                return 0;
             }
         }
 

--- a/NuKeeper/Engine/IGithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/IGithubRepositoryEngine.cs
@@ -6,6 +6,6 @@ namespace NuKeeper.Engine
 {
     public interface IGithubRepositoryEngine
     {
-        Task Run(RepositorySettings repository, UsernamePasswordCredentials gitCreds, Identity userIdentity);
+        Task<int> Run(RepositorySettings repository, UsernamePasswordCredentials gitCreds, Identity userIdentity);
     }
 }

--- a/NuKeeper/Engine/IRepositoryUpdater.cs
+++ b/NuKeeper/Engine/IRepositoryUpdater.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using NuKeeper.Git;
 
 namespace NuKeeper.Engine
 {
     public interface IRepositoryUpdater
     {
-        Task Run(IGitDriver git, RepositoryData repository);
+        Task<int> Run(IGitDriver git, RepositoryData repository);
     }
 }

--- a/NuKeeper/Engine/Packages/IPackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/IPackageUpdater.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Engine.Packages
 {
     public interface IPackageUpdater
     {
-        Task MakeUpdatePullRequest(
+        Task<bool> MakeUpdatePullRequest(
             IGitDriver git,
             PackageUpdateSet updateSet,
             NuGetSources sources,

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -31,7 +31,7 @@ namespace NuKeeper.Engine.Packages
             _modalSettings = modalSettings;
         }
 
-        public async Task MakeUpdatePullRequest(
+        public async Task<bool> MakeUpdatePullRequest(
             IGitDriver git,
             PackageUpdateSet updateSet,
             NuGetSources sources,
@@ -59,10 +59,12 @@ namespace NuKeeper.Engine.Packages
                 await MakeGitHubPullRequest(updateSet, repository, prTitle, branchName);
 
                 git.Checkout(repository.DefaultBranch);
+                return true;
             }
             catch (Exception ex)
             {
                 _logger.Error("Update failed", ex);
+                return false;
             }
         }
 

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Git;

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -82,7 +82,15 @@ namespace NuKeeper.Engine
 
             var targetUpdates = await _updateSelection.SelectTargets(repository.Push, updates);
 
-            if (updates.Count == 0)
+            return await DoTargetUpdates(git, repository, targetUpdates, sources);
+        }
+
+        private async Task<int> DoTargetUpdates(
+            IGitDriver git, RepositoryData repository,
+            IReadOnlyCollection<PackageUpdateSet> targetUpdates,
+            NuGetSources sources)
+        {
+            if (targetUpdates.Count == 0)
             {
                 _logger.Terse("No updates can be applied. Exiting.");
                 return 0;
@@ -100,6 +108,7 @@ namespace NuKeeper.Engine
             {
                 _logger.Info($"Done {updatesDone} updates");
             }
+
             return updatesDone;
         }
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -124,18 +124,18 @@ namespace NuKeeper.Engine
             IEnumerable<PackageUpdateSet> targetUpdates,
             NuGetSources sources)
         {
-            var passes = 0;
+            var updatesDone = 0;
 
             foreach (var updateSet in targetUpdates)
             {
-                var pass = await _packageUpdater.MakeUpdatePullRequest(git, updateSet, sources, repository);
-                if (pass)
+                var success = await _packageUpdater.MakeUpdatePullRequest(git, updateSet, sources, repository);
+                if (success)
                 {
-                    passes++;
+                    updatesDone++;
                 }
             }
 
-            return passes;
+            return updatesDone;
         }
     }
 }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -15,7 +15,7 @@ namespace NuKeeper.Engine
 {
     public class RepositoryUpdater : IRepositoryUpdater
     {
-        private readonly INugetSourcesReader _nugetSourcesReader;
+        private readonly INuGetSourcesReader _nugetSourcesReader;
         private readonly IUpdateFinder _updateFinder;
         private readonly IPackageUpdateSelection _updateSelection;
         private readonly IPackageUpdater _packageUpdater;
@@ -25,7 +25,7 @@ namespace NuKeeper.Engine
         private readonly UserSettings _settings;
 
         public RepositoryUpdater(
-            INugetSourcesReader nugetSourcesReader,
+            INuGetSourcesReader nugetSourcesReader,
             IUpdateFinder updateFinder,
             IPackageUpdateSelection updateSelection,
             IPackageUpdater packageUpdater,

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -16,20 +16,20 @@ namespace NuKeeper.Local
 {
     public class LocalEngine
     {
-        private INugetSourcesReader _nugetSourcesReader;
+        private INuGetSourcesReader _nuGetSourcesReader;
         private readonly IUpdateFinder _updateFinder;
         private readonly IPackageUpdateSetSort _sorter;
         private readonly ILocalUpdater _updater;
         private readonly INuKeeperLogger _logger;
 
         public LocalEngine(
-            INugetSourcesReader nugetSourcesReader,
+            INuGetSourcesReader nuGetSourcesReader,
             IUpdateFinder updateFinder,
             IPackageUpdateSetSort sorter,
             ILocalUpdater updater,
             INuKeeperLogger logger)
         {
-            _nugetSourcesReader = nugetSourcesReader;
+            _nuGetSourcesReader = nuGetSourcesReader;
             _updateFinder = updateFinder;
             _sorter = sorter;
             _updater = updater;
@@ -40,7 +40,7 @@ namespace NuKeeper.Local
         {
             var folder = TargetFolder(settings.UserSettings);
 
-            var sources = _nugetSourcesReader.Read(folder, settings.UserSettings.NuGetSources);
+            var sources = _nuGetSourcesReader.Read(folder, settings.UserSettings.NuGetSources);
 
             var sortedUpdates = await GetSortedUpdates(folder, sources, settings.UserSettings.AllowedChange);
 


### PR DESCRIPTION
Flow the success status up to the caller, to let the caller know
if a PR was successfully made
How many PRs were made on this repo
How many repos have been changed

Will need this for limiting the number of repos altered in a run, for #276 

Also it adds test coverage, at the expense of using lots o'mocks. 