### PR TITLE
ProjectFileReader can read package refs

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackageAssert.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackageAssert.cs
@@ -13,6 +13,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
 
             Assert.That(package.Id, Is.Not.Empty);
             Assert.That(package.Version.ToString(), Is.Not.Empty);
+            Assert.That(package.ProjectReferences, Is.Not.Null);
         }
     }
 }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -169,7 +169,8 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             var package = packages.FirstOrDefault();
 
             Assert.That(package.ProjectReferences.Count, Is.EqualTo(1));
-            Assert.That(package.ProjectReferences.First(), Is.EqualTo("c:\\temp\\somewhere\\src\\other.csproj"));
+
+            StringAssert.EndsWith("other.csproj", package.ProjectReferences.First());
         }
 
         [Test]

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -151,7 +151,25 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             var package = packages.FirstOrDefault();
 
             PackageAssert.IsPopulated(package);
-            Assert.That(packages.First().IsPrerelease, Is.False);
+            Assert.That(package.IsPrerelease, Is.False);
+            Assert.That(package.ProjectReferences, Is.Not.Null);
+            Assert.That(package.ProjectReferences.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ProjectReferencesIsPopulated()
+        {
+            const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
+
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package.ProjectReferences.Count, Is.EqualTo(1));
+            Assert.That(package.ProjectReferences.First(), Is.EqualTo("c:\\temp\\somewhere\\src\\other.csproj"));
         }
 
         [Test]
@@ -304,7 +322,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             Assert.That(packages.First().IsPrerelease, Is.True);
         }
 
-                [Test]
+        [Test]
         public void PackageWithMetadataShouldBeRead()
         {
             const string noVersion =
@@ -337,8 +355,6 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             Assert.That(packages.Count, Is.EqualTo(1));
             PackageAssert.IsPopulated(packages[0]);
         }
-
-
 
         private ProjectFileReader MakeReader()
         {

--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
@@ -5,14 +7,17 @@ namespace NuKeeper.Inspection.RepositoryInspection
 {
     public class PackageInProject
     {
-        public PackageInProject(PackageIdentity identity, PackagePath path)
+        public PackageInProject(PackageIdentity identity,
+            PackagePath path,
+            IEnumerable<string> projectReferences)
         {
             Identity = identity;
             Path = path;
+            ProjectReferences = projectReferences?.ToList() ?? new List<string>();
         }
 
         public PackageInProject(string id, string version, PackagePath path) :
-            this(new PackageIdentity(id, new NuGetVersion(version)), path)
+            this(new PackageIdentity(id, new NuGetVersion(version)), path, null)
         {
         }
 
@@ -23,5 +28,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
         public NuGetVersion Version => Identity.Version;
 
         public bool IsPrerelease => Identity.Version.IsPrerelease;
+
+        public IReadOnlyCollection<string> ProjectReferences { get; }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/PackagePath.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackagePath.cs
@@ -50,5 +50,10 @@ namespace NuKeeper.Inspection.RepositoryInspection
         /// directory and file name
         /// </summary>
         public string FullName => Info.FullName;
+
+        public override string ToString()
+        {
+            return $"{PackageReferenceType} {RelativePath} in {BaseDirectory}";
+        }
     }
 }

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -237,10 +237,11 @@ namespace NuKeeper.Tests.Engine
 
         private static PackageUpdateSet UpdateSet()
         {
-            PackageIdentity fooPackage = new PackageIdentity("foo", new NuGetVersion(1,2,3));
+            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1,2,3));
+            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig);
             var packages = new[]
             {
-                new PackageInProject(fooPackage, new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig))
+                new PackageInProject(fooPackage, path, null)
             };
 
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -104,7 +104,8 @@ namespace NuKeeper.Tests.Local
                 Enumerable.Empty<PackageDependency>());
             var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
 
-            var pip = new PackageInProject(fooPackage, new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile));
+            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile);
+            var pip = new PackageInProject(fooPackage, path, null);
 
             return new PackageUpdateSet(packages, new List<PackageInProject> {pip});
         }


### PR DESCRIPTION
`ProjectFileReader` can read package refs and put them on the `PackageInProject` data.

Work towards a fix for #325 
This will only benefit new-style projects with `PackageReference` in the project file.