### PR TITLE
Remove the RunMode enum

### DIFF
--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -27,14 +27,10 @@ namespace NuKeeper.Tests.Local
 
             var settings = new SettingsContainer
             {
-                ModalSettings = new ModalSettings
-                {
-                    Mode = RunMode.Inspect
-                },
                 UserSettings = new UserSettings()
             };
 
-            await engine.Run(settings);
+            await engine.Run(settings, false);
 
             await finder.Received()
                 .FindPackageUpdateSets(Arg.Any<IFolder>(),
@@ -56,14 +52,10 @@ namespace NuKeeper.Tests.Local
 
             var settings = new SettingsContainer
             {
-                ModalSettings = new ModalSettings
-                {
-                    Mode = RunMode.Update
-                },
                 UserSettings = new UserSettings()
             };
 
-            await engine.Run(settings);
+            await engine.Run(settings, true);
 
             await finder.Received()
                 .FindPackageUpdateSets(Arg.Any<IFolder>(),

--- a/NuKeeper/Commands/InspectCommand.cs
+++ b/NuKeeper/Commands/InspectCommand.cs
@@ -25,13 +25,12 @@ namespace NuKeeper.Commands
                 return baseResult;
             }
 
-            settings.ModalSettings.Mode = RunMode.Inspect;
             return ValidationResult.Success;
         }
 
         protected override async Task<int> Run(SettingsContainer settings)
         {
-            await _engine.Run(settings);
+            await _engine.Run(settings, false);
             return 0;
         }
     }

--- a/NuKeeper/Commands/UpdateCommand.cs
+++ b/NuKeeper/Commands/UpdateCommand.cs
@@ -29,7 +29,6 @@ namespace NuKeeper.Commands
                 return baseResult;
             }
 
-            settings.ModalSettings.Mode = RunMode.Update;
             settings.UserSettings.MaxPackageUpdates = MaxPackageUpdates;
 
             return ValidationResult.Success;
@@ -37,7 +36,7 @@ namespace NuKeeper.Commands
 
         protected override async Task<int> Run(SettingsContainer settings)
         {
-            await _engine.Run(settings);
+            await _engine.Run(settings, true);
             return 0;
         }
     }

--- a/NuKeeper/Configuration/ModalSettings.cs
+++ b/NuKeeper/Configuration/ModalSettings.cs
@@ -2,7 +2,6 @@ namespace NuKeeper.Configuration
 {
     public class ModalSettings
     {
-        public RunMode Mode { get; set;  }
         public string OrganisationName { get; set; }
         public RepositorySettings Repository { get; set; }
         public string[] Labels { get; set; }

--- a/NuKeeper/Configuration/RunMode.cs
+++ b/NuKeeper/Configuration/RunMode.cs
@@ -1,8 +1,0 @@
-namespace NuKeeper.Configuration
-{
-    public enum RunMode
-    {
-        Inspect,
-        Update
-    }
-}

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.Local
             _logger = logger;
         }
 
-        public async Task Run(SettingsContainer settings)
+        public async Task Run(SettingsContainer settings, bool write)
         {
             var updater = _updaterCreator.Create(settings);
             var folder = TargetFolder(settings.UserSettings);
@@ -46,15 +46,13 @@ namespace NuKeeper.Local
 
             var sortedUpdates = await GetSortedUpdates(folder, sources, settings.UserSettings.AllowedChange);
 
-            switch (settings.ModalSettings.Mode)
+            if (write)
             {
-                case RunMode.Inspect:
-                    Report(sortedUpdates);
-                    break;
-
-                case RunMode.Update:
-                    await updater.ApplyUpdates(sortedUpdates, sources);
-                    break;
+                await updater.ApplyUpdates(sortedUpdates, sources);
+            }
+            else
+            {
+                Report(sortedUpdates);
             }
         }
 


### PR DESCRIPTION
Remove the `RunMode` enum
it's only used in `localEngine` and has 2 options remaining (inspect, update) now so it can be a bool write flag.