### PR TITLE
read github token from env

### DIFF
--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -58,7 +58,7 @@ namespace NuKeeper.Commands
             _configureLogger.SetLogLevel(Verbosity);
             var settings = MakeSettings();
 
-            var validationResult = ValidateSettings(settings);
+            var validationResult = PopulateSettings(settings);
             if (!validationResult.IsSuccess)
             {
                 var logger = _configureLogger as INuKeeperLogger;
@@ -91,15 +91,10 @@ namespace NuKeeper.Commands
                 }
             };
 
-            PopulateSettings(settings);
             return settings;
         }
 
-        protected virtual void PopulateSettings(SettingsContainer settings)
-        {
-        }
-
-        protected virtual ValidationResult ValidateSettings(SettingsContainer settings)
+        protected virtual ValidationResult PopulateSettings(SettingsContainer settings)
         {
             return ValidationResult.Success;
         }

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -54,9 +54,11 @@ namespace NuKeeper.Commands
 
         protected override void PopulateSettings(SettingsContainer settings)
         {
+            var token = ReadToken();
+
             settings.GithubAuthSettings = new GithubAuthSettings(
                 SettingsParser.EnsureTrailingSlash(GithubApiEndpoint),
-                GitHubToken);
+                token);
 
             settings.UserSettings.MaxRepositoriesChanged = AllowedMaxRepositoriesChangedChange;
             settings.UserSettings.MaxPullRequestsPerRepository = MaxPullRequestsPerRepository;
@@ -65,9 +67,25 @@ namespace NuKeeper.Commands
             settings.ModalSettings.Labels = Label;
         }
 
+        private string ReadToken()
+        {
+            if (!string.IsNullOrWhiteSpace(GitHubToken))
+            {
+                return GitHubToken;
+            }
+
+            var envToken = Environment.GetEnvironmentVariable("NuKeeper_github_token");
+            if (!string.IsNullOrWhiteSpace(envToken))
+            {
+                return envToken;
+            }
+
+            return string.Empty;
+        }
+
         protected override ValidationResult ValidateSettings(SettingsContainer settings)
         {
-            if (string.IsNullOrWhiteSpace(GitHubToken))
+            if (string.IsNullOrWhiteSpace(settings.GithubAuthSettings.Token))
             {
                 return ValidationResult.Failure("The required GitHub access token was not found");
             }

--- a/NuKeeper/Commands/GlobalCommand.cs
+++ b/NuKeeper/Commands/GlobalCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
@@ -17,14 +16,16 @@ namespace NuKeeper.Commands
             _engine = engine;
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
-            base.PopulateSettings(settings);
-            settings.ModalSettings.Mode = RunMode.Global;
-        }
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
 
-        protected override ValidationResult ValidateSettings(SettingsContainer settings)
-        {
+            settings.ModalSettings.Mode = RunMode.Global;
+
             if (settings.UserSettings.PackageIncludes == null)
             {
                 return ValidationResult.Failure("Global mode must have an include regex");
@@ -36,7 +37,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure("Global mode must not use public github");
             }
 
-            return base.ValidateSettings(settings);
+            return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)

--- a/NuKeeper/Commands/InspectCommand.cs
+++ b/NuKeeper/Commands/InspectCommand.cs
@@ -17,10 +17,16 @@ namespace NuKeeper.Commands
             _engine = engine;
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
-            base.PopulateSettings(settings);
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
             settings.ModalSettings.Mode = RunMode.Inspect;
+            return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)

--- a/NuKeeper/Commands/LocalNuKeeperCommand.cs
+++ b/NuKeeper/Commands/LocalNuKeeperCommand.cs
@@ -16,9 +16,16 @@ namespace NuKeeper.Commands
         {
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
             settings.UserSettings.Directory = Path;
+            return ValidationResult.Success;
         }
     }
 }

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -21,11 +21,17 @@ namespace NuKeeper.Commands
             _engine = engine;
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
-            base.PopulateSettings(settings);
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
             settings.ModalSettings.Mode = RunMode.Organisation;
             settings.ModalSettings.OrganisationName = GithubOrganisationName;
+            return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -22,11 +22,18 @@ namespace NuKeeper.Commands
             _engine = engine;
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
-            base.PopulateSettings(settings);
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
             settings.ModalSettings.Mode = RunMode.Repository;
             settings.ModalSettings.Repository = SettingsParser.ReadRepositorySettings(GitHubRepositoryUri);
+
+            return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -17,10 +17,16 @@ namespace NuKeeper.Commands
             _engine = engine;
         }
 
-        protected override void PopulateSettings(SettingsContainer settings)
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
-            base.PopulateSettings(settings);
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
             settings.ModalSettings.Mode = RunMode.Update;
+            return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -15,7 +15,9 @@ namespace NuKeeper
     [Subcommand("inspect", typeof(InspectCommand))]
     [Subcommand("update", typeof(UpdateCommand))]
     [Subcommand("repository", typeof(RepositoryCommand))]
+    [Subcommand("repo", typeof(RepositoryCommand))]
     [Subcommand("organisation", typeof(OrganisationCommand))]
+    [Subcommand("org", typeof(OrganisationCommand))]
     [Subcommand("global", typeof(GlobalCommand))]
     public class Program
     {


### PR DESCRIPTION
read github token from environment var
and refactor config validation
Populating config can't be a separate activity to validating it. 
Best example is if the URI can't be parsed,
e.g. `dotnet run repository sometoken --api foo`
then it must stop trying to populate and return a validation failure
also a couple of short command aliases: "org" and "repo"