### PR TITLE
Don't remove package before updating for dotnetcore - fixes #337

### DIFF
--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -32,7 +32,13 @@ namespace NuKeeper.Update.Process
             _logger.Verbose($"dotnet update package {currentPackage.Id} in path {projectPath} {projectFileName} from source {sourceUrl}");
 
             await _externalProcess.Run(projectPath, "dotnet", $"restore {projectFileName} {sources}", true);
-            await _externalProcess.Run(projectPath, "dotnet", $"remove {projectFileName} package {currentPackage.Id}", true);
+
+            if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
+            {
+                await _externalProcess.Run(projectPath, "dotnet",
+                    $"remove {projectFileName} package {currentPackage.Id}", true);
+            }
+
             await _externalProcess.Run(projectPath, "dotnet", $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}", true);
         }
     }

--- a/NuKeeper.Update/UpdateRunner.cs
+++ b/NuKeeper.Update/UpdateRunner.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Update
         {
             foreach (var current in updateSet.CurrentPackages)
             {
-                var updateCommands = GetUpdateCommands(current.Path.PackageReferenceType, sources);
+                var updateCommands = GetUpdateCommands(current.Path.PackageReferenceType);
                 foreach (var updateCommand in updateCommands)
                 {
                     await updateCommand.Invoke(current, updateSet.SelectedVersion, updateSet.Selected.Source, sources);
@@ -30,8 +30,7 @@ namespace NuKeeper.Update
         }
 
         private IReadOnlyCollection<IPackageCommand> GetUpdateCommands(
-            PackageReferenceType packageReferenceType,
-            NuGetSources sources)
+            PackageReferenceType packageReferenceType)
         {
             switch (packageReferenceType)
             {


### PR DESCRIPTION
This should prevent order of packages in the file changing on updates.