### PR TITLE
Maxrepo setting is in the File

### DIFF
--- a/NuKeeper.Tests/Commands/GlobalCommandTests.cs
+++ b/NuKeeper.Tests/Commands/GlobalCommandTests.cs
@@ -66,6 +66,9 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings.GithubAuthSettings, Is.Not.Null);
             Assert.That(settings.GithubAuthSettings.Token, Is.EqualTo("testToken"));
 
+            Assert.That(settings.GithubAuthSettings.ApiBase, Is.Not.Null);
+            Assert.That(settings.GithubAuthSettings.ApiBase.ToString(), Is.EqualTo("http://github.contoso.com/api/"));
+
             Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
             Assert.That(settings.SourceControlServerSettings.Repository, Is.Null);
             Assert.That(settings.SourceControlServerSettings.OrganisationName, Is.Null);
@@ -79,12 +82,12 @@ namespace NuKeeper.Tests.Commands
             var settings = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.UserSettings, Is.Not.Null);
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(10));
+
             Assert.That(settings.PackageFilters, Is.Not.Null);
             Assert.That(settings.PackageFilters.Includes, Is.Not.Null);
             Assert.That(settings.PackageFilters.Includes.ToString(), Is.EqualTo("testRepos"));
-            Assert.That(settings.GithubAuthSettings.Token, Is.EqualTo("testToken"));
-            Assert.That(settings.GithubAuthSettings.ApiBase, Is.Not.Null);
-            Assert.That(settings.GithubAuthSettings.ApiBase.ToString(), Is.EqualTo("http://github.contoso.com/api/"));
         }
 
         [Test]
@@ -176,6 +179,21 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.PackageFilters, Is.Not.Null);
             Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(42));
+        }
+
+        [Test]
+        public async Task WillReadMaxRepoFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                MaxRepo = 42
+            };
+
+            var settings = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(42));
         }
 
         public async Task<SettingsContainer> CaptureSettings(FileSettings settingsIn)

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -92,6 +92,7 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.NuGetSources, Is.Null);
             Assert.That(settings.UserSettings.ReportMode, Is.EqualTo(ReportMode.Off));
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
 
             Assert.That(settings.SourceControlServerSettings.IncludeRepos, Is.Null);
             Assert.That(settings.SourceControlServerSettings.ExcludeRepos, Is.Null);
@@ -146,6 +147,21 @@ namespace NuKeeper.Tests.Commands
         }
 
         [Test]
+        public async Task WillNotReadMaxRepoFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                MaxRepo = 42
+            };
+
+            var settings = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
+        }
+
+        [Test]
         public async Task MaxPrFromCommandLineOverridesFiles()
         {
             var fileSettings = new FileSettings
@@ -159,7 +175,6 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings.PackageFilters, Is.Not.Null);
             Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(101));
         }
-
 
         [Test]
         public async Task LabelsOnCommandLineWillReplaceFileLabels()

--- a/NuKeeper.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Tests/Configuration/FileSettingsReaderTests.cs
@@ -26,6 +26,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
             Assert.That(data.MaxPr, Is.Null);
+            Assert.That(data.MaxRepo, Is.Null);
         }
 
         [Test]
@@ -44,6 +45,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
             Assert.That(data.MaxPr, Is.Null);
+            Assert.That(data.MaxRepo, Is.Null);
         }
 
         [Test]
@@ -57,7 +59,8 @@ namespace NuKeeper.Tests.Configuration
                ""includeRepos"":""repoIn"",
                ""excludeRepos"":""repoOut"",
                ""label"": [ ""foo"", ""bar"" ],
-               ""maxpr"": 42
+               ""maxpr"": 42,
+               ""maxRepo"": 12,
 }";
 
             var path = MakeTestFile(configData);
@@ -79,6 +82,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.Label, Does.Contain("bar"));
 
             Assert.That(data.MaxPr, Is.EqualTo(42));
+            Assert.That(data.MaxRepo, Is.EqualTo(12));
         }
 
         [Test]
@@ -90,7 +94,9 @@ namespace NuKeeper.Tests.Configuration
                ""iNClude"":""fred"",
                ""excludE"":""fish"",
                ""IncluDeRepoS"":""repo2"",
-               ""label"": [""mark"" ]
+               ""label"": [""mark"" ],
+               ""MAXrepo"":3,
+
 }";
 
             var path = MakeTestFile(configData);
@@ -107,6 +113,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.IncludeRepos, Is.EqualTo("repo2"));
             Assert.That(data.Label.Length, Is.EqualTo(1));
             Assert.That(data.Label, Does.Contain("mark"));
+            Assert.That(data.MaxRepo, Is.EqualTo(3));
         }
 
         [Test]

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
@@ -17,11 +16,6 @@ namespace NuKeeper.Commands
             Description =
                 "GitHub personal access token to authorise access to GitHub server.")]
         public string GitHubToken { get; set; }
-
-        [Option(CommandOptionType.SingleValue, ShortName = "x", LongName = "maxrepo",
-            Description = "The maximum number of repositories to change. Defaults to 10.")]
-        // ReSharper disable once MemberCanBePrivate.Global
-        protected int AllowedMaxRepositoriesChangedChange { get; } = 10;
 
         [Option(CommandOptionType.SingleValue, ShortName = "f", LongName = "fork",
             Description =
@@ -86,11 +80,9 @@ namespace NuKeeper.Commands
 
             var fileSettings = FileSettingsCache.Get();
 
-            const int DefaultMaxPr = 3;
-
-            settings.UserSettings.MaxRepositoriesChanged = AllowedMaxRepositoriesChangedChange;
+            const int defaultMaxPullRequests = 3;
             settings.PackageFilters.MaxPackageUpdates =
-                Concat.FirstValue(MaxPullRequestsPerRepository, fileSettings.MaxPr, DefaultMaxPr);
+                Concat.FirstValue(MaxPullRequestsPerRepository, fileSettings.MaxPr, defaultMaxPullRequests);
 
             settings.UserSettings.ForkMode = ForkMode;
             settings.UserSettings.ReportMode = ReportMode;

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -15,6 +15,11 @@ namespace NuKeeper.Commands
         [Option(CommandOptionType.SingleValue, ShortName = "er", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
         public string ExcludeRepos { get; set; }
 
+        [Option(CommandOptionType.SingleValue, ShortName = "x", LongName = "maxrepo",
+            Description = "The maximum number of repositories to change. Defaults to 10.")]
+        public int? AllowedMaxRepositoriesChangedChange { get; set; }
+
+
         protected MultipleRepositoryCommand(IGitHubEngine engine, IConfigureLogLevel logger, IFileSettingsCache fileSettingsCache)
             : base(engine, logger, fileSettingsCache)
         {
@@ -39,6 +44,12 @@ namespace NuKeeper.Commands
             {
                 return regexExcludeReposValid;
             }
+
+            var fileSettings = FileSettingsCache.Get();
+
+            const int defaultMaxReposChanged = 10;
+            settings.UserSettings.MaxRepositoriesChanged = Concat.FirstValue(
+                AllowedMaxRepositoriesChangedChange, fileSettings.MaxRepo, defaultMaxReposChanged);
 
             return ValidationResult.Success;
         }

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -38,6 +38,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Could not read GitHub repository URI: '{GitHubRepositoryUri}'");
             }
 
+            settings.UserSettings.MaxRepositoriesChanged = 1;
             settings.SourceControlServerSettings.Scope = ServerScope.Repository;
             return ValidationResult.Success;
         }

--- a/NuKeeper/Configuration/FileSettings.cs
+++ b/NuKeeper/Configuration/FileSettings.cs
@@ -13,6 +13,7 @@ namespace NuKeeper.Configuration
         public string[] Label { get; set; }
 
         public int? MaxPr { get; set; }
+        public int? MaxRepo { get; set; }
 
         public static FileSettings Empty()
         {


### PR DESCRIPTION
`MaxRepo` setting is read from the file.
It only makes sense to have it an an option on `MultipleRepositoryCommand` subclasses, now that this is a thing. On the (single) repository command, it is equal to 1.

And `crfl` all the line endings.