### PR TITLE
Stop using RunMode for Github commands

### DIFF
--- a/NuKeeper.Tests/Engine/GitHubEngineTests.cs
+++ b/NuKeeper.Tests/Engine/GitHubEngineTests.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Tests.Engine
             var engine = MakeGithubEngine(
                 new List<RepositorySettings>());
 
-            var count = await engine.Run(MakeSettings());
+            var count = await engine.Run(GithubScope.Repository, MakeSettings());
 
             Assert.That(count, Is.EqualTo(0));
         }
@@ -35,7 +35,7 @@ namespace NuKeeper.Tests.Engine
             };
             var engine = MakeGithubEngine(oneRepo);
 
-            var count = await engine.Run(MakeSettings());
+            var count = await engine.Run(GithubScope.Repository, MakeSettings());
 
             Assert.That(count, Is.EqualTo(1));
         }
@@ -50,7 +50,7 @@ namespace NuKeeper.Tests.Engine
             };
             var engine = MakeGithubEngine(repos);
 
-            var count = await engine.Run(MakeSettings());
+            var count = await engine.Run(GithubScope.Repository, MakeSettings());
 
             Assert.That(count, Is.EqualTo(2));
         }
@@ -65,7 +65,7 @@ namespace NuKeeper.Tests.Engine
             };
             var engine = MakeGithubEngine(2, repos);
 
-            var count = await engine.Run(MakeSettings());
+            var count = await engine.Run(GithubScope.Repository, MakeSettings());
 
             Assert.That(count, Is.EqualTo(2));
         }
@@ -82,7 +82,7 @@ namespace NuKeeper.Tests.Engine
             };
             var engine = MakeGithubEngine(0, repos);
 
-            var count = await engine.Run(MakeSettings());
+            var count = await engine.Run(GithubScope.Repository, MakeSettings());
 
             Assert.That(count, Is.EqualTo(0));
         }
@@ -99,7 +99,7 @@ namespace NuKeeper.Tests.Engine
 
             var engine = MakeGithubEngine(1, repos);
 
-            var count = await engine.Run(new SettingsContainer
+            var count = await engine.Run(GithubScope.Repository, new SettingsContainer
             {
                 GithubAuthSettings = MakeGitHubAuthSettings(),
                 UserSettings = new UserSettings
@@ -134,7 +134,7 @@ namespace NuKeeper.Tests.Engine
 
             githubCreator.Create(null).ReturnsForAnyArgs(github);
 
-            repoDiscovery.GetRepositories()
+            repoDiscovery.GetRepositories(Arg.Any<GithubScope>())
                 .Returns(repos);
 
             repositoryDiscoveryCreator.Create(null).ReturnsForAnyArgs(repoDiscovery);

--- a/NuKeeper.Tests/Engine/GitHubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GitHubRepositoryDiscoveryTests.cs
@@ -20,13 +20,12 @@ namespace NuKeeper.Tests.Engine
             var github = Substitute.For<IGitHub>();
             var settings = new ModalSettings
             {
-                Mode = RunMode.Repository,
                 Repository = new RepositorySettings()
             };
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, settings);
 
-            var reposResponse = await githubRepositoryDiscovery.GetRepositories();
+            var reposResponse = await githubRepositoryDiscovery.GetRepositories(GithubScope.Repository);
 
             var repos = reposResponse.ToList();
 
@@ -42,7 +41,7 @@ namespace NuKeeper.Tests.Engine
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, OrgModeSettings());
 
-            var repos = await githubRepositoryDiscovery.GetRepositories();
+            var repos = await githubRepositoryDiscovery.GetRepositories(GithubScope.Organisation);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Empty);
@@ -63,7 +62,7 @@ namespace NuKeeper.Tests.Engine
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, OrgModeSettings());
 
-            var repos = await githubRepositoryDiscovery.GetRepositories();
+            var repos = await githubRepositoryDiscovery.GetRepositories(GithubScope.Organisation);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -90,7 +89,7 @@ namespace NuKeeper.Tests.Engine
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(github, OrgModeSettings());
 
-            var repos = await githubRepositoryDiscovery.GetRepositories();
+            var repos = await githubRepositoryDiscovery.GetRepositories(GithubScope.Organisation);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -110,7 +109,6 @@ namespace NuKeeper.Tests.Engine
         {
             return new ModalSettings
             {
-                Mode = RunMode.Organisation,
                 OrganisationName = "testOrg"
             };
         }

--- a/NuKeeper/Commands/GlobalCommand.cs
+++ b/NuKeeper/Commands/GlobalCommand.cs
@@ -24,8 +24,6 @@ namespace NuKeeper.Commands
                 return baseResult;
             }
 
-            settings.ModalSettings.Mode = RunMode.Global;
-
             if (settings.UserSettings.PackageIncludes == null)
             {
                 return ValidationResult.Failure("Global mode must have an include regex");
@@ -42,7 +40,7 @@ namespace NuKeeper.Commands
 
         protected override async Task<int> Run(SettingsContainer settings)
         {
-            await _engine.Run(settings);
+            await _engine.Run(GithubScope.Global, settings);
             return 0;
         }
 

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -29,14 +29,13 @@ namespace NuKeeper.Commands
                 return baseResult;
             }
 
-            settings.ModalSettings.Mode = RunMode.Organisation;
             settings.ModalSettings.OrganisationName = GithubOrganisationName;
             return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)
         {
-            await _engine.Run(settings);
+            await _engine.Run(GithubScope.Organisation, settings);
             return 0;
         }
     }

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -36,7 +36,6 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Bad GitHub repository URI: '{GitHubRepositoryUri}'");
             }
 
-            settings.ModalSettings.Mode = RunMode.Repository;
             settings.ModalSettings.Repository = GitSettingsReader.ReadRepositorySettings(repoUri);
 
             if (settings.ModalSettings.Repository == null)
@@ -49,7 +48,7 @@ namespace NuKeeper.Commands
 
         protected override async Task<int> Run(SettingsContainer settings)
         {
-            await _engine.Run(settings);
+            await _engine.Run(GithubScope.Repository, settings);
             return 0;
         }
     }

--- a/NuKeeper/Configuration/GithubAuthSettings.cs
+++ b/NuKeeper/Configuration/GithubAuthSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NuKeeper.Configuration
 {

--- a/NuKeeper/Configuration/GithubScope.cs
+++ b/NuKeeper/Configuration/GithubScope.cs
@@ -1,0 +1,9 @@
+namespace NuKeeper.Configuration
+{
+    public enum GithubScope
+    {
+        Repository,
+        Organisation,
+        Global,
+    }
+}

--- a/NuKeeper/Configuration/RunMode.cs
+++ b/NuKeeper/Configuration/RunMode.cs
@@ -2,9 +2,6 @@ namespace NuKeeper.Configuration
 {
     public enum RunMode
     {
-        Repository,
-        Organisation,
-        Global,
         Inspect,
         Update
     }

--- a/NuKeeper/Engine/GitHubEngine.cs
+++ b/NuKeeper/Engine/GitHubEngine.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Engine
             _logger = logger;
         }
 
-        public async Task<int> Run(SettingsContainer settings)
+        public async Task<int> Run(GithubScope scope, SettingsContainer settings)
         {
             var github = _githubCreator.Create(settings);
             var repositoryDiscovery = _repositoryDiscoveryCreator.Create(settings);
@@ -52,7 +52,7 @@ namespace NuKeeper.Engine
 
             var userIdentity = GetUserIdentity(githubUser);
 
-            var repositories = await repositoryDiscovery.GetRepositories();
+            var repositories = await repositoryDiscovery.GetRepositories(scope);
 
             var reposUpdated = 0;
 

--- a/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
@@ -24,17 +24,17 @@ namespace NuKeeper.Engine
             _logger = logger;
         }
 
-        public async Task<IEnumerable<RepositorySettings>> GetRepositories()
+        public async Task<IEnumerable<RepositorySettings>> GetRepositories(GithubScope scope)
         {
-            switch (_settings.Mode)
+            switch (scope)
             {
-                case RunMode.Global:
+                case GithubScope.Global:
                     return await ForAllOrgs();
 
-                case RunMode.Organisation:
+                case GithubScope.Organisation:
                     return await FromOrganisation(_settings.OrganisationName);
 
-                case RunMode.Repository:
+                case GithubScope.Repository:
                     return new[] { _settings.Repository };
 
                 default:

--- a/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
@@ -38,6 +38,7 @@ namespace NuKeeper.Engine
                     return new[] { _settings.Repository };
 
                 default:
+                    _logger.Error($"Unknown GithubScope {scope}");
                     return Enumerable.Empty<RepositorySettings>();
             }
         }

--- a/NuKeeper/Engine/IGitHubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/IGitHubRepositoryDiscovery.cs
@@ -6,6 +6,6 @@ namespace NuKeeper.Engine
 {
     public interface IGitHubRepositoryDiscovery
     {
-        Task<IEnumerable<RepositorySettings>> GetRepositories();
+        Task<IEnumerable<RepositorySettings>> GetRepositories(GithubScope scope);
     }
 }


### PR DESCRIPTION
The `RunMode` enumeration is obsolete, it is a catalogue of "run modes" which have been replaced with commands.

Extract a `GithubScope` enum for handing one of the remaining functions of runmode, selecting source repository(s) for remote operations.

Will remove the remaining use in determining if a local operation is read-only or not in another PR. It would conflict with existing PR #389  in that area.