### PR TITLE
IsPackable is not needed

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <RootNamespace>NuKeeper</RootNamespace>
     <AssemblyName>NuKeeper</AssemblyName>


### PR DESCRIPTION
"IsPackable: A Boolean value that specifies whether the project can be packed. The default value is true."
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj