### PR TITLE
Cache the SourceRepository objects across parallel invocations

### DIFF
--- a/NuKeeper.Inspection/NuGetApi/ConcurrentSourceRepositoryCache.cs
+++ b/NuKeeper.Inspection/NuGetApi/ConcurrentSourceRepositoryCache.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace NuKeeper.Inspection.NuGetApi
+{
+    public class ConcurrentSourceRepositoryCache
+    {
+        private readonly ConcurrentDictionary<PackageSource, SourceRepository> _packageSources
+            = new ConcurrentDictionary<PackageSource, SourceRepository>();
+
+        public SourceRepository Get(PackageSource source)
+        {
+            return _packageSources.GetOrAdd(source, CreateSourceRepository);
+        }
+
+        private static SourceRepository CreateSourceRepository(PackageSource packageSource)
+        {
+            return new SourceRepository(packageSource, Repository.Provider.GetCoreV3());
+        }
+    }
+}


### PR DESCRIPTION
Build the `SourceRepository` objects upfront
one per source, not one per request, as they are http inside
We expect that there are small number of sources, just 1 in many cases.
#383