### PR TITLE
Added repository filter to global and org commands

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -14,7 +14,7 @@ using NuKeeper.Update.ProcessRunner;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    [Category("WindowsOnly")]
+    [Category("WindowsOnly")] // Windows only due to NuGetUpdatePackageCommand
     public class NuGetUpdatePackageCommandTests
     {
         private readonly string _testDotNetClassicProject =
@@ -48,7 +48,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             Directory.CreateDirectory(workDirectory);
             var packagesFolder = Path.Combine(workDirectory, "packages");
             Directory.CreateDirectory(packagesFolder);
-            
+
             var projectContents = _testDotNetClassicProject.Replace("{packageVersion}", oldPackageVersion);
             var projectPath = Path.Combine(workDirectory, testProject);
             await File.WriteAllTextAsync(projectPath, projectContents);

--- a/NuKeeper.Tests/Engine/RepositoryBuilder.cs
+++ b/NuKeeper.Tests/Engine/RepositoryBuilder.cs
@@ -18,9 +18,10 @@ namespace NuKeeper.Tests.Engine
         }
 
         public static Repository MakeRepository(
-            string forkHtmlUrl = ForkHtmlUrl, 
-            string forkCloneUrl = ForkCloneUrl, 
-            bool canPull = true, bool canPush = true)
+            string forkHtmlUrl = ForkHtmlUrl,
+            string forkCloneUrl = ForkCloneUrl,
+            bool canPull = true, bool canPush = true,
+            string name = "repoName")
         {
             const string omniUrl = "http://somewhere.com/fork";
             var owner = MakeUser(omniUrl);
@@ -31,7 +32,7 @@ namespace NuKeeper.Tests.Engine
             return new Repository(omniUrl, forkHtmlUrl, forkCloneUrl,
                 omniUrl, omniUrl, omniUrl, omniUrl,
                 123, "nodeId",
-                owner, "repoName", "repoName", "a test repo", "homepage",
+                owner, name, name, "a test repo", "homepage",
                 "EN", false, true,
                 1, 1, "master",
                 1, null, DateTimeOffset.Now, DateTimeOffset.Now,

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
+using NuKeeper.Engine;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Report;
 
@@ -8,6 +10,8 @@ namespace NuKeeper.Commands
 {
     internal abstract class GitHubNuKeeperCommand : CommandBase
     {
+        private readonly GitHubEngine _engine;
+
         [Argument(1, Name = "Token",
             Description =
                 "GitHub personal access token to authorise access to GitHub server.")]
@@ -49,8 +53,9 @@ namespace NuKeeper.Commands
                 "Controls if a CSV report file of possible updates is generated. Allowed values are Off, On, ReportOnly (which skips applying updates). Defaults to Off.")]
         protected ReportMode ReportMode { get; } = ReportMode.Off;
 
-        protected GitHubNuKeeperCommand(IConfigureLogLevel logger) : base(logger)
+        protected GitHubNuKeeperCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(logger)
         {
+            _engine = engine;
         }
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
@@ -91,6 +96,12 @@ namespace NuKeeper.Commands
             settings.SourceControlServerSettings.Labels = Label;
 
             return ValidationResult.Success;
+        }
+
+        protected override async Task<int> Run(SettingsContainer settings)
+        {
+            await _engine.Run(settings);
+            return 0;
         }
 
         private string ReadToken()

--- a/NuKeeper/Commands/GlobalCommand.cs
+++ b/NuKeeper/Commands/GlobalCommand.cs
@@ -7,13 +7,10 @@ using NuKeeper.Inspection.Logging;
 namespace NuKeeper.Commands
 {
     [Command(Description = "Performs version checks and generates pull requests for all repositories the provided token can access.")]
-    internal class GlobalCommand : GitHubNuKeeperCommand
+    internal class GlobalCommand : MultipleRepositoryCommand
     {
-        private readonly GitHubEngine _engine;
-
-        public GlobalCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(logger)
+        public GlobalCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(engine, logger)
         {
-            _engine = engine;
         }
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
@@ -39,12 +36,5 @@ namespace NuKeeper.Commands
 
             return ValidationResult.Success;
         }
-
-        protected override async Task<int> Run(SettingsContainer settings)
-        {
-            await _engine.Run(settings);
-            return 0;
-        }
-
     }
 }

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using McMaster.Extensions.CommandLineUtils;
+using NuKeeper.Configuration;
+using NuKeeper.Engine;
+using NuKeeper.Inspection.Logging;
+
+namespace NuKeeper.Commands
+{
+    internal abstract class MultipleRepositoryCommand : GitHubNuKeeperCommand
+    {
+        [Option(CommandOptionType.SingleValue, ShortName = "ir", LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
+        // ReSharper disable once UnassignedGetOnlyAutoProperty
+        // ReSharper disable once MemberCanBePrivate.Global
+        protected string IncludeRepos { get; }
+
+        [Option(CommandOptionType.SingleValue, ShortName = "er", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once UnassignedGetOnlyAutoProperty
+        protected string ExcludeRepos { get; }
+
+        protected MultipleRepositoryCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(engine, logger)
+        {
+        }
+
+        protected override ValidationResult PopulateSettings(SettingsContainer settings)
+        {
+            var baseResult = base.PopulateSettings(settings);
+            if (!baseResult.IsSuccess)
+            {
+                return baseResult;
+            }
+
+            var regexIncludeReposValid = PopulateIncludeRepos(settings, IncludeRepos);
+            if (!regexIncludeReposValid.IsSuccess)
+            {
+                return regexIncludeReposValid;
+            }
+
+            var regexExcludeReposValid = PopulateExcludeRepos(settings, ExcludeRepos);
+            if (!regexExcludeReposValid.IsSuccess)
+            {
+                return regexExcludeReposValid;
+            }
+
+            return ValidationResult.Success;
+        }
+
+        private static ValidationResult PopulateIncludeRepos(SettingsContainer settings, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                settings.SourceControlServerSettings.IncludeRepos = null;
+                return ValidationResult.Success;
+            }
+
+            try
+            {
+                settings.SourceControlServerSettings.IncludeRepos = new Regex(value);
+            }
+            catch (Exception ex)
+            {
+                return ValidationResult.Failure($"Unable to parse regex '{value}' for IncludeRepos: {ex.Message}");
+            }
+
+            return ValidationResult.Success;
+        }
+
+        private static ValidationResult PopulateExcludeRepos(SettingsContainer settings, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                settings.SourceControlServerSettings.ExcludeRepos = null;
+                return ValidationResult.Success;
+            }
+
+            try
+            {
+                settings.SourceControlServerSettings.ExcludeRepos = new Regex(value);
+            }
+            catch (Exception ex)
+            {
+                return ValidationResult.Failure($"Unable to parse regex '{value}' for ExcludeRepos: {ex.Message}");
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -7,18 +7,15 @@ using NuKeeper.Inspection.Logging;
 namespace NuKeeper.Commands
 {
     [Command(Description = "Performs version checks and generates pull requests for all repositories in a github organisation.")]
-    internal class OrganisationCommand : GitHubNuKeeperCommand
+    internal class OrganisationCommand : MultipleRepositoryCommand
     {
-        private readonly GitHubEngine _engine;
-
         [Argument(0, Name = "GitHub organisation name", Description = "The organisation to scan.")]
         // ReSharper disable once UnassignedGetOnlyAutoProperty
         // ReSharper disable once MemberCanBePrivate.Global
         protected string GithubOrganisationName { get; }
 
-        public OrganisationCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(logger)
+        public OrganisationCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(engine, logger)
         {
-            _engine = engine;
         }
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
@@ -32,12 +29,6 @@ namespace NuKeeper.Commands
             settings.SourceControlServerSettings.Scope = ServerScope.Organisation;
             settings.SourceControlServerSettings.OrganisationName = GithubOrganisationName;
             return ValidationResult.Success;
-        }
-
-        protected override async Task<int> Run(SettingsContainer settings)
-        {
-            await _engine.Run(settings);
-            return 0;
         }
     }
 }

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -10,16 +10,13 @@ namespace NuKeeper.Commands
     [Command(Description = "Performs version checks and generates pull requests for a single repository on GitHub.")]
     internal class RepositoryCommand : GitHubNuKeeperCommand
     {
-        private readonly GitHubEngine _engine;
-
         [Argument(0, Name = "GitHub repository URI", Description = "The URI of the repository to scan.")]
         // ReSharper disable once UnassignedGetOnlyAutoProperty
         // ReSharper disable once MemberCanBePrivate.Global
         protected string GitHubRepositoryUri { get; }
 
-        public RepositoryCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(logger)
+        public RepositoryCommand(GitHubEngine engine, IConfigureLogLevel logger) : base(engine, logger)
         {
-            _engine = engine;
         }
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
@@ -45,12 +42,6 @@ namespace NuKeeper.Commands
 
             settings.SourceControlServerSettings.Scope = ServerScope.Repository;
             return ValidationResult.Success;
-        }
-
-        protected override async Task<int> Run(SettingsContainer settings)
-        {
-            await _engine.Run(settings);
-            return 0;
         }
     }
 }

--- a/NuKeeper/Configuration/SourceControlServerSettings.cs
+++ b/NuKeeper/Configuration/SourceControlServerSettings.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace NuKeeper.Configuration
 {
     public class SourceControlServerSettings
@@ -6,5 +8,7 @@ namespace NuKeeper.Configuration
         public string OrganisationName { get; set; }
         public RepositorySettings Repository { get; set; }
         public string[] Labels { get; set; }
+        public Regex IncludeRepos { get; set; }
+        public Regex ExcludeRepos { get; set; }
     }
 }


### PR DESCRIPTION
We would like to add the ability to filter repos by regexes. We have added the --includerepos and --excluderepos arguments to the global and org commands.

We would appreciate your feedback.