### PR TITLE
Revert .nfproj file support

### DIFF
--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         public IEnumerable<string> GetFilePatterns()
         {
-            return new[] {"*.csproj", "*.vbproj", "*.fsproj", "*.nfproj"};
+            return new[] {"*.csproj", "*.vbproj", "*.fsproj" };
         }
 
         public IEnumerable<PackageInProject> Read(Stream fileContents, string baseDirectory, string relativePath)

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -113,19 +113,6 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
         }
 
         [Test]
-        public void FindsNfprojFile()
-        {
-            var scanner = MakeScanner();
-            var temporaryPath = GetUniqueTempFolder();
-
-            WriteFile(temporaryPath, "sample.nfproj", Vs2017ProjectFileTemplateWithPackages);
-
-            var results = scanner.FindAllNuGetPackages(temporaryPath);
-
-            Assert.That(results, Has.Count.EqualTo(1));
-        }
-
-        [Test]
         public void FindsNuspec()
         {
             var scanner = MakeScanner();

--- a/NuKeeper/Commands/LocalNuKeeperCommand.cs
+++ b/NuKeeper/Commands/LocalNuKeeperCommand.cs
@@ -7,8 +7,8 @@ namespace NuKeeper.Commands
 {
     internal abstract class LocalNuKeeperCommand : CommandBase
     {
-        [Argument(0, Description = "The path to a .sln or .csproj file or .nfproj, or to a directory containing a .NET Core solution/project. " +
-                                   "If none is specified, the current directory will be used.")]
+        [Argument(0, Description = "The path to a .sln or project file, or to a directory containing a .NET solution/project. " +
+               "If none is specified, the current directory will be used.")]
         // ReSharper disable once UnassignedGetOnlyAutoProperty
         // ReSharper disable once MemberCanBePrivate.Global
         protected string Path { get; }

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Engine
 
         public async Task<bool> ContainsDotNetProjects(RepositorySettings repository)
         {
-            var request = new SearchCodeRequest("\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\" OR \".nfproj\"")
+            var request = new SearchCodeRequest("\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"")
             {
                 Repos = new RepositoryCollection {{repository.RepositoryOwner, repository.RepositoryName}},
                 In = new []{CodeInQualifier.Path},


### PR DESCRIPTION
Revert .nfproj file support it is not going to work, as `nuget` and `dotnet` don't know what to do with them.
these are best handled by copying `*.nfproj` to `.csproj`, running tools and then copying back.