### PR TITLE
Handle packages differing only by name case

### DIFF
--- a/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Inspection.NuGetApi
             VersionChange allowedChange)
         {
             var latestOfEach = packages
-                .GroupBy(pi => pi.Id)
+                .GroupBy(pi => pi.Id.ToLowerInvariant())
                 .Select(HighestVersion);
 
             var lookupTasks = latestOfEach
@@ -35,7 +35,7 @@ namespace NuKeeper.Inspection.NuGetApi
 
             await Task.WhenAll(lookupTasks);
 
-            var result = new Dictionary<string, PackageLookupResult>();
+            var result = new Dictionary<string, PackageLookupResult>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var lookupTask in lookupTasks)
             {

--- a/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace NuKeeper.Inspection.NuGetApi
             _lookupReporter = lookupReporter;
         }
 
-        public async Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
+        public async Task<IDictionary<string, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
             NuGetSources sources,
             VersionChange allowedChange)
@@ -45,7 +46,7 @@ namespace NuKeeper.Inspection.NuGetApi
             return result;
         }
 
-        private void ProcessLookupResult(PackageLookupResult packageLookup, Dictionary<string, PackageLookupResult> result)
+        private void ProcessLookupResult(PackageLookupResult packageLookup, IDictionary<string, PackageLookupResult> result)
         {
             var selectedVersion = packageLookup.Selected();
 

--- a/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Inspection.NuGetApi
 {
     public interface IBulkPackageLookup
     {
-        Task<Dictionary<string, PackageLookupResult>> FindVersionUpdates(
+        Task<IDictionary<string, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
             NuGetSources sources,
             VersionChange allowedChange);

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -49,6 +49,25 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         }
 
         [Test]
+        public async Task FindsSingleUpdateForPackageDifferingOnlyByCase()
+        {
+            var packages = new List<PackageIdentity>
+            {
+                Current("nunit"),
+                Current("NUnit")
+            };
+
+            var lookup = BuildBulkPackageLookup();
+
+            var results = await lookup.FindVersionUpdates(
+                packages, NuGetSources.GlobalFeed, VersionChange.Major);
+
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results, Does.ContainKey("NUnit"));
+        }
+
+        [Test]
         public async Task InvalidPackageIsIgnored()
         {
             var packages = new List<PackageIdentity>


### PR DESCRIPTION
NuGet treats them as identical.

For issue #307 