### PR TITLE
Local update should also have. sln restore

### DIFF
--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -1,7 +1,13 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
@@ -17,9 +23,33 @@ namespace NuKeeper.Tests.Engine
             var cmd = Substitute.For<IFileRestoreCommand>();
             var folder = Substitute.For<IFolder>();
 
-            var solutionResture = new SolutionsRestore(cmd);
+            var packages = new List<PackageUpdateSet>();
 
-            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
+            var solutionRestore = new SolutionsRestore(cmd);
+
+            await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
+
+            await cmd.DidNotReceiveWithAnyArgs()
+                .Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
+        }
+
+        [Test]
+        public async Task WhenThereAreNoMatchingPackagesTheCommandIsNotCalled()
+        {
+            var packages = new List<PackageUpdateSet>()
+            {
+                UpdateSet(PackageReferenceType.ProjectFile),
+            };
+
+            var sln = new FileInfo("foo.sln");
+
+            var cmd = Substitute.For<IFileRestoreCommand>();
+            var folder = Substitute.For<IFolder>();
+            folder.Find(Arg.Any<string>()).Returns(new[] { sln });
+
+            var solutionRestore = new SolutionsRestore(cmd);
+
+            await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
             await cmd.DidNotReceiveWithAnyArgs()
                 .Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
@@ -28,15 +58,20 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereIsOneSolutionsTheCommandIsCalled()
         {
+            var packages = new List<PackageUpdateSet>
+            {
+                UpdateSet(PackageReferenceType.PackagesConfig)
+            };
+
             var sln = new FileInfo("foo.sln");
 
             var cmd = Substitute.For<IFileRestoreCommand>();
             var folder = Substitute.For<IFolder>();
             folder.Find(Arg.Any<string>()).Returns(new[] { sln });
 
-            var solutionResture = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionsRestore(cmd);
 
-            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
+            await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
             await cmd.Received(1).Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
             await cmd.Received().Invoke(sln, Arg.Any<NuGetSources>());
@@ -45,6 +80,11 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreTwoSolutionsTheCommandIsCalledForEachOfThem()
         {
+            var packages = new List<PackageUpdateSet>
+            {
+                UpdateSet(PackageReferenceType.PackagesConfig)
+            };
+
             var sln1 = new FileInfo("foo.sln");
             var sln2 = new FileInfo("bar.sln");
 
@@ -52,13 +92,29 @@ namespace NuKeeper.Tests.Engine
             var folder = Substitute.For<IFolder>();
             folder.Find(Arg.Any<string>()).Returns(new[] { sln1, sln2 });
 
-            var solutionResture = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionsRestore(cmd);
 
-            await solutionResture.Restore(folder, NuGetSources.GlobalFeed);
+            await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
             await cmd.Received(2).Invoke(Arg.Any<FileInfo>(), Arg.Any<NuGetSources>());
             await cmd.Received().Invoke(sln1, Arg.Any<NuGetSources>());
             await cmd.Received().Invoke(sln2, Arg.Any<NuGetSources>());
         }
+
+        private static PackageUpdateSet UpdateSet(PackageReferenceType refType)
+        {
+            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
+            var path = new PackagePath("c:\\foo", "bar", refType);
+            var packages = new[]
+            {
+                new PackageInProject(fooPackage, path, null)
+            };
+
+            var latest = new PackageSearchMedatadata(fooPackage, new PackageSource(NuGetConstants.V3FeedUrl), null, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
     }
 }

--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -39,6 +39,7 @@ namespace NuKeeper.Tests.Local
             await updater.Received(0)
                 .ApplyUpdates(
                     Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<SettingsContainer>());
         }
@@ -66,6 +67,7 @@ namespace NuKeeper.Tests.Local
                 .Received(1)
                 .ApplyUpdates(
                     Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<SettingsContainer>());
         }

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -7,12 +7,14 @@ using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Configuration;
+using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sources;
 using NuKeeper.Local;
 using NuKeeper.Update;
+using NuKeeper.Update.Process;
 using NuKeeper.Update.Selection;
 using NUnit.Framework;
 
@@ -27,10 +29,13 @@ namespace NuKeeper.Tests.Local
             var selection = Substitute.For<IUpdateSelection>();
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
+            var folder = Substitute.For<IFolder>();
+            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
 
-            var updater = new LocalUpdater(selection, runner, logger);
+            var updater = new LocalUpdater(selection, runner, restorer, logger);
 
             await updater.ApplyUpdates(new List<PackageUpdateSet>(),
+                folder,
                 NuGetSources.GlobalFeed, Settings());
 
             await runner.Received(0)
@@ -52,10 +57,12 @@ namespace NuKeeper.Tests.Local
 
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
+            var folder = Substitute.For<IFolder>();
+            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
 
-            var updater = new LocalUpdater(selection, runner, logger);
+            var updater = new LocalUpdater(selection, runner, restorer, logger);
 
-            await updater.ApplyUpdates(updates, NuGetSources.GlobalFeed, Settings());
+            await updater.ApplyUpdates(updates, folder, NuGetSources.GlobalFeed, Settings());
 
             await runner.Received(1)
                 .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());
@@ -74,13 +81,14 @@ namespace NuKeeper.Tests.Local
             var selection = Substitute.For<IUpdateSelection>();
             FilterIsPassThrough(selection);
 
-
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
+            var folder = Substitute.For<IFolder>();
+            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
 
-            var updater = new LocalUpdater(selection, runner, logger);
+            var updater = new LocalUpdater(selection, runner, restorer, logger);
 
-            await updater.ApplyUpdates(updates, NuGetSources.GlobalFeed, Settings());
+            await updater.ApplyUpdates(updates, folder, NuGetSources.GlobalFeed, Settings());
 
             await runner.Received(2)
                 .Update(Arg.Any<PackageUpdateSet>(), Arg.Any<NuGetSources>());

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -98,10 +98,7 @@ namespace NuKeeper.Engine
                 return 0;
             }
 
-            if (AnyProjectRequiresNuGetRestore(targetUpdates))
-            {
-                await _solutionsRestore.Restore(git.WorkingFolder, sources);
-            }
+            await _solutionsRestore.CheckRestore(targetUpdates, git.WorkingFolder, sources);
 
             var updatesDone = await UpdateAllTargets(git, repository, targetUpdates, sources);
 
@@ -115,12 +112,6 @@ namespace NuKeeper.Engine
             }
 
             return updatesDone;
-        }
-
-        private static bool AnyProjectRequiresNuGetRestore(IEnumerable<PackageUpdateSet> targetUpdates)
-        {
-            return targetUpdates.SelectMany(u => u.CurrentPackages)
-                .Any(p => p.Path.PackageReferenceType != PackageReferenceType.ProjectFile);
         }
 
         private static void GitInit(IGitDriver git, RepositoryData repository)

--- a/NuKeeper/Local/ILocalUpdater.cs
+++ b/NuKeeper/Local/ILocalUpdater.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
+using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sources;
 
@@ -10,6 +11,7 @@ namespace NuKeeper.Local
     {
         Task ApplyUpdates(
             IReadOnlyCollection<PackageUpdateSet> updates,
+            IFolder workingFolder,
             NuGetSources sources,
             SettingsContainer settings);
     }

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -46,7 +46,7 @@ namespace NuKeeper.Local
 
             if (write)
             {
-                await _updater.ApplyUpdates(sortedUpdates, sources, settings);
+                await _updater.ApplyUpdates(sortedUpdates, folder, sources, settings);
             }
             else
             {


### PR DESCRIPTION
Local update command should also have a `.sln` restore applied when appropriate.

Moved the check for this into `SolutionsRestore` when both code paths can call it, and it's now under test.