### PR TITLE
Allow local update to work

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.6.1</VersionPrefix>
     <PackageVersion>$(VersionPrefix)</PackageVersion>
     <Copyright>Copyright (c) NuKeeper 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
@@ -26,6 +27,8 @@ namespace NuKeeper.Commands
             }
 
             settings.ModalSettings.Mode = RunMode.Update;
+            settings.UserSettings.MaxPullRequestsPerRepository = 1;
+
             return ValidationResult.Success;
         }
 


### PR DESCRIPTION
Local update command will do nothing if `MaxPullRequestsPerRepository` is zero, as it is by default :(

`UpdateSelection` line 33 applies it
Bug fix