### PR TITLE
Better detailed logging in DotNet and nuget commands

### DIFF
--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Inspection.Logging;
 using NuKeeper.Update.ProcessRunner;
 using NUnit.Framework;
 
@@ -48,7 +50,7 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
 
         private static async Task<ProcessOutput> RunExternalProcess(string command, string args, bool ensureSuccess)
         {
-            IExternalProcess process = new ExternalProcess();
+            IExternalProcess process = new ExternalProcess(Substitute.For<INuKeeperLogger>());
             return await process.Run(".", command, args, ensureSuccess);
         }
 

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -26,6 +26,7 @@ namespace NuKeeper.Update.Process
         {
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
+            var sourceUrl = packageSource.SourceUri.ToString();
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";
@@ -39,7 +40,7 @@ namespace NuKeeper.Update.Process
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = "add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
             _logger.Detailed($"In path {projectPath}, dotnet {addCommand}");
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -29,17 +29,21 @@ namespace NuKeeper.Update.Process
             var sourceUrl = packageSource.SourceUri.ToString();
             var sources = allSources.CommandLine("-s");
 
-            _logger.Detailed($"dotnet update package {currentPackage.Id} in path {projectPath} {projectFileName} from source {sourceUrl}");
+            var restoreCommand = $"restore {projectFileName} {sources}";
+            _logger.Detailed($"dotnet {restoreCommand} in path {projectPath}");
 
-            await _externalProcess.Run(projectPath, "dotnet", $"restore {projectFileName} {sources}", true);
+            await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {
-                await _externalProcess.Run(projectPath, "dotnet",
-                    $"remove {projectFileName} package {currentPackage.Id}", true);
+                var removeCommand = $"remove {projectFileName} package {currentPackage.Id}";
+                _logger.Detailed($"dotnet {removeCommand} in path {projectPath}");
+                await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            await _externalProcess.Run(projectPath, "dotnet", $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}", true);
+            var addCommand = "add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            _logger.Detailed($"dotnet {addCommand} in path {projectPath}");
+            await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
     }
 }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Update.Process
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _externalProcess = externalProcess ?? new ExternalProcess();
+            _externalProcess = externalProcess ?? new ExternalProcess(logger);
         }
 
         public async Task Invoke(PackageInProject currentPackage,
@@ -30,18 +30,15 @@ namespace NuKeeper.Update.Process
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";
-            _logger.Detailed($"In path {projectPath}, dotnet {restoreCommand}");
             await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {
                 var removeCommand = $"remove {projectFileName} package {currentPackage.Id}";
-                _logger.Detailed($"In path {projectPath}, dotnet {removeCommand}");
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
             var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
-            _logger.Detailed($"In path {projectPath}, dotnet {addCommand}");
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
     }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -26,7 +26,6 @@ namespace NuKeeper.Update.Process
         {
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
-            var sourceUrl = packageSource.SourceUri.ToString();
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -29,19 +29,18 @@ namespace NuKeeper.Update.Process
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";
-            _logger.Detailed($"dotnet {restoreCommand} in path {projectPath}");
-
+            _logger.Detailed($"In path {projectPath}, dotnet {restoreCommand}");
             await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {
                 var removeCommand = $"remove {projectFileName} package {currentPackage.Id}";
-                _logger.Detailed($"dotnet {removeCommand} in path {projectPath}");
+                _logger.Detailed($"In path {projectPath}, dotnet {removeCommand}");
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
             var addCommand = "add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
-            _logger.Detailed($"dotnet {addCommand} in path {projectPath}");
+            _logger.Detailed($"In path {projectPath}, dotnet {addCommand}");
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
     }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Update.Process
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _externalProcess = externalProcess ?? new ExternalProcess();
+            _externalProcess = externalProcess ?? new ExternalProcess(logger);
         }
 
         public async Task Invoke(FileInfo file, NuGetSources sources)
@@ -44,7 +44,6 @@ namespace NuKeeper.Update.Process
             var sourcesCommandLine = sources.CommandLine("-Source");
 
             var restoreCommand = $"restore {file.Name} {sourcesCommandLine}";
-            _logger.Detailed($"In path {file.DirectoryName}, {nuget} {restoreCommand}");
 
             var processOutput = await _externalProcess.Run(file.DirectoryName, nuget, restoreCommand, ensureSuccess: false);
 

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -43,10 +43,10 @@ namespace NuKeeper.Update.Process
 
             var sourcesCommandLine = sources.CommandLine("-Source");
 
-            var arguments = $"restore {file.Name} {sourcesCommandLine}";
-            _logger.Detailed($"{nuget} {arguments}");
+            var restoreCommand = $"restore {file.Name} {sourcesCommandLine}";
+            _logger.Detailed($"In path {file.DirectoryName}, {nuget} {restoreCommand}");
 
-            var processOutput = await _externalProcess.Run(file.DirectoryName, nuget, arguments, ensureSuccess: false);
+            var processOutput = await _externalProcess.Run(file.DirectoryName, nuget, restoreCommand, ensureSuccess: false);
 
             if (processOutput.Success)
             {

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Update.Process
             IExternalProcess externalProcess = null)
         {
             _logger = logger;
-            _externalProcess = externalProcess ?? new ExternalProcess();
+            _externalProcess = externalProcess ?? new ExternalProcess(logger);
         }
 
         public async Task Invoke(PackageInProject currentPackage,
@@ -42,8 +42,6 @@ namespace NuKeeper.Update.Process
 
             var sources = allSources.CommandLine("-Source");
             var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
-            _logger.Detailed($"In path {projectPath}, {nuget} {updateCommand}");
-
             await _externalProcess.Run(projectPath, nuget, updateCommand, true);
         }
     }

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -42,7 +42,7 @@ namespace NuKeeper.Update.Process
 
             var sources = allSources.CommandLine("-Source");
             var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
-            _logger.Detailed($"In path {projectPath}, nuget {updateCommand}");
+            _logger.Detailed($"In path {projectPath}, {nuget} {updateCommand}");
 
             await _externalProcess.Run(projectPath, nuget, updateCommand, true);
         }

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -31,7 +31,7 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
-            var dirName = currentPackage.Path.Info.DirectoryName;
+            var projectPath = currentPackage.Path.Info.DirectoryName;
 
             var nuget = NuGetPath.FindExecutable();
             if (string.IsNullOrWhiteSpace(nuget))
@@ -41,10 +41,10 @@ namespace NuKeeper.Update.Process
             }
 
             var sources = allSources.CommandLine("-Source");
-            var arguments = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
-            _logger.Detailed(arguments);
+            var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
+            _logger.Detailed($"In path {projectPath}, nuget {updateCommand}");
 
-            await _externalProcess.Run(dirName, nuget, arguments, true);
+            await _externalProcess.Run(projectPath, nuget, updateCommand, true);
         }
     }
 }

--- a/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
+++ b/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Update.ProcessRunner
 
         public async Task<ProcessOutput> Run(string workingDirectory, string command, string arguments, bool ensureSuccess)
         {
-            _logger.Detailed($"In path {workingDirectory},running command: {command} {arguments}");
+            _logger.Detailed($"In path {workingDirectory}, running command: {command} {arguments}");
 
             System.Diagnostics.Process process;
 


### PR DESCRIPTION
In Detailed verbosity, Log the complete text of the actual commands sent to `dotnet` or `nuget` in a standard format.