### PR TITLE
Review exceptions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>0.8.1</VersionPrefix>
+    <VersionPrefix>0.8.2</VersionPrefix>
     <PackageVersion>$(VersionPrefix)</PackageVersion>
     <Copyright>Copyright (c) NuKeeper 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>0.8.2</VersionPrefix>
+    <VersionPrefix>0.8.1</VersionPrefix>
     <PackageVersion>$(VersionPrefix)</PackageVersion>
     <Copyright>Copyright (c) NuKeeper 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageVersionTestData.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                     return CurrentVersionOnly();
 
                 default:
-                    throw new Exception($"Invalid version change {change}");
+                    throw new ArgumentOutOfRangeException($"Invalid version change {change}");
             }
         }
 

--- a/NuKeeper.Inspection/NuGetApi/NuGetLogger.cs
+++ b/NuKeeper.Inspection/NuGetApi/NuGetLogger.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Inspection.NuGetApi
                     _logger.Error(message.Message);
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException($"Invalid log level {message.Level}");
             }
         }
 

--- a/NuKeeper.Inspection/NuKeeperException.cs
+++ b/NuKeeper.Inspection/NuKeeperException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace NuKeeper.Inspection
+{
+    [Serializable]
+    public class NuKeeperException: ApplicationException
+    {
+        public NuKeeperException()
+        {            
+        }
+        public NuKeeperException(string message) : base(message)
+        {
+        }
+
+        public NuKeeperException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+    }
+}

--- a/NuKeeper.Inspection/NuKeeperException.cs
+++ b/NuKeeper.Inspection/NuKeeperException.cs
@@ -6,8 +6,9 @@ namespace NuKeeper.Inspection
     public class NuKeeperException: ApplicationException
     {
         public NuKeeperException()
-        {            
+        {
         }
+
         public NuKeeperException(string message) : base(message)
         {
         }
@@ -15,6 +16,5 @@ namespace NuKeeper.Inspection
         public NuKeeperException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
             }
             catch (Exception ex)
             {
-                throw new ApplicationException($"Unable to parse file {packagePath.FullName}", ex);
+                throw new NuKeeperException($"Unable to parse file {packagePath.FullName}", ex);
             }
         }
 

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -150,7 +150,6 @@ namespace NuKeeper.Tests
             return new PackagePath("c:\\foo", "bar\\aproj.csproj", packageRefType);
         }
 
-
         private static PackagePath PathToProjectOne()
         {
             return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);

--- a/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
+++ b/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using NuKeeper.Inspection;
 using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Update.ProcessRunner
@@ -40,7 +41,7 @@ namespace NuKeeper.Update.ProcessRunner
 
             if (process == null)
             {
-                throw new Exception($"Could not start external process for {command}");
+                throw new NuKeeperException($"Could not start external process for {command}");
             }
 
             var textOut = await process.StandardOutput.ReadToEndAsync();
@@ -57,7 +58,7 @@ namespace NuKeeper.Update.ProcessRunner
 
                 if (ensureSuccess)
                 {
-                    throw new Exception(message);
+                    throw new NuKeeperException(message);
                 }
             }
 

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -34,7 +34,7 @@ namespace NuKeeper.Engine
                     return await FindUpstreamRepoOnly(forkMode, fallbackFork);
 
                 default:
-                    throw new Exception($"Unknown fork mode: {forkMode}");
+                    throw new ArgumentOutOfRangeException($"Unknown fork mode: {forkMode}");
             }
         }
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -71,7 +71,7 @@ namespace NuKeeper.Engine
                     return 0;
 
                 default:
-                    throw new Exception($"Unknown report mode: '{settings.UserSettings.ReportMode}'");
+                    throw new ArgumentOutOfRangeException($"Unknown report mode: '{settings.UserSettings.ReportMode}'");
             }
 
             if (updates.Count == 0)

--- a/NuKeeper/Git/LibGit2SharpDriver.cs
+++ b/NuKeeper/Git/LibGit2SharpDriver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using LibGit2Sharp;
+using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
 using GitCommands = LibGit2Sharp.Commands;
@@ -81,7 +82,7 @@ namespace NuKeeper.Git
             var qualifiedBranchName = "origin/" + branchName;
             if (BranchExists(qualifiedBranchName))
             {
-                throw new Exception($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+                throw new NuKeeperException($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
             }
 
             _logger.Detailed($"Git checkout new branch '{branchName}'");
@@ -124,7 +125,7 @@ namespace NuKeeper.Git
 
             if (repoSignature == null)
             {
-                throw new InvalidOperationException(
+                throw new NuKeeperException(
                     "Failed to build signature, did not get valid git user identity from github token or from repo config");
             }
 

--- a/NuKeeper/GitHub/OctokitClient.cs
+++ b/NuKeeper/GitHub/OctokitClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
+using NuKeeper.Inspection;
 using NuKeeper.Inspection.Formats;
 using NuKeeper.Inspection.Logging;
 using Octokit;
@@ -39,7 +40,7 @@ namespace NuKeeper.GitHub
         {
             if (!_initialised)
             {
-                throw new InvalidOperationException("Github has not been initialised");
+                throw new NuKeeperException("Github has not been initialised");
             }
         }
 


### PR DESCRIPTION
- use `ArgumentOutOfRangeException` with a message when an enum value doesn't match in any case
- use `ArgumentNullException` when an argument can't be null and `ArgumentException` when it is othwerwise invalid.
- use new custom type `NuKeeperException` for other cases where `Exception`, `ApplicationException` or `InvalidOperationException` was used.