### PR TITLE
Flag prerelease

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -125,7 +125,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadata> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();
-            allVersions.Lookup(Arg.Any<string>(), Arg.Any<NuGetSources>())
+            allVersions.Lookup(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<NuGetSources>())
                 .Returns(actualResults);
             return allVersions;
         }

--- a/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Inspection.NuGetApi
             NuGetSources sources,
             VersionChange allowedChange)
         {
-            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, sources);
+            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, false, sources);
             return VersionChanges.MakeVersions(package.Version, foundVersions, allowedChange);
         }
     }

--- a/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
@@ -7,6 +7,7 @@ namespace NuKeeper.Inspection.NuGetApi
     public interface IPackageVersionsLookup
     {
         Task<IReadOnlyCollection<PackageSearchMedatadata>> Lookup(
-            string packageName, NuGetSources sources);
+            string packageName, bool includePrerelease,
+            NuGetSources sources);
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -47,6 +47,34 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
             Assert.That(latest.Identity.Id, Is.EqualTo("Newtonsoft.Json"));
             Assert.That(latest.Identity.Version.Major, Is.GreaterThan(1));
             Assert.That(latest.Published.HasValue, Is.True);
+            Assert.That(latest.Identity.Version.IsPrerelease, Is.False);
+        }
+
+        [Test]
+        public async Task CanGetPreReleases()
+        {
+            var lookup = BuildPackageLookup();
+
+            var packages = await lookup.Lookup("Moq", true, NuGetSources.GlobalFeed);
+
+            Assert.That(packages, Is.Not.Null);
+
+            var betas = packages
+                .Where(p => p.Identity.Version.IsPrerelease)
+                .OrderByDescending(p => p.Identity.Version)
+                .ToList();
+
+            Assert.That(betas, Is.Not.Null);
+            Assert.That(betas, Is.Not.Empty);
+
+            var beta = betas.FirstOrDefault();
+
+            Assert.That(beta, Is.Not.Null);
+            Assert.That(beta.Identity, Is.Not.Null);
+            Assert.That(beta.Identity.Version, Is.Not.Null);
+
+            Assert.That(beta.Identity.Id, Is.EqualTo("Moq"));
+            Assert.That(beta.Identity.Version.IsPrerelease, Is.True);
         }
 
         [Test]

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json", NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -31,7 +31,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json", NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -54,7 +54,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Moq", NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Moq", false, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 


### PR DESCRIPTION
Work towards allowing pre-release updates
`PackageVersionsLookup` is passed a flag to `includePrerelease`, rather than using a hard-coded false.
It's not used yet, the hard-coded false is still there at the caller's caller.

Intention is to allow existing pre-releases to update to later pre-releases.  ( #175 )
 That will come later, as it might disrupt other things and therefore needs more tests.