### PR TITLE
Short command names "repo" and "org"

### DIFF
--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -14,8 +14,8 @@ namespace NuKeeper
     [VersionOptionFromMember(MemberName = nameof(GetVersion))]
     [Subcommand("inspect", typeof(InspectCommand))]
     [Subcommand("update", typeof(UpdateCommand))]
-    [Subcommand("repository", typeof(RepositoryCommand))]
-    [Subcommand("organisation", typeof(OrganisationCommand))]
+    [Subcommand("repo", typeof(RepositoryCommand))]
+    [Subcommand("org", typeof(OrganisationCommand))]
     [Subcommand("global", typeof(GlobalCommand))]
     public class Program
     {


### PR DESCRIPTION
`repo` and `org` instead of `repository` and `organisation` / "organization"

Ideally both would work, but we haven't yet seen a good way to do a command alias.
We also want a default command, `inspect` should run if no command is specified.