### PR TITLE
Project file reader should check for no-version

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -238,6 +238,22 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             PackageAssert.IsPopulated(packages[0]);
         }
 
+        [Test]
+        public void PackageWithoutVersionShouldBeSkipped()
+        {
+            const string noVersion =
+                @"<PackageReference Include=""Microsoft.AspNetCore.App"" />";
+
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
+                .ToList();
+
+            Assert.That(packages, Is.Empty);
+        }
+
         private ProjectFileReader MakeReader()
         {
             return new ProjectFileReader(Substitute.For<INuKeeperLogger>());

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -254,6 +254,23 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             Assert.That(packages, Is.Empty);
         }
 
+        [Test]
+        public void PackageWithWildCardVersionShouldBeSkipped()
+        {
+            const string noVersion =
+                @"<PackageReference Include=""AWSSDK.Core"" Version=""3.3.*"" />";
+
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
+                .ToList();
+
+            Assert.That(packages, Is.Empty);
+        }
+
+
         private ProjectFileReader MakeReader()
         {
             return new ProjectFileReader(Substitute.For<INuKeeperLogger>());

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -67,6 +67,12 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 var id = el.Attribute("Include")?.Value;
                 var version = el.Attribute("Version")?.Value ?? el.Value;
 
+                if (string.IsNullOrWhiteSpace(version))
+                {
+                    _logger.Info($"Skipping package '{id}' with no version specified.");
+                    return null;
+                }
+
                 return new PackageInProject(id, version, path);
             }
             catch (Exception ex)

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Inspection.RepositoryInspection
@@ -73,7 +75,14 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return null;
                 }
 
-                return new PackageInProject(id, version, path);
+                var versionParseSuccess = NuGetVersion.TryParse(version, out var nugetVersion);
+                if (!versionParseSuccess)
+                {
+                    _logger.Info($"Skipping package '{id}' with version '{version}' that could not be parsed.");
+                    return null;
+                }
+
+                return new PackageInProject(new PackageIdentity(id, nugetVersion), path);
             }
             catch (Exception ex)
             {

--- a/NuKeeper.Inspection/Sources/NuGetSources.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSources.cs
@@ -15,7 +15,9 @@ namespace NuKeeper.Inspection.Sources
                 throw new ArgumentException(nameof(sources));
             }
 
-            this.Items = sources.Select(s => new PackageSource(s)).ToList();
+            Items = sources
+                .Select(s => new PackageSource(s))
+                .ToList();
         }
 
         public NuGetSources(IEnumerable<PackageSource> sources)
@@ -32,7 +34,7 @@ namespace NuKeeper.Inspection.Sources
                 throw new ArgumentException(nameof(sources));
             }
 
-            this.Items = items;
+            Items = items;
         }
 
         private const string GlobalFeedUrl = "https://api.nuget.org/v3/index.json";


### PR DESCRIPTION
Project file reader should check for a package imported with no-version or a version range. 
These are things that happen.

e.g. `<PackageReference Include="Microsoft.AspNetCore.App" />`
and `<PackageReference Include="AWSSDK.Core" Version="3.3.*" />`
This is a very basic fix for #311 

We don't parse these cases yet. :(