### PR TITLE
Multi update

### DIFF
--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -153,7 +153,7 @@ namespace NuKeeper.Tests.Engine
         {
             var settings = new FilterSettings
             {
-                MaxUpdates = Int32.MaxValue,
+                MaxPackageUpdates = Int32.MaxValue,
                 MinimumAge = TimeSpan.Zero
             };
             var logger = Substitute.For<INuKeeperLogger>();

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -153,7 +153,7 @@ namespace NuKeeper.Tests.Engine
         {
             var settings = new FilterSettings
             {
-                MaxPullRequests = Int32.MaxValue,
+                MaxUpdates = Int32.MaxValue,
                 MinimumAge = TimeSpan.Zero
             };
             var logger = Substitute.For<INuKeeperLogger>();

--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Configuration;
 using NuKeeper.Creators;
 using NuKeeper.Inspection;
+using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sort;
 using NuKeeper.Inspection.Sources;
 using NuKeeper.Local;
@@ -17,7 +21,8 @@ namespace NuKeeper.Tests.Local
         [Test]
         public async Task CanRunInspect()
         {
-            var engine = MakeLocalEngine();
+            var updater = Substitute.For<ILocalUpdater>();
+            var engine = MakeLocalEngine(updater);
 
             var settings = new SettingsContainer
             {
@@ -29,18 +34,58 @@ namespace NuKeeper.Tests.Local
             };
 
             await engine.Run(settings);
+
+            await updater
+                .Received(0)
+                .ApplyUpdates(
+                    Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<NuGetSources>());
         }
 
-        private static LocalEngine MakeLocalEngine()
+        [Test]
+        public async Task CanRunUpdate()
+        {
+            var updater = Substitute.For<ILocalUpdater>();
+            var engine = MakeLocalEngine(updater);
+
+            var settings = new SettingsContainer
+            {
+                ModalSettings = new ModalSettings
+                {
+                    Mode = RunMode.Update
+                },
+                UserSettings = new UserSettings()
+            };
+
+            await engine.Run(settings);
+
+            await updater
+                .Received(1)
+                .ApplyUpdates(
+                    Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<NuGetSources>());
+        }
+
+        private static LocalEngine MakeLocalEngine(ILocalUpdater updater)
         {
             var reader = Substitute.For<INuGetSourcesReader>();
             var finder = Substitute.For<IUpdateFinder>();
+            finder.FindPackageUpdateSets(
+                    Arg.Any<IFolder>(), Arg.Any<NuGetSources>(),
+                    Arg.Any<VersionChange>())
+                .Returns(new List<PackageUpdateSet>());
+
             var sorter = Substitute.For<IPackageUpdateSetSort>();
+            sorter.Sort(Arg.Any<IReadOnlyCollection<PackageUpdateSet>>())
+                .Returns(x => x.ArgAt<IReadOnlyCollection<PackageUpdateSet>>(0));
+
             var logger = Substitute.For<INuKeeperLogger>();
 
-            var updater = Substitute.For<ICreate<ILocalUpdater>>();
+            var updaterCreator = Substitute.For<ICreate<ILocalUpdater>>();
+            updaterCreator.Create(Arg.Any<SettingsContainer>())
+                .Returns(updater);
 
-            var engine = new LocalEngine(reader, finder, sorter, updater, logger);
+            var engine = new LocalEngine(reader, finder, sorter, updaterCreator, logger);
             Assert.That(engine, Is.Not.Null);
             return engine;
         }

--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Configuration;
+using NuKeeper.Creators;
+using NuKeeper.Inspection;
+using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.Sort;
+using NuKeeper.Inspection.Sources;
+using NuKeeper.Local;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Local
+{
+    [TestFixture]
+    public class LocalEngineTests
+    {
+        [Test]
+        public async Task CanRunInspect()
+        {
+            var engine = MakeLocalEngine();
+
+            var settings = new SettingsContainer
+            {
+                ModalSettings = new ModalSettings
+                {
+                    Mode = RunMode.Inspect
+                },
+                UserSettings = new UserSettings()
+            };
+
+            await engine.Run(settings);
+        }
+
+        private static LocalEngine MakeLocalEngine()
+        {
+            var reader = Substitute.For<INuGetSourcesReader>();
+            var finder = Substitute.For<IUpdateFinder>();
+            var sorter = Substitute.For<IPackageUpdateSetSort>();
+            var logger = Substitute.For<INuKeeperLogger>();
+
+            var updater = Substitute.For<ICreate<ILocalUpdater>>();
+
+            var engine = new LocalEngine(reader, finder, sorter, updater, logger);
+            Assert.That(engine, Is.Not.Null);
+            return engine;
+        }
+    }
+}

--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -21,8 +21,9 @@ namespace NuKeeper.Tests.Local
         [Test]
         public async Task CanRunInspect()
         {
+            var finder = Substitute.For<IUpdateFinder>();
             var updater = Substitute.For<ILocalUpdater>();
-            var engine = MakeLocalEngine(updater);
+            var engine = MakeLocalEngine(finder, updater);
 
             var settings = new SettingsContainer
             {
@@ -35,8 +36,12 @@ namespace NuKeeper.Tests.Local
 
             await engine.Run(settings);
 
-            await updater
-                .Received(0)
+            await finder.Received()
+                .FindPackageUpdateSets(Arg.Any<IFolder>(),
+                    Arg.Any<NuGetSources>(),
+                    Arg.Any<VersionChange>());
+
+            await updater.Received(0)
                 .ApplyUpdates(
                     Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
                     Arg.Any<NuGetSources>());
@@ -45,8 +50,9 @@ namespace NuKeeper.Tests.Local
         [Test]
         public async Task CanRunUpdate()
         {
+            var finder = Substitute.For<IUpdateFinder>();
             var updater = Substitute.For<ILocalUpdater>();
-            var engine = MakeLocalEngine(updater);
+            var engine = MakeLocalEngine(finder, updater);
 
             var settings = new SettingsContainer
             {
@@ -59,6 +65,11 @@ namespace NuKeeper.Tests.Local
 
             await engine.Run(settings);
 
+            await finder.Received()
+                .FindPackageUpdateSets(Arg.Any<IFolder>(),
+                    Arg.Any<NuGetSources>(),
+                    Arg.Any<VersionChange>());
+
             await updater
                 .Received(1)
                 .ApplyUpdates(
@@ -66,10 +77,9 @@ namespace NuKeeper.Tests.Local
                     Arg.Any<NuGetSources>());
         }
 
-        private static LocalEngine MakeLocalEngine(ILocalUpdater updater)
+        private static LocalEngine MakeLocalEngine(IUpdateFinder finder, ILocalUpdater updater)
         {
             var reader = Substitute.For<INuGetSourcesReader>();
-            var finder = Substitute.For<IUpdateFinder>();
             finder.FindPackageUpdateSets(
                     Arg.Any<IFolder>(), Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>())

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -1,7 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sources;
 using NuKeeper.Local;
@@ -27,6 +33,75 @@ namespace NuKeeper.Tests.Local
 
             await runner.Received(0)
                 .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());
+        }
+
+        [Test]
+        public async Task SingleItemCase()
+        {
+
+            var updates = new List<PackageUpdateSet>
+            {
+                MakePackageUpdateSet("foo")
+            };
+
+            var selection = Substitute.For<IUpdateSelection>();
+            FilterIsPassThrough(selection);
+
+
+            var runner = Substitute.For<IUpdateRunner>();
+            var logger = Substitute.For<INuKeeperLogger>();
+
+            var updater = new LocalUpdater(selection, runner, logger);
+
+            await updater.ApplyUpdates(updates, NuGetSources.GlobalFeed);
+
+            await runner.Received(1)
+                .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());
+        }
+
+        [Test]
+        public async Task TwoItemsCase()
+        {
+
+            var updates = new List<PackageUpdateSet>
+            {
+                MakePackageUpdateSet("foo"),
+                MakePackageUpdateSet("bar")
+            };
+
+            var selection = Substitute.For<IUpdateSelection>();
+            FilterIsPassThrough(selection);
+
+
+            var runner = Substitute.For<IUpdateRunner>();
+            var logger = Substitute.For<INuKeeperLogger>();
+
+            var updater = new LocalUpdater(selection, runner, logger);
+
+            await updater.ApplyUpdates(updates, NuGetSources.GlobalFeed);
+
+            await runner.Received(2)
+                .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());
+        }
+
+
+        private static void FilterIsPassThrough(IUpdateSelection selection)
+        {
+            selection
+                .Filter(Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(), Arg.Any<Func<PackageUpdateSet, Task<bool>>>())
+                .Returns(x => x.ArgAt<IReadOnlyCollection<PackageUpdateSet>>(0));
+        }
+
+        private static PackageUpdateSet MakePackageUpdateSet(string packageName)
+        {
+            var fooPackage = new PackageIdentity(packageName, new NuGetVersion("1.2.3"));
+            var latest = new PackageSearchMedatadata(fooPackage, new PackageSource("http://none"), null,
+                Enumerable.Empty<PackageDependency>());
+            var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
+
+            var pip = new PackageInProject(fooPackage, new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile));
+
+            return new PackageUpdateSet(packages, new List<PackageInProject> {pip});
         }
     }
 }

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Inspection.Logging;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sources;
+using NuKeeper.Local;
+using NuKeeper.Update;
+using NuKeeper.Update.Selection;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Local
+{
+    [TestFixture]
+    public class LocalUpdaterTests
+    {
+        [Test]
+        public async Task EmptyListCase()
+        {
+            var selection = Substitute.For<IUpdateSelection>();
+            var runner = Substitute.For<IUpdateRunner>();
+            var logger = Substitute.For<INuKeeperLogger>();
+
+            var updater = new LocalUpdater(selection, runner, logger);
+
+            await updater.ApplyUpdates(new List<PackageUpdateSet>(), NuGetSources.GlobalFeed);
+
+            await runner.Received(0)
+                .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());
+        }
+    }
+}

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -72,7 +72,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxUpdates = 10,
+                MaxPackageUpdates = 10,
                 Includes = new Regex("bar")
             };
 
@@ -95,7 +95,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxUpdates = 10,
+                MaxPackageUpdates = 10,
                 Excludes = new Regex("bar")
             };
 
@@ -119,7 +119,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings 
             {
-                MaxUpdates = 10,
+                MaxPackageUpdates = 10,
                 Excludes = new Regex("bar"),
                 Includes = new Regex("foo")
             };
@@ -301,7 +301,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxUpdates = maxPullRequests,
+                MaxPackageUpdates = maxPullRequests,
                 MinimumAge = TimeSpan.Zero
             };
             return new UpdateSelection(settings, Substitute.For<INuKeeperLogger>());
@@ -313,7 +313,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxUpdates = maxPullRequests,
+                MaxPackageUpdates = maxPullRequests,
                 MinimumAge = minAge
             };
             return new UpdateSelection(settings, Substitute.For<INuKeeperLogger>());

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -72,7 +72,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxPullRequests = 10,
+                MaxUpdates = 10,
                 Includes = new Regex("bar")
             };
 
@@ -95,7 +95,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxPullRequests = 10,
+                MaxUpdates = 10,
                 Excludes = new Regex("bar")
             };
 
@@ -119,7 +119,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings 
             {
-                MaxPullRequests = 10,
+                MaxUpdates = 10,
                 Excludes = new Regex("bar"),
                 Includes = new Regex("foo")
             };
@@ -301,7 +301,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxPullRequests = maxPullRequests,
+                MaxUpdates = maxPullRequests,
                 MinimumAge = TimeSpan.Zero
             };
             return new UpdateSelection(settings, Substitute.For<INuKeeperLogger>());
@@ -313,7 +313,7 @@ namespace NuKeeper.Update.Tests
 
             var settings = new FilterSettings
             {
-                MaxPullRequests = maxPullRequests,
+                MaxUpdates = maxPullRequests,
                 MinimumAge = minAge
             };
             return new UpdateSelection(settings, Substitute.For<INuKeeperLogger>());

--- a/NuKeeper.Update/Selection/FilterSettings.cs
+++ b/NuKeeper.Update/Selection/FilterSettings.cs
@@ -6,7 +6,7 @@ namespace NuKeeper.Update.Selection
     public class FilterSettings
     {
         public TimeSpan MinimumAge { get; set; }
-        public int MaxUpdates { get; set; }
+        public int MaxPackageUpdates { get; set; }
         public Regex Excludes { get; set; }
         public Regex Includes { get; set; }
     }

--- a/NuKeeper.Update/Selection/FilterSettings.cs
+++ b/NuKeeper.Update/Selection/FilterSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 
 namespace NuKeeper.Update.Selection
@@ -6,7 +6,7 @@ namespace NuKeeper.Update.Selection
     public class FilterSettings
     {
         public TimeSpan MinimumAge { get; set; }
-        public int MaxPullRequests { get; set; }
+        public int MaxUpdates { get; set; }
         public Regex Excludes { get; set; }
         public Regex Includes { get; set; }
     }

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.Update.Selection
             var filtered = await ApplyFilters(candidates, remoteCheck);
 
             var capped = filtered
-                .Take(_settings.MaxUpdates)
+                .Take(_settings.MaxPackageUpdates)
                 .ToList();
 
             LogPackageCounts(candidates.Count, filtered.Count, capped.Count);

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.Update.Selection
             var filtered = await ApplyFilters(candidates, remoteCheck);
 
             var capped = filtered
-                .Take(_settings.MaxPullRequests)
+                .Take(_settings.MaxUpdates)
                 .ToList();
 
             LogPackageCounts(candidates.Count, filtered.Count, capped.Count);

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -84,7 +84,7 @@ namespace NuKeeper.Commands
             settings.GithubAuthSettings = new GithubAuthSettings(githubUrl, token);
 
             settings.UserSettings.MaxRepositoriesChanged = AllowedMaxRepositoriesChangedChange;
-            settings.UserSettings.MaxPullRequestsPerRepository = MaxPullRequestsPerRepository;
+            settings.UserSettings.MaxPackageUpdates = MaxPullRequestsPerRepository;
             settings.UserSettings.ForkMode = ForkMode;
             settings.UserSettings.ReportMode = ReportMode;
 

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -6,14 +6,13 @@ using NuKeeper.Local;
 
 namespace NuKeeper.Commands
 {
-    [Command(Description = "Applies first relevant update to a local project.")]
+    [Command(Description = "Applies relevant updates to a local project.")]
     internal class UpdateCommand : LocalNuKeeperCommand
     {
-        [Option(CommandOptionType.SingleValue, ShortName = "m", LongName = "max-updates",
-            Description =
-                "Maximum number of package updates to make. Defaults to 1.")]
-        protected int MaxPackageUpdates { get; } = 1
-            ;
+        [Option(CommandOptionType.SingleValue, ShortName = "m", LongName = "maxupdates",
+            Description = "Maximum number of package updates to make. Defaults to 1.")]
+        protected int MaxPackageUpdates { get; } = 1;
+
         private readonly LocalEngine _engine;
 
         public UpdateCommand(LocalEngine engine, IConfigureLogLevel logger)

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -9,10 +9,10 @@ namespace NuKeeper.Commands
     [Command(Description = "Applies first relevant update to a local project.")]
     internal class UpdateCommand : LocalNuKeeperCommand
     {
-        [Option(CommandOptionType.SingleValue, LongName = "changes",
+        [Option(CommandOptionType.SingleValue, ShortName = "m", LongName = "max-updates",
             Description =
-                "Maximum number of changes to make. Defaults to 1.")]
-        protected int Changes { get; } = 1
+                "Maximum number of package updates to make. Defaults to 1.")]
+        protected int MaxPackageUpdates { get; } = 1
             ;
         private readonly LocalEngine _engine;
 
@@ -31,7 +31,7 @@ namespace NuKeeper.Commands
             }
 
             settings.ModalSettings.Mode = RunMode.Update;
-            settings.UserSettings.MaxPackageUpdates = Changes;
+            settings.UserSettings.MaxPackageUpdates = MaxPackageUpdates;
 
             return ValidationResult.Success;
         }

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
@@ -10,6 +9,11 @@ namespace NuKeeper.Commands
     [Command(Description = "Applies first relevant update to a local project.")]
     internal class UpdateCommand : LocalNuKeeperCommand
     {
+        [Option(CommandOptionType.SingleValue, LongName = "changes",
+            Description =
+                "Maximum number of changes to make. Defaults to 1.")]
+        protected int Changes { get; } = 1
+            ;
         private readonly LocalEngine _engine;
 
         public UpdateCommand(LocalEngine engine, IConfigureLogLevel logger)
@@ -27,7 +31,7 @@ namespace NuKeeper.Commands
             }
 
             settings.ModalSettings.Mode = RunMode.Update;
-            settings.UserSettings.MaxPullRequestsPerRepository = 1;
+            settings.UserSettings.MaxPullRequestsPerRepository = Changes;
 
             return ValidationResult.Success;
         }

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -31,7 +31,7 @@ namespace NuKeeper.Commands
             }
 
             settings.ModalSettings.Mode = RunMode.Update;
-            settings.UserSettings.MaxPullRequestsPerRepository = Changes;
+            settings.UserSettings.MaxPackageUpdates = Changes;
 
             return ValidationResult.Success;
         }

--- a/NuKeeper/Configuration/UserSettings.cs
+++ b/NuKeeper/Configuration/UserSettings.cs
@@ -14,7 +14,7 @@ namespace NuKeeper.Configuration
 
         public Regex PackageExcludes { get; set; }
 
-        public int MaxPullRequestsPerRepository { get; set; }
+        public int MaxPackageUpdates { get; set; }
 
         public int MaxRepositoriesChanged { get; set; }
 

--- a/NuKeeper/Creators/UpdateSelectionCreator.cs
+++ b/NuKeeper/Creators/UpdateSelectionCreator.cs
@@ -24,7 +24,7 @@ namespace NuKeeper.Creators
             {
                 Excludes = settings.PackageExcludes,
                 Includes = settings.PackageIncludes,
-                MaxUpdates = settings.MaxPullRequestsPerRepository,
+                MaxPackageUpdates = settings.MaxPackageUpdates,
                 MinimumAge = settings.MinimumPackageAge
             };
         }

--- a/NuKeeper/Creators/UpdateSelectionCreator.cs
+++ b/NuKeeper/Creators/UpdateSelectionCreator.cs
@@ -24,7 +24,7 @@ namespace NuKeeper.Creators
             {
                 Excludes = settings.PackageExcludes,
                 Includes = settings.PackageIncludes,
-                MaxPullRequests = settings.MaxPullRequestsPerRepository,
+                MaxUpdates = settings.MaxPullRequestsPerRepository,
                 MinimumAge = settings.MinimumPackageAge
             };
         }

--- a/NuKeeper/Local/ILocalUpdater.cs
+++ b/NuKeeper/Local/ILocalUpdater.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Local
 {
     public interface ILocalUpdater
     {
-        Task ApplyAnUpdate(
+        Task ApplyUpdates(
             IReadOnlyCollection<PackageUpdateSet> updates,
             NuGetSources sources);
     }

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.Local
                     break;
 
                 case RunMode.Update:
-                    await updater.ApplyAnUpdate(sortedUpdates, sources);
+                    await updater.ApplyUpdates(sortedUpdates, sources);
                     break;
             }
         }

--- a/NuKeeper/Local/LocalUpdater.cs
+++ b/NuKeeper/Local/LocalUpdater.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Local
             _logger = logger;
         }
 
-        public async Task ApplyAnUpdate(
+        public async Task ApplyUpdates(
             IReadOnlyCollection<PackageUpdateSet> updates,
             NuGetSources sources)
         {
@@ -44,12 +44,13 @@ namespace NuKeeper.Local
                 return;
             }
 
-            var candidate = filtered.First();
+            foreach (var update in filtered)
+            {
+                var reporter = new ConsoleReporter();
+                _logger.Minimal("Updating " + reporter.Describe(update));
 
-            var reporter = new ConsoleReporter();
-            _logger.Minimal("Updating " + reporter.Describe(candidate));
-
-            await _updateRunner.Update(candidate, sources);
+                await _updateRunner.Update(update, sources);
+            }
         }
     }
 }


### PR DESCRIPTION
Allow local `update` command to update multiple packages. #368
Rename `MaxPullRequests` to `MaxPackageUpdates` in `FilterSettings` and elsewhere 
as in local mode there aren't pull requests at all