### PR TITLE
PackageUpdates as test data factory

### DIFF
--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -33,6 +33,7 @@ namespace NuKeeper.Tests
         [TestCase(typeof(UpdateCommand))]
         [TestCase(typeof(RepositoryCommand))]
         [TestCase(typeof(OrganisationCommand))]
+        [TestCase(typeof(GlobalCommand))]
         public void CommandsCanBeResolved(Type commandType)
         {
             var container = ContainerRegistration.Init();

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Engine;
-using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
 
@@ -219,7 +218,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasVersionLimitData()
         {
-            var updates = UpdateSetForLimited(MakePackageForV110())
+            var updates = PackageUpdates.LimitedToMinor(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -232,7 +231,7 @@ namespace NuKeeper.Tests.Engine
         {
             var publishedAt = new DateTimeOffset(2018, 2, 20, 11, 32 ,45, TimeSpan.Zero);
 
-            var updates = UpdateSetForLimited(publishedAt, MakePackageForV110())
+            var updates = PackageUpdates.LimitedToMinor(publishedAt, MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -244,7 +243,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMajorVersionChange()
         {
-            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(new PackageIdentity("foo.bar", new NuGetVersion("2.1.1")), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -255,7 +254,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMinorVersionChange()
         {
-            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("1.2.1"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(new PackageIdentity("foo.bar", new NuGetVersion("1.2.1")), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -266,7 +265,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithPatchVersionChange()
         {
-            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("1.1.9"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(new PackageIdentity("foo.bar", new NuGetVersion("1.1.9")), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -293,7 +292,7 @@ namespace NuKeeper.Tests.Engine
 
             var updates = new List<PackageUpdateSet>
             {
-                PackageUpdates.ForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110()),
+                PackageUpdates.ForNewVersion(new PackageIdentity("foo.bar", new NuGetVersion("2.1.1")), MakePackageForV110()),
                 PackageUpdates.ForNewVersion(packageTwo, MakePackageForV110("packageTwo"))
             };
 
@@ -318,33 +317,6 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Not.Contain("[ "));
             Assert.That(report, Does.Not.Contain(" ]"));
             Assert.That(report, Does.Not.Contain("There is also a higher version"));
-        }
-
-        private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
-        {
-            return UpdateSetForLimited(null, packages);
-        }
-
-        private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
-        {
-            var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, PackageUpdates.OfficialPackageSource(), publishedAt, null);
-
-            var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), PackageUpdates.OfficialPackageSource(), null, null);
-
-            var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
-        private static PackageIdentity NewPackageFooBar123()
-        {
-            return NewPackageFooBar("1.2.3");
-        }
-
-        private static PackageIdentity NewPackageFooBar(string version)
-        {
-            return new PackageIdentity("foo.bar", new NuGetVersion(version));
         }
 
         private static PackageInProject MakePackageForV110(string packageName = "foo.bar")

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Engine;

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MarkPullRequestTitle_UpdateIsCorrect()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakePullRequestTitle(updates);
@@ -29,7 +29,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_OneUpdateIsCorrect()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110());
+            var updates = PackageUpdates.For(MakePackageForV110());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -41,7 +41,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_TwoUpdatesIsCorrect()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -53,7 +53,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_TwoUpdatesSameVersionIsCorrect()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -66,7 +66,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_IsNotEmpty()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -78,7 +78,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -89,7 +89,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -100,7 +100,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasPublishedDate()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -112,7 +112,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasProjectDetails()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+            var updates = PackageUpdates.For(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -124,7 +124,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_NotEmpty()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -136,7 +136,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -148,7 +148,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -160,7 +160,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasProjectList()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -173,7 +173,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_NotEmpty()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -185,7 +185,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -196,7 +196,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -207,7 +207,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasProjectList()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+            var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -245,7 +245,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMajorVersionChange()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -256,7 +256,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMinorVersionChange()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("1.2.1"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("1.2.1"), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -267,7 +267,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithPatchVersionChange()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("1.1.9"), MakePackageForV110())
+            var updates = PackageUpdates.ForNewVersion(NewPackageFooBar("1.1.9"), MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -278,7 +278,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithInternalPackageSource()
         {
-            var updates = PackageUpdateSetBuilder.UpdateSetForInternalSource(MakePackageForV110())
+            var updates = PackageUpdates.ForInternalSource(MakePackageForV110())
                 .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -294,8 +294,8 @@ namespace NuKeeper.Tests.Engine
 
             var updates = new List<PackageUpdateSet>
             {
-                PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110()),
-                PackageUpdateSetBuilder.UpdateSetForNewVersion(packageTwo, MakePackageForV110("packageTwo"))
+                PackageUpdates.ForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110()),
+                PackageUpdates.ForNewVersion(packageTwo, MakePackageForV110("packageTwo"))
             };
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -329,10 +329,10 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, PackageUpdateSetBuilder.OfficialPackageSource(), publishedAt, null);
+            var latest = new PackageSearchMedatadata(latestId, PackageUpdates.OfficialPackageSource(), publishedAt, null);
 
             var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), PackageUpdateSetBuilder.OfficialPackageSource(), null, null);
+                NewPackageFooBar123(), PackageUpdates.OfficialPackageSource(), null, null);
 
             var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -16,7 +16,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MarkPullRequestTitle_UpdateIsCorrect()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakePullRequestTitle(updates);
 
@@ -28,7 +29,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_OneUpdateIsCorrect()
         {
-            var updates = UpdateSetFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -40,7 +41,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_TwoUpdatesIsCorrect()
         {
-            var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -52,7 +53,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void MakeCommitMessage_TwoUpdatesSameVersionIsCorrect()
         {
-            var updates = UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3());
 
             var report = CommitWording.MakeCommitMessage(updates);
 
@@ -65,7 +66,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_IsNotEmpty()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -76,7 +78,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -86,7 +89,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -96,7 +100,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasPublishedDate()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -107,7 +112,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasProjectDetails()
         {
-            var updates = UpdateSetsFor(MakePackageForV110());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -118,7 +124,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_NotEmpty()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -129,7 +136,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -140,7 +148,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -151,7 +160,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdates_MakeCommitDetails_HasProjectList()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV100());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV100())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -163,7 +173,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_NotEmpty()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -174,7 +185,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasStandardTexts()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -184,7 +196,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasVersionInfo()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -194,7 +207,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void TwoUpdatesSameVersion_MakeCommitDetails_HasProjectList()
         {
-            var updates = UpdateSetsFor(MakePackageForV110(), MakePackageForV110InProject3());
+            var updates = PackageUpdateSetBuilder.UpdateSetFor(MakePackageForV110(), MakePackageForV110InProject3())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -206,10 +220,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdate_MakeCommitDetails_HasVersionLimitData()
         {
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForLimited(MakePackageForV110())
-            };
+            var updates = UpdateSetForLimited(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -221,10 +233,8 @@ namespace NuKeeper.Tests.Engine
         {
             var publishedAt = new DateTimeOffset(2018, 2, 20, 11, 32 ,45, TimeSpan.Zero);
 
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForLimited(publishedAt, MakePackageForV110())
-            };
+            var updates = UpdateSetForLimited(publishedAt, MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -235,10 +245,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMajorVersionChange()
         {
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110())
-            };
+            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -248,10 +256,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithMinorVersionChange()
         {
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForNewVersion(NewPackageFooBar("1.2.1"), MakePackageForV110())
-            };
+            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("1.2.1"), MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -261,10 +267,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithPatchVersionChange()
         {
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForNewVersion(NewPackageFooBar("1.1.9"), MakePackageForV110())
-            };
+            var updates = PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("1.1.9"), MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -274,10 +278,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public void OneUpdateWithInternalPackageSource()
         {
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSetForInternalSource(MakePackageForV110())
-            };
+            var updates = PackageUpdateSetBuilder.UpdateSetForInternalSource(MakePackageForV110())
+                .InList();
 
             var report = CommitWording.MakeCommitDetails(updates);
 
@@ -292,8 +294,8 @@ namespace NuKeeper.Tests.Engine
 
             var updates = new List<PackageUpdateSet>
             {
-                UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110()),
-                UpdateSetForNewVersion(packageTwo, MakePackageForV110("packageTwo"))
+                PackageUpdateSetBuilder.UpdateSetForNewVersion(NewPackageFooBar("2.1.1"), MakePackageForV110()),
+                PackageUpdateSetBuilder.UpdateSetForNewVersion(packageTwo, MakePackageForV110("packageTwo"))
             };
 
             var report = CommitWording.MakeCommitDetails(updates);
@@ -319,39 +321,6 @@ namespace NuKeeper.Tests.Engine
             Assert.That(report, Does.Not.Contain("There is also a higher version"));
         }
 
-        private static List<PackageUpdateSet> UpdateSetsFor(params PackageInProject[] packages)
-        {
-            return  new List<PackageUpdateSet>
-            {
-                UpdateSetFor(packages)
-            };
-        }
-
-        private static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
-        {
-            var newPackage = NewPackageFooBar123();
-            return UpdateSetForNewVersion(newPackage, packages);
-        }
-
-        private static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
-        {
-            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, OfficialPackageSource(), publishedDate, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
-        private static PackageUpdateSet UpdateSetForInternalSource(params PackageInProject[] packages)
-        {
-            var newPackage = NewPackageFooBar123();
-            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(newPackage, new PackageSource("http://internalfeed.myco.com/api"), publishedDate, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
         private static PackageUpdateSet UpdateSetForLimited(params PackageInProject[] packages)
         {
             return UpdateSetForLimited(null, packages);
@@ -360,10 +329,10 @@ namespace NuKeeper.Tests.Engine
         private static PackageUpdateSet UpdateSetForLimited(DateTimeOffset? publishedAt, params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
-            var latest = new PackageSearchMedatadata(latestId, OfficialPackageSource(), publishedAt, null);
+            var latest = new PackageSearchMedatadata(latestId, PackageUpdateSetBuilder.OfficialPackageSource(), publishedAt, null);
 
             var match = new PackageSearchMedatadata(
-                NewPackageFooBar123(), OfficialPackageSource(), null, null);
+                NewPackageFooBar123(), PackageUpdateSetBuilder.OfficialPackageSource(), null, null);
 
             var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
             return new PackageUpdateSet(updates, packages);
@@ -377,11 +346,6 @@ namespace NuKeeper.Tests.Engine
         private static PackageIdentity NewPackageFooBar(string version)
         {
             return new PackageIdentity("foo.bar", new NuGetVersion(version));
-        }
-
-        private static PackageSource OfficialPackageSource()
-        {
-            return new PackageSource(NuGetConstants.V3FeedUrl);
         }
 
         private static PackageInProject MakePackageForV110(string packageName = "foo.bar")

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Engine;
@@ -36,10 +35,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereIsOneInput_ItIsTheTarget()
         {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion()
-            };
+            var updateSets = UpdateFooFromOneVersion()
+                .InList();
 
             var target = SelectionForFilter(BranchFilter(true));
 

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -116,7 +116,7 @@ namespace NuKeeper.Tests.Engine
 
             var matchVersion = new NuGetVersion("4.0.0");
             var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
-                new PackageSource("http://none"), pubDate, null);
+                PackageUpdates.OfficialPackageSource(), pubDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
             return new PackageUpdateSet(updates, currentPackages);
@@ -133,7 +133,7 @@ namespace NuKeeper.Tests.Engine
             };
 
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
-            var match = new PackageSearchMedatadata(matchId, new PackageSource("http://none"), pubDate, null);
+            var match = new PackageSearchMedatadata(matchId, PackageUpdates.OfficialPackageSource(), pubDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
             return new PackageUpdateSet(updates, currentPackages);

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.Tests.Engine
             var updateSelection = Substitute.For<IPackageUpdateSelection>();
             UpdateSelectionAll(updateSelection);
 
-            var updates = UpdateSet()
+            var updates = PackageUpdates.UpdateSet()
                 .InList();
 
             var (repoUpdater, packageUpdater) = MakeRepositoryUpdater(
@@ -84,7 +84,9 @@ namespace NuKeeper.Tests.Engine
                 Substitute.For<IUpdateRunner>(),
                 Substitute.For<INuKeeperLogger>());
 
-            var updates = Enumerable.Range(1, numberOfUpdates).Select(x => UpdateSet()).ToList();
+            var updates = Enumerable.Range(1, numberOfUpdates)
+                .Select(_ => PackageUpdates.UpdateSet())
+                .ToList();
 
             var settings = MakeSettings(ReportMode.Off, consolidateUpdates);
             
@@ -117,8 +119,8 @@ namespace NuKeeper.Tests.Engine
 
             var twoUpdates = new List<PackageUpdateSet>
             {
-                UpdateSet(),
-                UpdateSet()
+                PackageUpdates.UpdateSet(),
+                PackageUpdates.UpdateSet()
             };
 
             var (repoUpdater, packageUpdater) = MakeRepositoryUpdater(
@@ -142,8 +144,8 @@ namespace NuKeeper.Tests.Engine
 
             var twoUpdates = new List<PackageUpdateSet>
                 {
-                    UpdateSet(),
-                    UpdateSet()
+                    PackageUpdates.UpdateSet(),
+                    PackageUpdates.UpdateSet()
                 };
 
             var (repoUpdater, packageUpdater) = MakeRepositoryUpdater(
@@ -256,23 +258,6 @@ namespace NuKeeper.Tests.Engine
             return new RepositoryData(
                 new ForkData(new Uri("http://foo.com"), "me", "test"),
                 new ForkData(new Uri("http://foo.com"), "me", "test"));
-        }
-
-        private static PackageUpdateSet UpdateSet()
-        {
-            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1,2,3));
-            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig);
-            var packages = new[]
-            {
-                new PackageInProject(fooPackage, path, null)
-            };
-
-            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(fooPackage,
-                PackageUpdates.OfficialPackageSource(), publishedDate, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
         }
     }
 }

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -271,7 +271,8 @@ namespace NuKeeper.Tests.Engine
             };
 
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(fooPackage, new PackageSource("https://somewhere"), publishedDate, null);
+            var latest = new PackageSearchMedatadata(fooPackage,
+                PackageUpdates.OfficialPackageSource(), publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Configuration;
@@ -54,10 +53,8 @@ namespace NuKeeper.Tests.Engine
             var updateSelection = Substitute.For<IPackageUpdateSelection>();
             UpdateSelectionAll(updateSelection);
 
-            var updates = new List<PackageUpdateSet>
-            {
-                UpdateSet()
-            };
+            var updates = UpdateSet()
+                .InList();
 
             var (repoUpdater, packageUpdater) = MakeRepositoryUpdater(
                 updateSelection, updates);

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -2,11 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
-using NuGet.Configuration;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
 using NuKeeper.Inspection.Files;
-using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sources;
 using NuKeeper.Update.Process;
@@ -36,10 +32,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreNoMatchingPackagesTheCommandIsNotCalled()
         {
-            var packages = new List<PackageUpdateSet>()
-            {
-                UpdateSet(PackageReferenceType.ProjectFile),
-            };
+            var packages = PackageUpdates.ForRefType(PackageReferenceType.ProjectFile)
+                .InList();
 
             var sln = new FileInfo("foo.sln");
 
@@ -58,10 +52,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereIsOneSolutionsTheCommandIsCalled()
         {
-            var packages = new List<PackageUpdateSet>
-            {
-                UpdateSet(PackageReferenceType.PackagesConfig)
-            };
+            var packages = PackageUpdates.ForRefType(PackageReferenceType.PackagesConfig)
+                .InList();
 
             var sln = new FileInfo("foo.sln");
 
@@ -80,10 +72,8 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreTwoSolutionsTheCommandIsCalledForEachOfThem()
         {
-            var packages = new List<PackageUpdateSet>
-            {
-                UpdateSet(PackageReferenceType.PackagesConfig)
-            };
+            var packages = PackageUpdates.ForRefType(PackageReferenceType.PackagesConfig)
+                .InList();
 
             var sln1 = new FileInfo("foo.sln");
             var sln2 = new FileInfo("bar.sln");
@@ -100,21 +90,5 @@ namespace NuKeeper.Tests.Engine
             await cmd.Received().Invoke(sln1, Arg.Any<NuGetSources>());
             await cmd.Received().Invoke(sln2, Arg.Any<NuGetSources>());
         }
-
-        private static PackageUpdateSet UpdateSet(PackageReferenceType refType)
-        {
-            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
-            var path = new PackagePath("c:\\foo", "bar", refType);
-            var packages = new[]
-            {
-                new PackageInProject(fooPackage, path, null)
-            };
-
-            var latest = new PackageSearchMedatadata(fooPackage, new PackageSource(NuGetConstants.V3FeedUrl), null, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
     }
 }

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreNoMatchingPackagesTheCommandIsNotCalled()
         {
-            var packages = PackageUpdates.ForRefType(PackageReferenceType.ProjectFile)
+            var packages = PackageUpdates.ForPackageRefType(PackageReferenceType.ProjectFile)
                 .InList();
 
             var sln = new FileInfo("foo.sln");
@@ -52,7 +52,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereIsOneSolutionsTheCommandIsCalled()
         {
-            var packages = PackageUpdates.ForRefType(PackageReferenceType.PackagesConfig)
+            var packages = PackageUpdates.ForPackageRefType(PackageReferenceType.PackagesConfig)
                 .InList();
 
             var sln = new FileInfo("foo.sln");
@@ -72,7 +72,7 @@ namespace NuKeeper.Tests.Engine
         [Test]
         public async Task WhenThereAreTwoSolutionsTheCommandIsCalledForEachOfThem()
         {
-            var packages = PackageUpdates.ForRefType(PackageReferenceType.PackagesConfig)
+            var packages = PackageUpdates.ForPackageRefType(PackageReferenceType.PackagesConfig)
                 .InList();
 
             var sln1 = new FileInfo("foo.sln");

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortDependencyTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortDependencyTests.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NSubstitute;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Sort;
-using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
 
@@ -193,7 +191,7 @@ namespace NuKeeper.Tests.Engine.Sort
                 projects.Add(MakePackageInProjectFor(package));
             }
 
-            return UpdateSetFor(newPackage, projects, deps);
+            return PackageUpdates.For(newPackage, StandardPublishedDate, projects, deps);
         }
 
         private static PackageInProject MakePackageInProjectFor(PackageIdentity package)
@@ -203,21 +201,6 @@ namespace NuKeeper.Tests.Engine.Sort
                 Path.Combine("folder", "src", "project1", "packages.config"),
                 PackageReferenceType.PackagesConfig);
             return new PackageInProject(package.Id, package.Version.ToString(), path);
-        }
-
-        private static PackageUpdateSet UpdateSetFor(PackageIdentity package,
-            List<PackageInProject> packages, List<PackageDependency> deps)
-        {
-            return UpdateSetFor(package, StandardPublishedDate, packages, deps);
-        }
-
-        private static PackageUpdateSet UpdateSetFor(PackageIdentity package, DateTimeOffset published,
-            List<PackageInProject> packages, List<PackageDependency> deps)
-        {
-            var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), published, deps);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
         }
 
         private List<PackageUpdateSet> Sort(IReadOnlyCollection<PackageUpdateSet> input)

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
@@ -196,7 +196,7 @@ namespace NuKeeper.Tests.Engine.Sort
 
         private static PackageUpdateSet UpdateSetFor(PackageIdentity package, DateTimeOffset published, params PackageInProject[] packages)
         {
-            var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), published, null);
+            var latest = new PackageSearchMedatadata(package, PackageUpdates.OfficialPackageSource(), published, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NSubstitute;
-using NuGet.Configuration;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Sort;
-using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.Tests.Engine.Sort
@@ -32,10 +30,8 @@ namespace NuKeeper.Tests.Engine.Sort
         [Test]
         public void CanSortOneItem()
         {
-            var items = new List<PackageUpdateSet>
-            {
-                OnePackageUpdateSet(1)
-            };
+            var items = OnePackageUpdateSet(1)
+                .InList();
 
             var output = Sort(items);
 
@@ -189,19 +185,6 @@ namespace NuKeeper.Tests.Engine.Sort
             return packageUpdateSet.Selected.Identity.Version.ToString();
         }
 
-        private static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
-        {
-            return UpdateSetFor(package, StandardPublishedDate, packages);
-        }
-
-        private static PackageUpdateSet UpdateSetFor(PackageIdentity package, DateTimeOffset published, params PackageInProject[] packages)
-        {
-            var latest = new PackageSearchMedatadata(package, PackageUpdates.OfficialPackageSource(), published, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
         private static PackageInProject MakePackageInProjectFor(PackageIdentity package)
         {
             var path = new PackagePath(
@@ -222,7 +205,7 @@ namespace NuKeeper.Tests.Engine.Sort
                 projects.Add(MakePackageInProjectFor(package));
             }
 
-            return UpdateSetFor(newPackage, projects.ToArray());
+            return PackageUpdates.UpdateSetFor(newPackage, projects.ToArray());
         }
 
         private PackageUpdateSet MakeTwoProjectVersions()
@@ -237,7 +220,7 @@ namespace NuKeeper.Tests.Engine.Sort
                 MakePackageInProjectFor(package124),
             };
 
-            return UpdateSetFor(newPackage, projects.ToArray());
+            return PackageUpdates.UpdateSetFor(newPackage, projects.ToArray());
         }
 
         private static PackageUpdateSet PackageChange(string newVersion, string oldVersion, DateTimeOffset? publishedDate = null)
@@ -255,7 +238,7 @@ namespace NuKeeper.Tests.Engine.Sort
                 MakePackageInProjectFor(oldPackage)
             };
 
-            return UpdateSetFor(newPackage, publishedDate.Value, projects.ToArray());
+            return PackageUpdates.UpdateSetFor(newPackage, publishedDate.Value, projects.ToArray());
         }
 
         private List<PackageUpdateSet> Sort(IReadOnlyCollection<PackageUpdateSet> input)

--- a/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
+++ b/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
@@ -16,8 +16,8 @@ namespace NuKeeper.Tests.Engine
         {
             var items = new List<PackageUpdateSet>
             {
-                PackageUpdateSetBuilder.MakePackageUpdateSet("foo"),
-                PackageUpdateSetBuilder.MakePackageUpdateSet("bar")
+                PackageUpdates.MakeUpdateSet("foo"),
+                PackageUpdates.MakeUpdateSet("bar")
             };
 
             var output = UpdateConsolidator.Consolidate(items, true);
@@ -34,8 +34,8 @@ namespace NuKeeper.Tests.Engine
         {
             var items = new List<PackageUpdateSet>
             {
-                PackageUpdateSetBuilder.MakePackageUpdateSet("foo"),
-                PackageUpdateSetBuilder.MakePackageUpdateSet("bar")
+                PackageUpdates.MakeUpdateSet("foo"),
+                PackageUpdates.MakeUpdateSet("bar")
             };
 
             var output = UpdateConsolidator.Consolidate(items, false);

--- a/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
+++ b/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
@@ -11,6 +9,36 @@ namespace NuKeeper.Tests.Engine
     [TestFixture]
     public class UpdateConsolidatorTests
     {
+        [Test]
+        public void WhenOneItemIsConsolidated()
+        {
+            var items = PackageUpdates.MakeUpdateSet("foo")
+                .InList();
+
+            var output = UpdateConsolidator.Consolidate(items, true);
+
+            var listOfLists = output.ToList();
+
+            // one list, containing all the items
+            Assert.That(listOfLists.Count, Is.EqualTo(1));
+            Assert.That(listOfLists[0].Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WhenOneItemIsNotConsolidated()
+        {
+            var items = PackageUpdates.MakeUpdateSet("foo")
+                .InList();
+
+            var output = UpdateConsolidator.Consolidate(items, false);
+
+            var listOfLists = output.ToList();
+
+            // one list, containing all the items
+            Assert.That(listOfLists.Count, Is.EqualTo(1));
+            Assert.That(listOfLists[0].Count, Is.EqualTo(1));
+        }
+
         [Test]
         public void WhenItemsAreConsolidated()
         {

--- a/NuKeeper.Tests/Engine/VersionChangesTests.cs
+++ b/NuKeeper.Tests/Engine/VersionChangesTests.cs
@@ -204,7 +204,7 @@ namespace NuKeeper.Tests.Engine
         {
             var version = new NuGetVersion(major, minor, patch);
             var packageId = new PackageIdentity("foo", version);
-            return new PackageSearchMedatadata(packageId, new PackageSource("http://none"), DateTimeOffset.Now, null);
+            return new PackageSearchMedatadata(packageId, PackageUpdates.OfficialPackageSource(), DateTimeOffset.Now, null);
         }
     }
 }

--- a/NuKeeper.Tests/Engine/VersionChangesTests.cs
+++ b/NuKeeper.Tests/Engine/VersionChangesTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Inspection.NuGetApi;
@@ -31,10 +30,8 @@ namespace NuKeeper.Tests.Engine
         public void WhenThereIsANewMajorVersion()
         {
             var current = new NuGetVersion(1, 2, 3);
-            var candidates = new List<PackageSearchMedatadata>
-            {
-                MetadataForVersion(2, 3, 4)
-            };
+            var candidates = MetadataForVersion(2, 3, 4)
+                .InList();
 
             var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Major);
 

--- a/NuKeeper.Tests/ListHelper.cs
+++ b/NuKeeper.Tests/ListHelper.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace NuKeeper.Tests
+{
+    public static class ListHelper
+    {
+        public static List<T> InList<T>(this T item)
+        {
+            return new List<T>
+            {
+                item
+            };
+        }
+    }
+}

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -40,11 +40,8 @@ namespace NuKeeper.Tests.Local
         [Test]
         public async Task SingleItemCase()
         {
-
-            var updates = new List<PackageUpdateSet>
-            {
-                PackageUpdates.MakeUpdateSet("foo")
-            };
+            var updates = PackageUpdates.MakeUpdateSet("foo")
+                .InList();
 
             var selection = Substitute.For<IUpdateSelection>();
             FilterIsPassThrough(selection);

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -43,7 +43,7 @@ namespace NuKeeper.Tests.Local
 
             var updates = new List<PackageUpdateSet>
             {
-                PackageUpdateSetBuilder.MakePackageUpdateSet("foo")
+                PackageUpdates.MakeUpdateSet("foo")
             };
 
             var selection = Substitute.For<IUpdateSelection>();
@@ -69,8 +69,8 @@ namespace NuKeeper.Tests.Local
 
             var updates = new List<PackageUpdateSet>
             {
-                PackageUpdateSetBuilder.MakePackageUpdateSet("foo"),
-                PackageUpdateSetBuilder.MakePackageUpdateSet("bar")
+                PackageUpdates.MakeUpdateSet("foo"),
+                PackageUpdates.MakeUpdateSet("bar")
             };
 
             var selection = Substitute.For<IUpdateSelection>();

--- a/NuKeeper.Tests/PackageUpdateSetBuilder.cs
+++ b/NuKeeper.Tests/PackageUpdateSetBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
@@ -10,18 +11,64 @@ namespace NuKeeper.Tests
 {
     public static class PackageUpdateSetBuilder
     {
-        public static PackageUpdateSet MakePackageUpdateSet(string packageName)
+        public static List<T> InList<T>(this T item)
         {
-            var fooPackage = new PackageIdentity(packageName, new NuGetVersion("1.2.3"));
-            var latest = new PackageSearchMedatadata(fooPackage, new PackageSource("http://none"), null,
+            return new List<T>
+            {
+                item
+            };
+        }
+
+        public static PackageUpdateSet MakePackageUpdateSet(string packageName, string version = "1.2.3")
+        {
+            var packageId = new PackageIdentity(packageName, new NuGetVersion(version));
+            var latest = new PackageSearchMedatadata(
+                packageId, OfficialPackageSource(),
+                null,
                 Enumerable.Empty<PackageDependency>());
+
             var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
 
             var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile);
-            var pip = new PackageInProject(fooPackage, path, null);
+            var pip = new PackageInProject(packageId, path, null);
 
             return new PackageUpdateSet(packages, new List<PackageInProject> { pip });
         }
 
+        public static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
+        {
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            return UpdateSetForNewVersion(newPackage, packages);
+        }
+
+        public static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
+        {
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(newPackage, OfficialPackageSource(), publishedDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        public static PackageUpdateSet UpdateSetForInternalSource(params PackageInProject[] packages)
+        {
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(newPackage,
+                InternalPackageSource(), publishedDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        public static PackageSource OfficialPackageSource()
+        {
+            return new PackageSource(NuGetConstants.V3FeedUrl);
+        }
+
+        public static PackageSource InternalPackageSource()
+        {
+            return new PackageSource("http://internalfeed.myco.com/api");
+        }
     }
 }

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -15,49 +15,12 @@ namespace NuKeeper.Tests
 
         public static PackageUpdateSet UpdateSet()
         {
-            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
-            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig);
-            var packages = new[]
-            {
-                new PackageInProject(fooPackage, path, null)
-            };
-
-            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(fooPackage,
-                OfficialPackageSource(), publishedDate, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
+            return MakeUpdateSet("foo", "1.2.3", PackageReferenceType.PackagesConfig);
         }
 
-        public static PackageUpdateSet For(
-            PackageIdentity package,
-            DateTimeOffset published,
-            List<PackageInProject> packages,
-            List<PackageDependency> dependencies)
-        {
-            var latest = new PackageSearchMedatadata(package, OfficialPackageSource(), published, dependencies);
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
-        public static PackageUpdateSet ForRefType(PackageReferenceType refType)
-        {
-            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
-            var path = new PackagePath("c:\\foo", "bar", refType);
-            var packages = new[]
-            {
-                new PackageInProject(fooPackage, path, null)
-            };
-
-            var latest = new PackageSearchMedatadata(fooPackage, OfficialPackageSource(), null, null);
-
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
-            return new PackageUpdateSet(updates, packages);
-        }
-
-
-        public static PackageUpdateSet MakeUpdateSet(string packageName, string version = "1.2.3")
+        public static PackageUpdateSet MakeUpdateSet(string packageName,
+            string version = "1.2.3",
+            PackageReferenceType packageRefType = PackageReferenceType.ProjectFile)
         {
             var packageId = new PackageIdentity(packageName, new NuGetVersion(version));
             var latest = new PackageSearchMedatadata(
@@ -67,11 +30,29 @@ namespace NuKeeper.Tests
 
             var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
 
-            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile);
-            var pip = new PackageInProject(packageId, path, null);
+            var path = new PackagePath("c:\\foo", "bar", packageRefType);
+            var pip = new PackageInProject(packageId, path, null)
+                .InList();
 
-            return new PackageUpdateSet(packages, new List<PackageInProject> { pip });
+            return new PackageUpdateSet(packages, pip);
         }
+
+        public static PackageUpdateSet For(
+            PackageIdentity package,
+            DateTimeOffset published,
+            IEnumerable<PackageInProject> packages,
+            IEnumerable<PackageDependency> dependencies)
+        {
+            var latest = new PackageSearchMedatadata(package, OfficialPackageSource(), published, dependencies);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        public static PackageUpdateSet ForPackageRefType(PackageReferenceType refType)
+        {
+            return MakeUpdateSet("foo", "1.2.3", refType);
+        }
+
 
         public static PackageUpdateSet For(params PackageInProject[] packages)
         {

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -13,6 +13,23 @@ namespace NuKeeper.Tests
     {
         private static readonly DateTimeOffset StandardPublishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
 
+        public static PackageUpdateSet UpdateSet()
+        {
+            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
+            var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.PackagesConfig);
+            var packages = new[]
+            {
+                new PackageInProject(fooPackage, path, null)
+            };
+
+            var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+            var latest = new PackageSearchMedatadata(fooPackage,
+                OfficialPackageSource(), publishedDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
         public static PackageUpdateSet For(
             PackageIdentity package,
             DateTimeOffset published,

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -11,6 +11,8 @@ namespace NuKeeper.Tests
 {
     public static class PackageUpdates
     {
+        private static readonly DateTimeOffset StandardPublishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
+
         public static PackageUpdateSet For(
             PackageIdentity package,
             DateTimeOffset published,
@@ -75,6 +77,19 @@ namespace NuKeeper.Tests
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(newPackage,
                 InternalPackageSource(), publishedDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        public static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
+        {
+            return UpdateSetFor(package, StandardPublishedDate, packages);
+        }
+
+        public static PackageUpdateSet UpdateSetFor(PackageIdentity package, DateTimeOffset published, params PackageInProject[] packages)
+        {
+            var latest = new PackageSearchMedatadata(package, OfficialPackageSource(), published, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -9,17 +9,9 @@ using NuKeeper.Inspection.RepositoryInspection;
 
 namespace NuKeeper.Tests
 {
-    public static class PackageUpdateSetBuilder
+    public static class PackageUpdates
     {
-        public static List<T> InList<T>(this T item)
-        {
-            return new List<T>
-            {
-                item
-            };
-        }
-
-        public static PackageUpdateSet MakePackageUpdateSet(string packageName, string version = "1.2.3")
+        public static PackageUpdateSet MakeUpdateSet(string packageName, string version = "1.2.3")
         {
             var packageId = new PackageIdentity(packageName, new NuGetVersion(version));
             var latest = new PackageSearchMedatadata(
@@ -35,13 +27,13 @@ namespace NuKeeper.Tests
             return new PackageUpdateSet(packages, new List<PackageInProject> { pip });
         }
 
-        public static PackageUpdateSet UpdateSetFor(params PackageInProject[] packages)
+        public static PackageUpdateSet For(params PackageInProject[] packages)
         {
             var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
-            return UpdateSetForNewVersion(newPackage, packages);
+            return ForNewVersion(newPackage, packages);
         }
 
-        public static PackageUpdateSet UpdateSetForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
+        public static PackageUpdateSet ForNewVersion(PackageIdentity newPackage, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(newPackage, OfficialPackageSource(), publishedDate, null);
@@ -50,7 +42,7 @@ namespace NuKeeper.Tests
             return new PackageUpdateSet(updates, packages);
         }
 
-        public static PackageUpdateSet UpdateSetForInternalSource(params PackageInProject[] packages)
+        public static PackageUpdateSet ForInternalSource(params PackageInProject[] packages)
         {
             var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -30,8 +30,7 @@ namespace NuKeeper.Tests
 
             var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
 
-            var path = new PackagePath("c:\\foo", "bar", packageRefType);
-            var pip = new PackageInProject(packageId, path, null)
+            var pip = new PackageInProject(packageId, MakePackagePath(packageRefType), null)
                 .InList();
 
             return new PackageUpdateSet(packages, pip);
@@ -145,6 +144,12 @@ namespace NuKeeper.Tests
             var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
+
+        private static PackagePath MakePackagePath(PackageReferenceType packageRefType)
+        {
+            return new PackagePath("c:\\foo", "bar\\aproj.csproj", packageRefType);
+        }
+
 
         private static PackagePath PathToProjectOne()
         {

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -11,6 +11,33 @@ namespace NuKeeper.Tests
 {
     public static class PackageUpdates
     {
+        public static PackageUpdateSet For(
+            PackageIdentity package,
+            DateTimeOffset published,
+            List<PackageInProject> packages,
+            List<PackageDependency> dependencies)
+        {
+            var latest = new PackageSearchMedatadata(package, OfficialPackageSource(), published, dependencies);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+        public static PackageUpdateSet ForRefType(PackageReferenceType refType)
+        {
+            var fooPackage = new PackageIdentity("foo", new NuGetVersion(1, 2, 3));
+            var path = new PackagePath("c:\\foo", "bar", refType);
+            var packages = new[]
+            {
+                new PackageInProject(fooPackage, path, null)
+            };
+
+            var latest = new PackageSearchMedatadata(fooPackage, OfficialPackageSource(), null, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
+
         public static PackageUpdateSet MakeUpdateSet(string packageName, string version = "1.2.3")
         {
             var packageId = new PackageIdentity(packageName, new NuGetVersion(version));

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -95,6 +95,23 @@ namespace NuKeeper.Tests
             return new PackageUpdateSet(updates, packages);
         }
 
+        public static PackageUpdateSet LimitedToMinor(params PackageInProject[] packages)
+        {
+            return LimitedToMinor(null, packages);
+        }
+
+        public static PackageUpdateSet LimitedToMinor(DateTimeOffset? publishedAt, params PackageInProject[] packages)
+        {
+            var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
+            var latest = new PackageSearchMedatadata(latestId, OfficialPackageSource(), publishedAt, null);
+
+            var match = new PackageSearchMedatadata(
+                new PackageIdentity("foo.bar", new NuGetVersion("1.2.3")), OfficialPackageSource(), null, null);
+
+            var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
+            return new PackageUpdateSet(updates, packages);
+        }
+
         public static PackageSource OfficialPackageSource()
         {
             return new PackageSource(NuGetConstants.V3FeedUrl);

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -53,7 +53,6 @@ namespace NuKeeper.Tests
             return MakeUpdateSet("foo", "1.2.3", refType);
         }
 
-
         public static PackageUpdateSet For(params PackageInProject[] packages)
         {
             var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
@@ -98,7 +97,8 @@ namespace NuKeeper.Tests
             return LimitedToMinor(null, packages);
         }
 
-        public static PackageUpdateSet LimitedToMinor(DateTimeOffset? publishedAt, params PackageInProject[] packages)
+        public static PackageUpdateSet LimitedToMinor(DateTimeOffset? publishedAt,
+            params PackageInProject[] packages)
         {
             var latestId = new PackageIdentity("foo.bar", new NuGetVersion("2.3.4"));
             var latest = new PackageSearchMedatadata(latestId, OfficialPackageSource(), publishedAt, null);

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -129,6 +129,52 @@ namespace NuKeeper.Tests
             return new PackageUpdateSet(updates, packages);
         }
 
+        // todo move these to PackageUpdates.
+        public static PackageUpdateSet UpdateFooFromOneVersion(TimeSpan? packageAge = null)
+        {
+            var pubDate = DateTimeOffset.Now.Subtract(packageAge ?? TimeSpan.Zero);
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("foo", "1.0.1", PathToProjectOne()),
+                new PackageInProject("foo", "1.0.1", PathToProjectTwo())
+            };
+
+            var matchVersion = new NuGetVersion("4.0.0");
+            var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
+                OfficialPackageSource(), pubDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        public static PackageUpdateSet UpdateBarFromTwoVersions(TimeSpan? packageAge = null)
+        {
+            var pubDate = DateTimeOffset.Now.Subtract(packageAge ?? TimeSpan.Zero);
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("bar", "1.0.1", PathToProjectOne()),
+                new PackageInProject("bar", "1.2.1", PathToProjectTwo())
+            };
+
+            var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
+            var match = new PackageSearchMedatadata(matchId, OfficialPackageSource(), pubDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        private static PackagePath PathToProjectOne()
+        {
+            return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);
+        }
+
+        private static PackagePath PathToProjectTwo()
+        {
+            return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
+        }
+
         public static PackageSource OfficialPackageSource()
         {
             return new PackageSource(NuGetConstants.V3FeedUrl);


### PR DESCRIPTION
`PackageUpdates` is  class in `NuKeeper.Tests` concerned with making `PackageUpdateSet` data.
All occurences of `new PackageUpdateSet` in that project are now in that class.

