### PR TITLE
Fix fork mode

### DIFF
--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -18,10 +18,9 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var forkFinder = new ForkFinder(Substitute.For<IGitHub>(),
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(Substitute.For<IGitHub>(), Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Null);
         }
@@ -36,10 +35,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(fallbackRepoData);
 
-            var forkFinder = new ForkFinder(github, 
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.Null);
             Assert.That(fork, Is.EqualTo(fallbackFork));
@@ -55,10 +53,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(fallbackRepoData);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Null);
         }
@@ -74,10 +71,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.EqualTo(fallbackFork));
             AssertForkMatchesRepo(fork, userRepo);
@@ -94,10 +90,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.EqualTo(fallbackFork));
             AssertForkMatchesRepo(fork, userRepo);
@@ -114,10 +109,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             Assert.That(fork, Is.EqualTo(fallbackFork));
         }
@@ -135,10 +129,9 @@ namespace NuKeeper.Tests.Engine
             github.MakeUserFork(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferForkSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var actualFork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var actualFork = await forkFinder.FindPushFork(ForkMode.PreferFork, "testUser", fallbackFork);
 
             await github.Received(1).MakeUserFork(Arg.Any<string>(), Arg.Any<string>());
 
@@ -157,10 +150,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferSingleRepoSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferSingleRepository, "testUser", fallbackFork);
 
             Assert.That(fork, Is.EqualTo(fallbackFork));
         }
@@ -181,10 +173,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakePreferSingleRepoSettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.PreferSingleRepository, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Not.EqualTo(fallbackFork));
             AssertForkMatchesRepo(fork, userRepo);
@@ -201,10 +192,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakeSingleRepoOnlySettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.SingleRepositoryOnly, "testUser", fallbackFork);
 
             Assert.That(fork, Is.EqualTo(fallbackFork));
         }
@@ -226,10 +216,9 @@ namespace NuKeeper.Tests.Engine
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
 
-            var forkFinder = new ForkFinder(github,
-                MakeSingleRepoOnlySettings(), Substitute.For<INuKeeperLogger>());
+            var forkFinder = new ForkFinder(github, Substitute.For<INuKeeperLogger>());
 
-            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+            var fork = await forkFinder.FindPushFork(ForkMode.SingleRepositoryOnly, "testUser", fallbackFork);
 
             Assert.That(fork, Is.Null);
         }
@@ -242,30 +231,6 @@ namespace NuKeeper.Tests.Engine
         private ForkData NoMatchFork()
         {
             return new ForkData(new Uri(RepositoryBuilder.NoMatchUrl), "testOrg", "someRepo");
-        }
-
-        private UserSettings MakePreferForkSettings()
-        {
-            return new UserSettings
-            {
-                ForkMode = ForkMode.PreferFork
-            };
-        }
-
-        private UserSettings MakePreferSingleRepoSettings()
-        {
-            return new UserSettings
-            {
-                ForkMode = ForkMode.PreferSingleRepository
-            };
-        }
-
-        private UserSettings MakeSingleRepoOnlySettings()
-        {
-            return new UserSettings
-            {
-                ForkMode = ForkMode.SingleRepositoryOnly
-            };
         }
 
         private static void AssertForkMatchesRepo(ForkData fork, Repository repo)

--- a/NuKeeper/Engine/GitHubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitHubRepositoryEngine.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.Engine
         {
             try
             {
-                var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
+                var repo = await BuildGitRepositorySpec(repository, settings.UserSettings.ForkMode, gitCreds.Username);
                 if (repo == null)
                 {
                     return 0;
@@ -64,11 +64,12 @@ namespace NuKeeper.Engine
         }
 
         private async Task<RepositoryData> BuildGitRepositorySpec(
-            RepositorySettings repository, 
+            RepositorySettings repository,
+            ForkMode forkMode,
             string userName)
         {
             var pullFork = new ForkData(repository.GithubUri, repository.RepositoryOwner, repository.RepositoryName);
-            var pushFork = await _forkFinder.FindPushFork(userName, pullFork);
+            var pushFork = await _forkFinder.FindPushFork(forkMode, userName, pullFork);
 
             if (pushFork == null)
             {

--- a/NuKeeper/Engine/IForkFinder.cs
+++ b/NuKeeper/Engine/IForkFinder.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
+using NuKeeper.Configuration;
 
 namespace NuKeeper.Engine
 {
     public interface IForkFinder
     {
-        Task<ForkData> FindPushFork(string userName, ForkData fallbackFork);
+        Task<ForkData> FindPushFork(ForkMode forkMode, string userName, ForkData fallbackFork);
     };
 }


### PR DESCRIPTION
Fix for #453

The commandline parsing was fine, the issue was in IoC ordering changes.

It is no longer correct for `ForkFinder` to get settings via the constructor and read the ForkMode off of it, as this happened before the setting were initialised.

Refactored to a method with another param but less object state.  Semi-functional style.