### PR TITLE
Skipping repositories that contain no .NET projects

### DIFF
--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -17,13 +17,13 @@ namespace NuKeeper.Integration.Tests.Engine
         {
             IRepositoryFilter subject = MakeRepositoryFilter();
 
-            var shouldSkip =
-                await subject.ShouldSkip(new RepositorySettings
+            var result =
+                await subject.ContainsDotNetProjects(new RepositorySettings
                 {
                     RepositoryName = "jquery",
                     RepositoryOwner = "jquery"
                 });
-            Assert.True(shouldSkip);
+            Assert.False(result);
         }
 
         [Test]
@@ -31,9 +31,9 @@ namespace NuKeeper.Integration.Tests.Engine
         {
             IRepositoryFilter subject = MakeRepositoryFilter();
 
-            var shouldSkip =
-                await subject.ShouldSkip(new RepositorySettings {RepositoryName = "cli", RepositoryOwner = "dotnet"});
-            Assert.False(shouldSkip);
+            var result =
+                await subject.ContainsDotNetProjects(new RepositorySettings {RepositoryName = "cli", RepositoryOwner = "dotnet"});
+            Assert.True(result);
         }
 
         private static RepositoryFilter MakeRepositoryFilter()

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Github;
+using NuKeeper.Inspection.Logging;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.Engine
+{
+    [TestFixture]
+    public class RepositoryFilterTests
+    {
+        [Test]
+        public async Task ShouldFilterOutNonDotnetRepository()
+        {
+            IRepositoryFilter subject = MakeRepositoryFilter();
+
+            var shouldSkip =
+                await subject.ShouldSkip(new RepositorySettings
+                {
+                    RepositoryName = "jquery",
+                    RepositoryOwner = "jquery"
+                });
+            Assert.True(shouldSkip);
+        }
+
+        [Test]
+        public async Task ShouldNotFilterOutADotnetRepository()
+        {
+            IRepositoryFilter subject = MakeRepositoryFilter();
+
+            var shouldSkip =
+                await subject.ShouldSkip(new RepositorySettings {RepositoryName = "cli", RepositoryOwner = "dotnet"});
+            Assert.False(shouldSkip);
+        }
+
+        private static RepositoryFilter MakeRepositoryFilter()
+        {
+            const string testKeyWithOnlyPublicAccess = "c13d2ce7774d39ae99ddaad46bd69c3d459b9992";
+            var logger = Substitute.For<INuKeeperLogger>();
+            return new RepositoryFilter(
+                new OctokitClient(
+                    new GithubAuthSettings(new Uri("https://api.github.com"),
+                        testKeyWithOnlyPublicAccess), logger), logger);
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Octokit" Version="0.30.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />

--- a/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Github;
+using NuKeeper.Inspection.Logging;
+using NUnit.Framework;
+using Octokit;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class RepositoryFilterTests
+    {
+        [Test]
+        public async Task ShouldFilterWhenNoMatchFound()
+        {
+            var githubClient = Substitute.For<IGithub>();
+            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(0, false, null)));
+
+            IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
+
+            var result = await subject.ShouldSkip(MakeSampleRepository());
+
+            Assert.True(result);
+        }
+
+        [Test]
+        public async Task ShouldNotFilterWhenMatchFound()
+        {
+            var githubClient = Substitute.For<IGithub>();
+            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(1, false, null)));
+
+            IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
+
+            var result = await subject.ShouldSkip(MakeSampleRepository());
+
+            Assert.False(result);
+        }
+
+        [Test]
+        public async Task ShouldNotFilterWhenSearchFails()
+        {
+            var githubClient = Substitute.For<IGithub>();
+            githubClient.Search(null).ThrowsForAnyArgs(new Exception());
+
+            IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
+
+            var result = await subject.ShouldSkip(MakeSampleRepository());
+
+            Assert.False(result);
+        }
+
+        private static RepositorySettings MakeSampleRepository()
+        {
+            return new RepositorySettings
+            {
+                RepositoryName = "sample-repo",
+                RepositoryOwner = "sample-owner"
+            };
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
@@ -22,9 +22,9 @@ namespace NuKeeper.Tests.Engine
 
             IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
 
-            var result = await subject.ShouldSkip(MakeSampleRepository());
+            var result = await subject.ContainsDotNetProjects(MakeSampleRepository());
 
-            Assert.True(result);
+            Assert.False(result);
         }
 
         [Test]
@@ -35,9 +35,9 @@ namespace NuKeeper.Tests.Engine
 
             IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
 
-            var result = await subject.ShouldSkip(MakeSampleRepository());
+            var result = await subject.ContainsDotNetProjects(MakeSampleRepository());
 
-            Assert.False(result);
+            Assert.True(result);
         }
 
         [Test]
@@ -48,9 +48,9 @@ namespace NuKeeper.Tests.Engine
 
             IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
 
-            var result = await subject.ShouldSkip(MakeSampleRepository());
+            var result = await subject.ContainsDotNetProjects(MakeSampleRepository());
 
-            Assert.False(result);
+            Assert.True(result);
         }
 
         private static RepositorySettings MakeSampleRepository()

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -30,6 +30,7 @@ namespace NuKeeper
             container.Register<IGithubRepositoryDiscovery, GithubRepositoryDiscovery>();
             container.Register<IPackageUpdateSelection, PackageUpdateSelection>();
             container.Register<IExistingBranchFilter, ExistingBranchFilter>();
+            container.Register<IRepositoryFilter, RepositoryFilter>();
 
             container.Register<GithubEngine>();
             container.Register<IGithubRepositoryEngine, GithubRepositoryEngine>();

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -42,7 +42,7 @@ namespace NuKeeper.Engine
                     return 0;
                 }
 
-                if (await _repositoryFilter.ShouldSkip(repository))
+                if (!await _repositoryFilter.ContainsDotNetProjects(repository))
                 {
                     return 0;
                 }

--- a/NuKeeper/Engine/GithubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GithubRepositoryEngine.cs
@@ -14,18 +14,21 @@ namespace NuKeeper.Engine
         private readonly IForkFinder _forkFinder;
         private readonly IFolderFactory _folderFactory;
         private readonly INuKeeperLogger _logger;
+        private readonly IRepositoryFilter _repositoryFilter;
 
         public GithubRepositoryEngine(
             IRepositoryUpdater repositoryUpdater,
             IForkFinder forkFinder,
             IFolderFactory folderFactory,
-            INuKeeperLogger logger
+            INuKeeperLogger logger,
+            IRepositoryFilter repositoryFilter
             )
         {
             _repositoryUpdater = repositoryUpdater;
             _forkFinder = forkFinder;
             _folderFactory = folderFactory;
             _logger = logger;
+            _repositoryFilter = repositoryFilter;
         }
 
         public async Task<int> Run(RepositorySettings repository, UsernamePasswordCredentials gitCreds,
@@ -35,6 +38,11 @@ namespace NuKeeper.Engine
             {
                 var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
                 if (repo == null)
+                {
+                    return 0;
+                }
+
+                if (await _repositoryFilter.ShouldSkip(repository))
                 {
                     return 0;
                 }

--- a/NuKeeper/Engine/IRepositoryFilter.cs
+++ b/NuKeeper/Engine/IRepositoryFilter.cs
@@ -5,6 +5,6 @@ namespace NuKeeper.Engine
 {
     public interface IRepositoryFilter
     {
-        Task<bool> ShouldSkip(RepositorySettings repository);
+        Task<bool> ContainsDotNetProjects(RepositorySettings repository);
     }
 }

--- a/NuKeeper/Engine/IRepositoryFilter.cs
+++ b/NuKeeper/Engine/IRepositoryFilter.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using NuKeeper.Configuration;
+
+namespace NuKeeper.Engine
+{
+    public interface IRepositoryFilter
+    {
+        Task<bool> ShouldSkip(RepositorySettings repository);
+    }
+}

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using NuKeeper.Configuration;
+using NuKeeper.Github;
+using NuKeeper.Inspection.Logging;
+using Octokit;
+
+namespace NuKeeper.Engine
+{
+    public class RepositoryFilter : IRepositoryFilter
+    {
+        private readonly IGithub _githubClient;
+        private readonly INuKeeperLogger _logger;
+
+        public RepositoryFilter(IGithub githubClient, INuKeeperLogger logger)
+        {
+            _githubClient = githubClient;
+            _logger = logger;
+        }
+
+        public async Task<bool> ShouldSkip(RepositorySettings repository)
+        {
+            var request = new SearchCodeRequest("\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"")
+            {
+                Repos = new RepositoryCollection {{repository.RepositoryOwner, repository.RepositoryName}},
+                In = new []{CodeInQualifier.Path},
+                PerPage = 1
+            };
+            try
+            {
+                var result = await _githubClient.Search(request);
+                if (result.TotalCount <= 0)
+                {
+                    _logger.Verbose(
+                        $"Repository {repository.RepositoryOwner}/{repository.RepositoryName} contains no .NET code on the default branch, skipping.");
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("GitHub Repository search failed.", ex);
+            }
+
+            return false;
+        }
+    }
+}

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Engine
             _logger = logger;
         }
 
-        public async Task<bool> ShouldSkip(RepositorySettings repository)
+        public async Task<bool> ContainsDotNetProjects(RepositorySettings repository)
         {
             var request = new SearchCodeRequest("\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"")
             {
@@ -33,7 +33,7 @@ namespace NuKeeper.Engine
                 {
                     _logger.Verbose(
                         $"Repository {repository.RepositoryOwner}/{repository.RepositoryName} contains no .NET code on the default branch, skipping.");
-                    return true;
+                    return false;
                 }
             }
             catch (Exception ex)
@@ -41,7 +41,7 @@ namespace NuKeeper.Engine
                 _logger.Error("GitHub Repository search failed.", ex);
             }
 
-            return false;
+            return true;
         }
     }
 }

--- a/NuKeeper/Github/IGithub.cs
+++ b/NuKeeper/Github/IGithub.cs
@@ -18,5 +18,7 @@ namespace NuKeeper.Github
         Task<Repository> MakeUserFork(string owner, string repositoryName);
 
         Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName);
+
+        Task<SearchCodeResult> Search(SearchCodeRequest search);
     }
 }

--- a/NuKeeper/Github/OctokitClient.cs
+++ b/NuKeeper/Github/OctokitClient.cs
@@ -100,6 +100,11 @@ namespace NuKeeper.Github
             return createdPullRequest;
         }
 
+        public async Task<SearchCodeResult> Search(SearchCodeRequest search)
+        {
+            return await _client.Search.SearchCode(search);
+        }
+
         private async Task AddLabelsToIssue(ForkData target, int issueNumber, IEnumerable<string> labels)
         {
             var labelsToApply = labels?


### PR DESCRIPTION
This makes the Organisation mode faster, by not cloning repositories that contain no .NET projects. The check is based on either of those files being present, checked with GitHub search API:
 - packages.config
 - .csproj
 - .fsproj
 - .vbproj