### PR TITLE
Allow beta updates when the current  package version is beta

### DIFF
--- a/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
@@ -18,7 +18,8 @@ namespace NuKeeper.Inspection.NuGetApi
             NuGetSources sources,
             VersionChange allowedChange)
         {
-            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, false, sources);
+            var allowBetas = package.Version.IsPrerelease;
+            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, allowBetas, sources);
             return VersionChanges.MakeVersions(package.Version, foundVersions, allowedChange);
         }
     }

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -101,13 +101,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         }
 
         [Test]
-        public async Task BetaVersion_ShouldNotReturnBetas()
+        public async Task BetaVersion_ShouldReturnBetas()
         {
             var lookup = BuildPackageLookup();
 
-            // when we ask for updates for newtonsoft 8.0.1
-            // we know that there is a later patch (8.0.3)
-            // and later major versions 9.0.1, 10.0.3 etc
+            // libgit2sharp is known for staying in preview for ages
             var package = await lookup.FindVersionUpdate(
                 new PackageIdentity("libgit2sharp", new NuGetVersion(0, 26, 0, "preview-0017")),
                 NuGetSources.GlobalFeed,

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -99,6 +99,27 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             Assert.That(package.Minor.Identity.Version.Major, Is.EqualTo(8));
             Assert.That(package.Major.Identity.Version.Major, Is.GreaterThan(8));
         }
+
+        [Test]
+        public async Task BetaVersion_ShouldNotReturnBetas()
+        {
+            var lookup = BuildPackageLookup();
+
+            // when we ask for updates for newtonsoft 8.0.1
+            // we know that there is a later patch (8.0.3)
+            // and later major versions 9.0.1, 10.0.3 etc
+            var package = await lookup.FindVersionUpdate(
+                new PackageIdentity("libgit2sharp", new NuGetVersion(0, 26, 0, "preview-0017")),
+                NuGetSources.GlobalFeed,
+                VersionChange.Minor);
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Selected(), Is.Not.Null);
+
+            var isBeta = package.Patch.Identity.Version.IsPrerelease;
+            Assert.That(isBeta, Is.True);
+        }
+
         private IApiPackageLookup BuildPackageLookup()
         {
             return new ApiPackageLookup(


### PR DESCRIPTION
Allow beta updates when the current  package version is beta.
This is a one line change.
Needs unit tests, an end-to-end run and a good look at the output wording.
Will it work? I don't know yet