### PR TITLE
Add support for version Release option

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -56,18 +56,19 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         [TestCase(VersionChange.Major, 2, 3, 4)]
         [TestCase(VersionChange.Minor, 1, 3, 1)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.Release, 1, 2, 3, "preview005")]
         [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenMajorVersionChangesAreAllowed(VersionChange dataRange,
-            int expectedMajor, int expectedMinor, int expectedPatch)
+            int expectedMajor, int expectedMinor, int expectedPatch, string expectedRelease = null)
         {
-            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
+            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedRelease);
             var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
             var updates = await lookup.FindVersionUpdate(
-                CurrentVersion123("TestPackage"),
+                CurrentVersion123("TestPackage", expectedRelease),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major);
 
@@ -79,18 +80,19 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         [TestCase(VersionChange.Major, 1, 3, 1)]
         [TestCase(VersionChange.Minor, 1, 3, 1)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.Release, 1, 2, 3, "preview005")]
         [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenMinorVersionChangesAreAllowed(VersionChange dataRange,
-            int expectedMajor, int expectedMinor, int expectedPatch)
+            int expectedMajor, int expectedMinor, int expectedPatch, string expectedRelease = null)
         {
-            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
+            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedRelease);
             var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
             var updates = await lookup.FindVersionUpdate(
-                CurrentVersion123("TestPackage"),
+                CurrentVersion123("TestPackage", expectedRelease),
                 NuGetSources.GlobalFeed,
                 VersionChange.Minor);
 
@@ -102,20 +104,45 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         [TestCase(VersionChange.Major, 1, 2, 5)]
         [TestCase(VersionChange.Minor, 1, 2, 5)]
         [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.Release, 1, 2, 3, "preview005")]
         [TestCase(VersionChange.None, 1, 2, 3)]
         public async Task WhenPatchVersionChangesAreAllowed(VersionChange dataRange,
-            int expectedMajor, int expectedMinor, int expectedPatch)
+            int expectedMajor, int expectedMinor, int expectedPatch, string expectedRelease = null)
         {
-            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch);
+            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedRelease);
             var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
             var allVersionsLookup = MockVersionLookup(resultPackages);
 
             IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
 
             var updates = await lookup.FindVersionUpdate(
-                CurrentVersion123("TestPackage"),
+                CurrentVersion123("TestPackage", expectedRelease),
                 NuGetSources.GlobalFeed,
                 VersionChange.Patch);
+
+            AssertPackagesIdentityIs(updates, "TestPackage");
+            Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
+            Assert.That(updates.Major.Identity.Version, Is.EqualTo(HighestVersion(resultPackages)));
+        }
+
+        [TestCase(VersionChange.Major, 1, 2, 5)]
+        [TestCase(VersionChange.Minor, 1, 2, 5)]
+        [TestCase(VersionChange.Patch, 1, 2, 5)]
+        [TestCase(VersionChange.Release, 1, 2, 3, "preview005")]
+        [TestCase(VersionChange.None, 1, 2, 3)]
+        public async Task WhenReleaseVersionChangesAreAllowed(VersionChange dataRange,
+            int expectedMajor, int expectedMinor, int expectedPatch, string expectedRelease = null)
+        {
+            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedRelease);
+            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
+            var allVersionsLookup = MockVersionLookup(resultPackages);
+
+            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
+
+            var updates = await lookup.FindVersionUpdate(
+                CurrentVersion123("TestPackage", expectedRelease),
+                NuGetSources.GlobalFeed,
+                VersionChange.Release);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -130,9 +157,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             return allVersions;
         }
 
-        private PackageIdentity CurrentVersion123(string packageId)
+        private PackageIdentity CurrentVersion123(string packageId, string release = null)
         {
-            return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
+            return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3, release));
         }
 
         private static void AssertPackagesIdentityIs(PackageLookupResult packages, string id)

--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -168,7 +168,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName),
                     Arg.Any<NuGetSources>(), Arg.Any<VersionChange>())
-                .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData, responseMetaData));
+                .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData, responseMetaData, responseMetaData));
         }
 
         private static BulkPackageLookup BuildBulkPackageLookup(IApiPackageLookup apiLookup)

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageLookupResultReporterTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageLookupResultReporterTests.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var logger = Substitute.For<INuKeeperLogger>();
             var reporter = new PackageLookupResultReporter(logger);
 
-            var data = new PackageLookupResult(VersionChange.Major, null, null, null);
+            var data = new PackageLookupResult(VersionChange.Major, null, null, null, null);
 
             reporter.Report(data);
 
@@ -39,7 +39,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)), 
                 new PackageSource("http://none"), DateTimeOffset.Now, null);
 
-            var data = new PackageLookupResult(VersionChange.Major, fooMetadata, fooMetadata, fooMetadata);
+            var data = new PackageLookupResult(VersionChange.Major, fooMetadata, fooMetadata, fooMetadata, fooMetadata);
 
             reporter.Report(data);
 
@@ -60,7 +60,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
                 new PackageSource("http://none"), DateTimeOffset.Now, null);
 
-            var data = new PackageLookupResult(VersionChange.Minor, fooMetadata, fooMetadata, fooMetadata);
+            var data = new PackageLookupResult(VersionChange.Minor, fooMetadata, fooMetadata, fooMetadata, fooMetadata);
 
             reporter.Report(data);
 
@@ -85,7 +85,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(2, 3, 4)),
                 new PackageSource("http://none"), DateTimeOffset.Now, null);
 
-            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, fooMinor, null);
+            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, fooMinor, null, null);
 
             reporter.Report(data);
 
@@ -106,7 +106,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 new PackageIdentity("foo", new NuGetVersion(3, 0, 0)),
                 new PackageSource("http://none"), DateTimeOffset.Now, null);
 
-            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, null, null);
+            var data = new PackageLookupResult(VersionChange.Minor, fooMajor, null, null, null);
 
             reporter.Report(data);
 

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
@@ -18,15 +18,22 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                     return NewMajorVersion()
                         .Concat(MinorVersions())
                         .Concat(PatchVersions())
+                        .Concat(ReleaseVersions())
                         .ToList();
 
                 case VersionChange.Minor:
                     return MinorVersions()
                         .Concat(PatchVersions())
+                        .Concat(ReleaseVersions())
                         .ToList();
 
                 case VersionChange.Patch:
-                    return PatchVersions();
+                    return PatchVersions()
+                        .Concat(ReleaseVersions())
+                        .ToList();
+
+                case VersionChange.Release:
+                    return ReleaseVersions();
 
                 case VersionChange.None:
                     return CurrentVersionOnly();
@@ -73,6 +80,22 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 PackageVersion(1, 0, 0)
             };
         }
+        private static List<PackageSearchMedatadata> ReleaseVersions()
+        {
+            return new List<PackageSearchMedatadata>
+            {
+                PackageVersion(1, 2, 3, "preview005"),
+                PackageVersion(1, 2, 3, "preview004"),
+                PackageVersion(1, 2, 3, "preview003"),
+                PackageVersion(1, 2, 3, "preview002"),
+                PackageVersion(1, 2, 3, "preview001"),
+
+                PackageVersion(1, 1, 0, "preview001"),
+                PackageVersion(1, 1, 0, "preview001"),
+                PackageVersion(1, 0, 0, "preview001"),
+                PackageVersion(1, 0, 0, "preview000"),
+            };
+        }
 
         private static List<PackageSearchMedatadata> CurrentVersionOnly()
         {
@@ -82,9 +105,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             };
         }
 
-        public static PackageSearchMedatadata PackageVersion(int major, int minor, int patch)
+        public static PackageSearchMedatadata PackageVersion(int major, int minor, int patch, string release = "")
         {
-            var version = new NuGetVersion(major, minor, patch);
+            var version = new NuGetVersion(major, minor, patch, release);
             var metadata = new PackageIdentity("TestPackage", version);
             return new PackageSearchMedatadata(metadata, new PackageSource("http://none"), DateTimeOffset.Now, null);
         }

--- a/NuKeeper.Inspection.Tests/Report/CsvFileReporterTests.cs
+++ b/NuKeeper.Inspection.Tests/Report/CsvFileReporterTests.cs
@@ -111,7 +111,7 @@ namespace NuKeeper.Inspection.Tests.Report
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), publishedDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, null, null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, null, null, null, null);
 
             Assert.Throws<ArgumentException>(() => new PackageUpdateSet(lookupResult, packages));
         }
@@ -45,7 +45,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [Test]
         public void NullPackages_IsNotAllowed()
         {
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
 
             var exception = Assert.Throws<ArgumentNullException>(() => new PackageUpdateSet(lookupResult, null));
 
@@ -55,7 +55,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [Test]
         public void EmptyPackages_IsNotAllowed()
         {
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
 
             var exception = Assert.Throws<ArgumentException>(
                 () => new PackageUpdateSet(lookupResult, Enumerable.Empty<PackageInProject>()));
@@ -73,7 +73,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, highest, null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, highest, null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
@@ -96,7 +96,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
@@ -115,7 +115,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates, Is.Not.Null);
@@ -135,7 +135,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates.CurrentPackages, Is.Not.Null);
@@ -157,7 +157,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
 
             Assert.Throws<ArgumentException>(() => new PackageUpdateSet(lookupResult, currentPackageBar));
         }
@@ -172,7 +172,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("fish", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var ex = Assert.Throws<ArgumentException>(() => new PackageUpdateSet(lookupResult, currentPackages));
 
             Assert.That(ex.Message, Is.EqualTo("Updates must all be for package 'foo', got 'bar, fish'"));
@@ -187,7 +187,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("bar", "1.0.0", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             Assert.Throws<ArgumentException>(() => new PackageUpdateSet(lookupResult, currentPackagesFooAndBar));
         }
 
@@ -199,7 +199,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectOne())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
@@ -214,7 +214,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(1));
@@ -229,7 +229,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 new PackageInProject("foo", "1.0.1", PathToProjectTwo())
             };
 
-            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null);
+            var lookupResult = new PackageLookupResult(VersionChange.Major, LatestFooMetadata(), null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(2));

--- a/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
@@ -200,7 +200,7 @@ namespace NuKeeper.Inspection.Tests.Sort
             var majorUpdate = Metadata(packageId, packageVersion, upstream);
 
             var lookupResult = new PackageLookupResult(VersionChange.Major,
-                majorUpdate, null, null);
+                majorUpdate, null, null, null);
             var updates = new PackageUpdateSet(lookupResult, currentPackages);
 
             return updates;

--- a/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
+++ b/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
@@ -157,7 +157,7 @@ namespace NuKeeper.Inspection.Tests
             var package = new PackageIdentity(pip.Id, new NuGetVersion("1.4.5"));
             var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), null, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
 
             return new PackageUpdateSet(updates, new List<PackageInProject> {pip });
         }

--- a/NuKeeper.Inspection/NuGetApi/PackageLookupResult.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageLookupResult.cs
@@ -8,12 +8,14 @@ namespace NuKeeper.Inspection.NuGetApi
             VersionChange allowedChange,
             PackageSearchMedatadata major,
             PackageSearchMedatadata minor,
-            PackageSearchMedatadata patch)
+            PackageSearchMedatadata patch,
+            PackageSearchMedatadata release)
         {
             AllowedChange = allowedChange;
             Major = major;
             Minor = minor;
             Patch = patch;
+            Release = release;
         }
 
         public VersionChange AllowedChange { get; }
@@ -21,6 +23,7 @@ namespace NuKeeper.Inspection.NuGetApi
         public PackageSearchMedatadata Major { get; }
         public PackageSearchMedatadata Minor { get; }
         public PackageSearchMedatadata Patch { get; }
+        public PackageSearchMedatadata Release { get; }
 
         public PackageSearchMedatadata Selected()
         {
@@ -34,6 +37,9 @@ namespace NuKeeper.Inspection.NuGetApi
 
                 case VersionChange.Patch:
                     return Patch;
+
+                case VersionChange.Release:
+                    return Release;
 
                 case VersionChange.None:
                     return null;

--- a/NuKeeper.Inspection/NuGetApi/VersionChange.cs
+++ b/NuKeeper.Inspection/NuGetApi/VersionChange.cs
@@ -2,9 +2,10 @@ namespace NuKeeper.Inspection.NuGetApi
 {
     public enum VersionChange
     {
-        None = 0,
-        Patch = 1,
-        Minor = 2,
-        Major = 3
+        None     = 0,
+        Release = 1,
+        Patch    = 2,
+        Minor    = 3,
+        Major    = 4,
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/VersionChanges.cs
+++ b/NuKeeper.Inspection/NuGetApi/VersionChanges.cs
@@ -19,7 +19,8 @@ namespace NuKeeper.Inspection.NuGetApi
             var major = FirstMatch(orderedCandidates, current, VersionChange.Major);
             var minor = FirstMatch(orderedCandidates, current, VersionChange.Minor);
             var patch = FirstMatch(orderedCandidates, current, VersionChange.Patch);
-            return new PackageLookupResult(allowedChange, major, minor, patch);
+            var release = FirstMatch(orderedCandidates, current, VersionChange.Release);
+            return new PackageLookupResult(allowedChange, major, minor, patch, release);
         }
 
         private static PackageSearchMedatadata FirstMatch(
@@ -42,6 +43,23 @@ namespace NuKeeper.Inspection.NuGetApi
 
                 case VersionChange.Patch:
                     return (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
+
+                case VersionChange.Release:
+                    if (string.IsNullOrEmpty(v1.Release))
+                    {
+                        return (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(v2.Release))
+                        {
+                            return (v1.Major == v2.Major) && (v1.Minor == v2.Minor);
+                        }
+                        else
+                        {
+                            return (v1.Major == v2.Major) && (v1.Minor == v2.Minor) && (v1.Patch == v2.Patch);
+                        }
+                    }
 
                 case VersionChange.None:
                     return (v1 == v2);

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -338,7 +338,7 @@ namespace NuKeeper.Tests.Engine
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(newPackage, OfficialPackageSource(), publishedDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 
@@ -348,7 +348,7 @@ namespace NuKeeper.Tests.Engine
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(newPackage, new PackageSource("http://internalfeed.myco.com/api"), publishedDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 
@@ -365,7 +365,7 @@ namespace NuKeeper.Tests.Engine
             var match = new PackageSearchMedatadata(
                 NewPackageFooBar123(), OfficialPackageSource(), null, null);
 
-            var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null);
+            var updates = new PackageLookupResult(VersionChange.Minor, latest, match, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -118,7 +118,7 @@ namespace NuKeeper.Tests.Engine
             var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
                 new PackageSource("http://none"), pubDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
 
@@ -135,7 +135,7 @@ namespace NuKeeper.Tests.Engine
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
             var match = new PackageSearchMedatadata(matchId, new PackageSource("http://none"), pubDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
 

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -273,7 +273,7 @@ namespace NuKeeper.Tests.Engine
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
             var latest = new PackageSearchMedatadata(fooPackage, new PackageSource("https://somewhere"), publishedDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
     }

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -112,7 +112,7 @@ namespace NuKeeper.Tests.Engine
 
             var latest = new PackageSearchMedatadata(fooPackage, new PackageSource(NuGetConstants.V3FeedUrl), null, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortDependencyTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortDependencyTests.cs
@@ -184,8 +184,8 @@ namespace NuKeeper.Tests.Engine.Sort
         private static PackageUpdateSet OnePackageUpdateSet(string packageName, int projectCount,
             List<PackageDependency> deps)
         {
-            var newPackage = new PackageIdentity(packageName, new NuGetVersion("1.4.5"));
-            var package = new PackageIdentity(packageName, new NuGetVersion("1.2.3"));
+            var newPackage = new PackageIdentity(packageName, new NuGetVersion("1.4.5-prview006"));
+            var package = new PackageIdentity(packageName, new NuGetVersion("1.2.3-preview004"));
 
             var projects = new List<PackageInProject>();
             foreach (var i in Enumerable.Range(1, projectCount))
@@ -216,7 +216,7 @@ namespace NuKeeper.Tests.Engine.Sort
         {
             var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), published, deps);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
@@ -198,7 +198,7 @@ namespace NuKeeper.Tests.Engine.Sort
         {
             var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), published, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 
@@ -213,8 +213,8 @@ namespace NuKeeper.Tests.Engine.Sort
 
         private static PackageUpdateSet OnePackageUpdateSet(int projectCount)
         {
-            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5"));
-            var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5-preview006"));
+            var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3-preview004"));
 
             var projects = new List<PackageInProject>();
             foreach(var i in Enumerable.Range(1, projectCount))
@@ -227,10 +227,10 @@ namespace NuKeeper.Tests.Engine.Sort
 
         private PackageUpdateSet MakeTwoProjectVersions()
         {
-            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5"));
+            var newPackage = new PackageIdentity("foo.bar", new NuGetVersion("1.4.5-preview006"));
 
-            var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
-            var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4"));
+            var package123 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3-preview004"));
+            var package124 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.4-preview005"));
             var projects = new List<PackageInProject>
             {
                 MakePackageInProjectFor(package123),

--- a/NuKeeper.Tests/Engine/VersionChangesTests.cs
+++ b/NuKeeper.Tests/Engine/VersionChangesTests.cs
@@ -74,6 +74,34 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
+        public void WhenThereAreNewMajorMinorPatchAndReleaseVersion()
+        {
+            var current = new NuGetVersion(1, 2, 3, "preview004");
+            var candidates = new List<PackageSearchMedatadata>
+            {
+                MetadataForVersion(2, 3, 4, "preview005"),
+                MetadataForVersion(1, 3, 4, "preview005"),
+                MetadataForVersion(1, 2, 4, "preview005")
+            };
+
+            var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Major);
+
+            Assert.That(result.AllowedChange, Is.EqualTo(VersionChange.Major));
+            Assert.That(result.Major, Is.Not.Null);
+            Assert.That(result.Major.Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4, "preview005")));
+
+            Assert.That(result.Minor, Is.Not.Null);
+            Assert.That(result.Minor.Identity.Version, Is.EqualTo(new NuGetVersion(1, 3, 4, "preview005")));
+
+            Assert.That(result.Patch, Is.Not.Null);
+            Assert.That(result.Patch.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 4, "preview005")));
+
+            Assert.That(result.Selected(), Is.EqualTo(result.Major));
+            Assert.That(result.Selected().Identity.Version, Is.EqualTo(new NuGetVersion(2, 3, 4, "preview005")));
+        }
+
+
+        [Test]
         public void WhenThereAreOnlyNewPatchVersion()
         {
             var current = new NuGetVersion(1, 2, 3);
@@ -96,6 +124,33 @@ namespace NuKeeper.Tests.Engine
             Assert.That(result.Selected(), Is.EqualTo(result.Patch));
             Assert.That(result.Major, Is.EqualTo(result.Minor));
             Assert.That(result.Major, Is.EqualTo(result.Patch));
+        }
+
+        [Test]
+        public void WhenThereAreOnlyNewReleaseVersion()
+        {
+            var current = new NuGetVersion(1, 2, 3, "preview004");
+            var candidates = new List<PackageSearchMedatadata>
+            {
+                MetadataForVersion(1, 2, 3, "preview007"),
+                MetadataForVersion(1, 2, 3, "preview005"),
+                MetadataForVersion(1, 2, 3, "preview004"),
+                MetadataForVersion(1, 2, 3, "preview006"),
+                MetadataForVersion(1, 2, 3, "preview008")
+            };
+
+            var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Major);
+
+            Assert.That(result.AllowedChange, Is.EqualTo(VersionChange.Major));
+            Assert.That(result.Major.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 3, "preview008")));
+
+            Assert.That(result.Selected(), Is.EqualTo(result.Major));
+            Assert.That(result.Selected(), Is.EqualTo(result.Minor));
+            Assert.That(result.Selected(), Is.EqualTo(result.Patch));
+            Assert.That(result.Selected(), Is.EqualTo(result.Release));
+            Assert.That(result.Major, Is.EqualTo(result.Minor));
+            Assert.That(result.Major, Is.EqualTo(result.Patch));
+            Assert.That(result.Major, Is.EqualTo(result.Release));
         }
 
         [Test]
@@ -126,6 +181,39 @@ namespace NuKeeper.Tests.Engine
 
             Assert.That(result.Major, Is.EqualTo(result.Minor));
             Assert.That(result.Major, Is.Not.EqualTo(result.Patch));
+        }
+
+        [Test]
+        public void WhenThereAreOnlyNewPatchAndReleaseVersion()
+        {
+            var current = new NuGetVersion(1, 2, 2, "preview004");
+            var candidates = new List<PackageSearchMedatadata>
+            {
+                MetadataForVersion(1, 2, 2, "preview007"),
+                MetadataForVersion(1, 2, 3, "preview005"),
+                MetadataForVersion(1, 2, 2, "preview004"),
+                MetadataForVersion(1, 2, 4, "preview001"),
+                MetadataForVersion(1, 2, 2, "preview006"),
+                MetadataForVersion(1, 2, 2, "preview008"),
+                MetadataForVersion(1, 2, 3, "preview007")
+            };
+
+            var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Major);
+
+            Assert.That(result.AllowedChange, Is.EqualTo(VersionChange.Major));
+            Assert.That(result.Major.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 4, "preview001")));
+            Assert.That(result.Minor.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 4, "preview001")));
+            Assert.That(result.Patch.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 4, "preview001")));
+            Assert.That(result.Release.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 2, "preview008")));
+
+            Assert.That(result.Selected(), Is.EqualTo(result.Major));
+            Assert.That(result.Selected(), Is.EqualTo(result.Minor));
+            Assert.That(result.Selected(), Is.EqualTo(result.Patch));
+            Assert.That(result.Selected(), Is.Not.EqualTo(result.Release));
+
+            Assert.That(result.Major, Is.EqualTo(result.Minor));
+            Assert.That(result.Major, Is.EqualTo(result.Patch));
+            Assert.That(result.Major, Is.Not.EqualTo(result.Release));
         }
 
         [Test]
@@ -173,21 +261,47 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public void WhenThereAreMultipleVersionsOutOfOrder()
+        public void WhenReleaseChangesAreAllowed()
         {
-            var current = new NuGetVersion(1, 2, 3);
+            var current = new NuGetVersion(1, 2, 3, "preview004");
             var candidates = new List<PackageSearchMedatadata>
             {
-                MetadataForVersion(1, 3, 4),
-                MetadataForVersion(2, 3, 4),
+                MetadataForVersion(2, 3, 4, "preview005"),
+                MetadataForVersion(1, 3, 4, "preview005"),
+                MetadataForVersion(1, 4, 5, "preview005"),
+                MetadataForVersion(1, 2, 3, "preview005")
+            };
+
+            var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Release);
+
+            Assert.That(result.AllowedChange, Is.EqualTo(VersionChange.Release));
+            Assert.That(result.Major, Is.Not.Null);
+            Assert.That(result.Minor, Is.Not.Null);
+            Assert.That(result.Patch, Is.Not.Null);
+            Assert.That(result.Release, Is.Not.Null);
+
+            Assert.That(result.Selected(), Is.EqualTo(result.Release));
+            Assert.That(result.Selected().Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 3, "preview005")));
+        }
+
+        [Test]
+        public void WhenThereAreMultipleVersionsOutOfOrder()
+        {
+            var current = new NuGetVersion(1, 2, 3, "preview004");
+            var candidates = new List<PackageSearchMedatadata>
+            {
+                MetadataForVersion(1, 3, 4, "preview005"),
+                MetadataForVersion(2, 3, 4, "preview006"),
                 MetadataForVersion(1, 2, 4),
-                MetadataForVersion(3, 3, 4),
+                MetadataForVersion(3, 3, 4, "preview005"),
                 MetadataForVersion(1, 5, 6),
-                MetadataForVersion(2, 5, 6),
-                MetadataForVersion(5, 6, 7),
+                MetadataForVersion(2, 5, 6, "preview002"),
+                MetadataForVersion(5, 6, 7, "preview009"),
                 MetadataForVersion(1, 1, 1),
-                MetadataForVersion(1, 2, 9),
-                MetadataForVersion(0, 1, 1)
+                MetadataForVersion(1, 4, 6, "preview002"),
+                MetadataForVersion(1, 3, 9, "preview007"),
+                MetadataForVersion(1, 2, 8),
+                MetadataForVersion(0, 1, 1, "preview005")
             };
 
             var result = VersionChanges.MakeVersions(current, candidates, VersionChange.Major);
@@ -195,14 +309,15 @@ namespace NuKeeper.Tests.Engine
             Assert.That(result.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(result.Selected(), Is.EqualTo(result.Major));
 
-            Assert.That(result.Major.Identity.Version, Is.EqualTo(new NuGetVersion(5, 6, 7)));
+            Assert.That(result.Major.Identity.Version, Is.EqualTo(new NuGetVersion(5, 6, 7, "preview009")));
             Assert.That(result.Minor.Identity.Version, Is.EqualTo(new NuGetVersion(1, 5, 6)));
-            Assert.That(result.Patch.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 9)));
+            Assert.That(result.Patch.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 8)));
+            Assert.That(result.Release.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 8)));
         }
 
-        private PackageSearchMedatadata MetadataForVersion(int major, int minor, int patch)
+        private PackageSearchMedatadata MetadataForVersion(int major, int minor, int patch, string release = "")
         {
-            var version = new NuGetVersion(major, minor, patch);
+            var version = new NuGetVersion(major, minor, patch, release);
             var packageId = new PackageIdentity("foo", version);
             return new PackageSearchMedatadata(packageId, new PackageSource("http://none"), DateTimeOffset.Now, null);
         }

--- a/NuKeeper.Tests/PackageUpdateSetBuilder.cs
+++ b/NuKeeper.Tests/PackageUpdateSetBuilder.cs
@@ -12,10 +12,10 @@ namespace NuKeeper.Tests
     {
         public static PackageUpdateSet MakePackageUpdateSet(string packageName)
         {
-            var fooPackage = new PackageIdentity(packageName, new NuGetVersion("1.2.3"));
+            var fooPackage = new PackageIdentity(packageName, new NuGetVersion("1.2.3-preview004"));
             var latest = new PackageSearchMedatadata(fooPackage, new PackageSource("http://none"), null,
                 Enumerable.Empty<PackageDependency>());
-            var packages = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var packages = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
 
             var path = new PackagePath("c:\\foo", "bar", PackageReferenceType.ProjectFile);
             var pip = new PackageInProject(fooPackage, path, null);

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -245,7 +245,7 @@ namespace NuKeeper.Update.Tests
 
             var latest = new PackageSearchMedatadata(newPackage, new PackageSource("http://none"), DateTimeOffset.Now, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, latest, null, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
 
@@ -263,7 +263,7 @@ namespace NuKeeper.Update.Tests
             var match = new PackageSearchMedatadata(new PackageIdentity("foo", matchVersion),
                 new PackageSource("http://none"), pubDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
 
@@ -280,7 +280,7 @@ namespace NuKeeper.Update.Tests
             var matchId = new PackageIdentity("bar", new NuGetVersion("4.0.0"));
             var match = new PackageSearchMedatadata(matchId, new PackageSource("http://none"), pubDate, null);
 
-            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null, null);
             return new PackageUpdateSet(updates, currentPackages);
         }
 

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.Commands
         protected readonly IFileSettingsCache FileSettingsCache;
 
         [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "change",
-            Description = "Allowed version change: Patch, Minor, Major. Defaults to Major.")]
+            Description = "Allowed version change: Release, Patch, Minor, Major. Defaults to Major.")]
         public VersionChange? AllowedChange { get; set; }
 
         [Option(CommandOptionType.MultipleValue, ShortName = "s", LongName = "source",


### PR DESCRIPTION
- Add Release to VersionChange enum.
- Update code to process nuget version _Release_ (like in X.Y.Z-alpha) as a valid update criteria.
- Add/update tests accordingly.

- Fix #457.

⚠️  couldn't edit the Wiki, so this will require updating the description for the "change" option.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>