### PR TITLE
Max repos

### DIFF
--- a/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserCommandlineTests.cs
@@ -85,6 +85,7 @@ namespace NuKeeper.Tests.Configuration
 
             AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(3));
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(10));
             Assert.That(settings.UserSettings.MinimumPackageAge, Is.EqualTo(TimeSpan.FromDays(7)));
         }
 
@@ -122,6 +123,18 @@ namespace NuKeeper.Tests.Configuration
 
             AssertSettingsNotNull(settings);
             Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void MaxRepoOverrideIsParsed()
+        {
+            var commandLine = ValidRepoCommandLine()
+                .Append("maxrepo=51");
+
+            var settings = SettingsParser.ReadSettings(commandLine);
+
+            AssertSettingsNotNull(settings);
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(51));
         }
 
         [Test]

--- a/NuKeeper.Tests/Configuration/SettingsParserTests.cs
+++ b/NuKeeper.Tests/Configuration/SettingsParserTests.cs
@@ -33,6 +33,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
+            Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(10));
         }
 
         [Test]
@@ -48,6 +49,8 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.LogLevel, Is.EqualTo(LogLevel.Info));
             Assert.That(settings.UserSettings.ForkMode, Is.EqualTo(ForkMode.PreferFork));
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
+            Assert.That(settings.UserSettings.MaxPullRequestsPerRepository, Is.EqualTo(10));
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(20));
         }
 
         [Test]
@@ -117,7 +120,6 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
         }
 
-
         private static RawConfiguration ValidRepoSettings()
         {
             return new RawConfiguration
@@ -131,7 +133,8 @@ namespace NuKeeper.Tests.Configuration
                 LogLevel = LogLevel.Info,
                 ForkMode = ForkMode.PreferFork,
                 ReportMode = ReportMode.Off,
-                Labels = "nukeeper"
+                Labels = "nukeeper",
+                MaxPullRequestsPerRepository = 10
             };
         }
 
@@ -148,7 +151,9 @@ namespace NuKeeper.Tests.Configuration
                 LogLevel = LogLevel.Info,
                 ForkMode = ForkMode.PreferFork,
                 ReportMode = ReportMode.Off,
-                Labels = "nukeeper"
+                Labels = "nukeeper",
+                MaxPullRequestsPerRepository = 10,
+                MaxRepositoriesChanged = 20
             };
         }
 
@@ -175,7 +180,6 @@ namespace NuKeeper.Tests.Configuration
                 Labels = "nukeeper"
             };
         }
-
 
         private static void AssertSettingsNotNull(SettingsContainer settings)
         {

--- a/NuKeeper.Tests/Engine/GithubEngineTests.cs
+++ b/NuKeeper.Tests/Engine/GithubEngineTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using NSubstitute;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
@@ -13,7 +15,69 @@ namespace NuKeeper.Tests.Engine
     public class GithubEngineTests
     {
         [Test]
-        public async Task SuperHappyFunPath()
+        public async Task SuccessCaseWithNoRepos()
+        {
+            var engine = MakeGithubEngine(
+                new List<RepositorySettings>());
+
+            var count = await engine.Run();
+
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task SuccessCaseWithOneRepo()
+        {
+            var oneRepo = new List<RepositorySettings>
+            {
+                new RepositorySettings()
+            };
+            var engine = MakeGithubEngine(oneRepo);
+
+            var count = await engine.Run();
+
+            Assert.That(count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task SuccessCaseWithTwoRepos()
+        {
+            var repos = new List<RepositorySettings>
+            {
+                new RepositorySettings(),
+                new RepositorySettings()
+            };
+            var engine = MakeGithubEngine(repos);
+
+            var count = await engine.Run();
+
+            Assert.That(count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task CountIsNotIncrementedWhenRepoEngineFails()
+        {
+            var repos = new List<RepositorySettings>
+            {
+                new RepositorySettings(),
+                new RepositorySettings()
+            };
+            var engine = MakeGithubEngine(0, repos);
+
+            var count = await engine.Run();
+
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        private static GithubEngine MakeGithubEngine(
+            List<RepositorySettings> repos)
+        {
+            return MakeGithubEngine(1, repos);
+        }
+
+            private static GithubEngine MakeGithubEngine(
+            int repoEngineResult,
+            List<RepositorySettings> repos)
         {
             var github = Substitute.For<IGithub>();
             var repoDiscovery = Substitute.For<IGithubRepositoryDiscovery>();
@@ -23,15 +87,21 @@ namespace NuKeeper.Tests.Engine
             github.GetCurrentUser().Returns(
                 RepositoryBuilder.MakeUser("http://test.user.com"));
 
+            repoDiscovery.GetRepositories()
+                .Returns(repos);
+
+            repoEngine.Run(
+                    Arg.Any<RepositorySettings>(),
+                    Arg.Any<UsernamePasswordCredentials>(),
+                    Arg.Any<Identity>())
+                .Returns(repoEngineResult);
+
             var setings = new GithubAuthSettings(new Uri("http://foo.com"), "token123");
 
             var engine = new GithubEngine(github, repoDiscovery, repoEngine,
                 setings,
                 folders, new NullNuKeeperLogger());
-
-            var count = await engine.Run();
-
-            Assert.That(count, Is.EqualTo(0));
+            return engine;
         }
     }
 }

--- a/NuKeeper/Configuration/RawConfiguration.cs
+++ b/NuKeeper/Configuration/RawConfiguration.cs
@@ -30,6 +30,10 @@ namespace NuKeeper.Configuration
         [OverriddenBy(ConfigurationSources.CommandLine, "maxpr")]
         public int MaxPullRequestsPerRepository;
 
+        [JsonConfig("max_repositories_changed"), Default(10)]
+        [OverriddenBy(ConfigurationSources.CommandLine, "maxrepo")]
+        public int MaxRepositoriesChanged;
+
         [JsonConfig("log_level"), Default("Info")]
         [OverriddenBy(ConfigurationSources.CommandLine, "log")]
         public LogLevel LogLevel;

--- a/NuKeeper/Configuration/SettingsParser.cs
+++ b/NuKeeper/Configuration/SettingsParser.cs
@@ -63,6 +63,7 @@ namespace NuKeeper.Configuration
                 LogLevel = settings.LogLevel,
                 ReportMode = settings.ReportMode,
                 MaxPullRequestsPerRepository = settings.MaxPullRequestsPerRepository,
+                MaxRepositoriesChanged = settings.MaxRepositoriesChanged,
                 NuGetSources = ReadNuGetSources(settings),
                 PackageIncludes = ParseRegex(settings.Include, nameof(settings.Include)),
                 PackageExcludes = ParseRegex(settings.Exclude, nameof(settings.Exclude)),

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -17,6 +17,8 @@ namespace NuKeeper.Configuration
 
         public int MaxPullRequestsPerRepository { get; set; }
 
+        public int MaxRepositoriesChanged { get; set; }
+
         public TimeSpan MinimumPackageAge { get; set; }
 
         public VersionChange AllowedChange { get; set; }

--- a/NuKeeper/Engine/GithubEngine.cs
+++ b/NuKeeper/Engine/GithubEngine.cs
@@ -15,6 +15,7 @@ namespace NuKeeper.Engine
         private readonly IGithub _github;
         private readonly IGithubRepositoryDiscovery _repositoryDiscovery;
         private readonly IGithubRepositoryEngine _repositoryEngine;
+        private readonly UserSettings _userSettings;
         private readonly string _githubToken;
         private readonly IFolderFactory _folderFactory;
         private readonly INuKeeperLogger _logger;
@@ -23,6 +24,7 @@ namespace NuKeeper.Engine
             IGithub github,
             IGithubRepositoryDiscovery repositoryDiscovery,
             IGithubRepositoryEngine repositoryEngine,
+            UserSettings userSettings,
             GithubAuthSettings settings,
             IFolderFactory folderFactory,
             INuKeeperLogger logger)
@@ -30,6 +32,7 @@ namespace NuKeeper.Engine
             _github = github;
             _repositoryDiscovery = repositoryDiscovery;
             _repositoryEngine = repositoryEngine;
+            _userSettings = userSettings;
             _githubToken = settings.Token;
             _folderFactory = folderFactory;
             _logger = logger;
@@ -56,6 +59,12 @@ namespace NuKeeper.Engine
 
             foreach (var repository in repositories)
             {
+                if (reposUpdated >= _userSettings.MaxRepositoriesChanged)
+                {
+                    _logger.Verbose($"Reached max of {reposUpdated} repositories changed");
+                    break;
+                }
+
                 var updatesInThisRepo = await _repositoryEngine.Run(repository, gitCreds, userIdentity);
                 if (updatesInThisRepo > 0)
                 {


### PR DESCRIPTION
A limit on the number of repositories altered in org mode.
Not a limit on the number of repos inspected, but on the number that actually get PRd.
This builds on previous PR #304 which counts the number of repos altered.
Needed for #276

There's a sensible (?) default of 10 repos.
So the command line to change the default would be e.g. `mode=org maxrepo=20`
