### PR TITLE
More warnings from analysers

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -130,7 +130,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             return allVersions;
         }
 
-        private PackageIdentity CurrentVersion123(string packageId)
+        private static PackageIdentity CurrentVersion123(string packageId)
         {
             return new PackageIdentity(packageId, new NuGetVersion(1, 2, 3));
         }

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA2007;CA1707</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
@@ -14,7 +15,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [TestCase("C:{sep}Code{sep}NuKeeper{sep}NuKeeper{sep}Packages.cs")]
         public void ShouldBeIncluded(string pathTemplate)
         {
-            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}");
+            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
             var actual = DirectoryExclusions.PathIsExcluded(path);
             Assert.That(actual, Is.False);
         }
@@ -25,7 +26,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [TestCase("C:{sep}Code{sep}NuKeeper{sep}.git{sep}config")]
         public void ShouldBeExcluded(string pathTemplate)
         {
-            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}");
+            var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
 
             var actual = DirectoryExclusions.PathIsExcluded(path);
             Assert.That(actual, Is.True);

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
@@ -125,7 +125,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             PackageAssert.IsPopulated(packages[0]);
         }
 
-        private PackagePath TempPath()
+        private static PackagePath TempPath()
         {
             return new PackagePath(
                 OsSpecifics.GenerateBaseDirectory(),

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
@@ -134,12 +134,12 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 PackageReferenceType.Nuspec);
         }
 
-        private NuspecFileReader MakeReader()
+        private static NuspecFileReader MakeReader()
         {
             return new NuspecFileReader(Substitute.For<INuKeeperLogger>());
         }
 
-        private Stream StreamFromString(string contents)
+        private static Stream StreamFromString(string contents)
         {
             return new MemoryStream(Encoding.UTF8.GetBytes(contents));
         }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -115,7 +116,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [Test]
         public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
         {
-            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion");
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(badVersion), TempPath())

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackageUpdateSetTests.cs
@@ -235,7 +235,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             Assert.That(updates.CountCurrentVersions(), Is.EqualTo(2));
         }
 
-        private PackageIdentity LatestVersionOfPackageFoo()
+        private static PackageIdentity LatestVersionOfPackageFoo()
         {
             return new PackageIdentity("foo", new NuGetVersion("1.2.3"));
         }
@@ -247,17 +247,17 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 _source, DateTimeOffset.Now, null);
         }
 
-        private NuGetVersion VersionFour()
+        private static NuGetVersion VersionFour()
         {
             return new NuGetVersion("4.0.0");
         }
 
-        private PackagePath PathToProjectOne()
+        private static PackagePath PathToProjectOne()
         {
             return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);
         }
 
-        private PackagePath PathToProjectTwo()
+        private static PackagePath PathToProjectTwo()
         {
             return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
         }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -131,7 +131,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             PackageAssert.IsPopulated(packages[0]);
         }
 
-        private PackagePath TempPath()
+        private static PackagePath TempPath()
         {
             return new PackagePath(
                 OsSpecifics.GenerateBaseDirectory(),

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -140,12 +140,12 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 PackageReferenceType.PackagesConfig);
         }
 
-        private PackagesFileReader MakeReader()
+        private static PackagesFileReader MakeReader()
         {
             return new PackagesFileReader(Substitute.For<INuKeeperLogger>());
         }
 
-        private Stream StreamFromString(string contents)
+        private static Stream StreamFromString(string contents)
         {
             return new MemoryStream(Encoding.UTF8.GetBytes(contents));
         }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackagesFileReaderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -121,7 +122,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [Test]
         public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
         {
-            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion");
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(badVersion), TempPath())

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -380,7 +380,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             PackageAssert.IsPopulated(packages[0]);
         }
 
-        private ProjectFileReader MakeReader()
+        private static ProjectFileReader MakeReader()
         {
             return new ProjectFileReader(Substitute.For<INuKeeperLogger>());
         }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -386,7 +386,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             return new ProjectFileReader(Substitute.For<INuKeeperLogger>());
         }
 
-        private Stream StreamFromString(string contents)
+        private static Stream StreamFromString(string contents)
         {
             return new MemoryStream(Encoding.UTF8.GetBytes(contents));
         }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -115,7 +116,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         [Test]
         public void ProjectWithEmptyPackageListCanBeRead()
         {
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", "");
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", "", StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -129,7 +130,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -143,7 +144,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -161,7 +162,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -178,10 +179,10 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var relativePath = $"..{Path.DirectorySeparatorChar}other{Path.DirectorySeparatorChar}other.csproj";
-            projectFile = projectFile.Replace("other.csproj", relativePath);
+            projectFile = projectFile.Replace("other.csproj", relativePath, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -201,7 +202,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             const string packagesText = @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile);
@@ -233,7 +234,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>
                   <PackageReference Include=""bar"" Version=""2.3.4""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
@@ -252,7 +253,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 @"<PackageReference Include=""foo"" Version=""1.2.3""></PackageReference>
                   <PackageReference Include=""bar"" Version=""2.3.4""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
@@ -287,7 +288,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
                 @"<PackageReference Include=""foo"" Version=""notaversion""></PackageReference>
                   <PackageReference Include=""bar"" Version=""2.3.4""></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", packagesText, StringComparison.OrdinalIgnoreCase);
 
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
@@ -303,7 +304,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             const string noVersion =
                 @"<PackageReference Include=""Microsoft.AspNetCore.App"" />";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion, StringComparison.OrdinalIgnoreCase);
 
 
             var reader = MakeReader();
@@ -319,7 +320,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             const string noVersion =
                 @"<PackageReference Include=""AWSSDK.Core"" Version=""3.3.*"" />";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion, StringComparison.OrdinalIgnoreCase);
 
 
             var reader = MakeReader();
@@ -335,7 +336,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             const string noVersion =
                 @"<PackageReference Include=""foo"" Version=""2.0.0-beta01"" />";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion, StringComparison.OrdinalIgnoreCase);
 
 
             var reader = MakeReader();
@@ -352,7 +353,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             const string noVersion =
                 @"<PackageReference Include=""NuGet.Protocol"" Version=""4.7.0+9245481f357ae542f92e6bc5e504fc898cfe5fc0"" />";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion, StringComparison.OrdinalIgnoreCase);
 
 
             var reader = MakeReader();
@@ -369,7 +370,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             const string noVersion =
                 @"<PackageReference Include=""foo""><Version>15.0.26606</Version><ExcludeAssets>all</ExcludeAssets></PackageReference>";
 
-            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion);
+            var projectFile = Vs2017ProjectFileTemplateWithPackages.Replace("{{Packages}}", noVersion, StringComparison.OrdinalIgnoreCase);
 
 
             var reader = MakeReader();

--- a/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
@@ -116,7 +116,8 @@ namespace NuKeeper.Inspection.Tests.Sort
             Assert.That(sorted[0], Is.EqualTo(testProj));
             Assert.That(sorted[1], Is.EqualTo(aProj));
 
-            logger.Received(1).Detailed(Arg.Is<string>(s => s.StartsWith("Resorted 2 projects by dependencies,")));
+            logger.Received(1).Detailed(Arg.Is<string>(s =>
+                s.StartsWith("Resorted 2 projects by dependencies,", StringComparison.OrdinalIgnoreCase)));
         }
 
         [Test]
@@ -141,7 +142,8 @@ namespace NuKeeper.Inspection.Tests.Sort
                 .ToList();
 
             AssertIsASortOf(sorted, items);
-            logger.Received(1).Minimal(Arg.Is<string>(s => s.StartsWith("Cannot sort by dependencies, cycle found at item")));
+            logger.Received(1).Minimal(Arg.Is<string>(
+                s => s.StartsWith("Cannot sort by dependencies, cycle found at item", StringComparison.OrdinalIgnoreCase)));
         }
 
         private static void AssertIsASortOf(List<PackageInProject> sorted, List<PackageInProject> original)

--- a/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
@@ -151,7 +151,7 @@ namespace NuKeeper.Inspection.Tests.Sort
             CollectionAssert.AreEquivalent(sorted, original);
         }
 
-        private PackageInProject PackageFor(string packageId, string packageVersion,
+        private static PackageInProject PackageFor(string packageId, string packageVersion,
             string relativePath, PackageInProject refProject = null)
         {
             relativePath = relativePath.Replace("{sep}", $"{Path.DirectorySeparatorChar}");

--- a/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -154,7 +155,7 @@ namespace NuKeeper.Inspection.Tests.Sort
         private static PackageInProject PackageFor(string packageId, string packageVersion,
             string relativePath, PackageInProject refProject = null)
         {
-            relativePath = relativePath.Replace("{sep}", $"{Path.DirectorySeparatorChar}");
+            relativePath = relativePath.Replace("{sep}", $"{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
             var basePath = "c_temp" + Path.DirectorySeparatorChar + "test";
 
             var refs = new List<string>();

--- a/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
@@ -172,7 +172,8 @@ namespace NuKeeper.Inspection.Tests.Sort
                 .ToList();
 
             AssertIsASortOf(sorted, items);
-            logger.Received(1).Minimal(Arg.Is<string>(s => s.StartsWith("Cannot sort by dependencies, cycle found at item")));
+            logger.Received(1).Minimal(Arg.Is<string>(
+                s => s.StartsWith("Cannot sort by dependencies, cycle found at item", StringComparison.OrdinalIgnoreCase)));
         }
 
 
@@ -184,7 +185,7 @@ namespace NuKeeper.Inspection.Tests.Sort
             CollectionAssert.AreEquivalent(sorted, original);
         }
 
-        private PackageDependency DependencyOn(PackageUpdateSet package)
+        private static PackageDependency DependencyOn(PackageUpdateSet package)
         {
             return new PackageDependency(package.SelectedId, new VersionRange(package.SelectedVersion));
         }
@@ -206,12 +207,12 @@ namespace NuKeeper.Inspection.Tests.Sort
             return updates;
         }
 
-        private PackagePath PathToProjectOne()
+        private static PackagePath PathToProjectOne()
         {
             return new PackagePath("c_temp", "projectOne", PackageReferenceType.PackagesConfig);
         }
 
-        private PackagePath PathToProjectTwo()
+        private static PackagePath PathToProjectTwo()
         {
             return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
         }

--- a/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageUpdateSetTopologicalSortTests.cs
@@ -216,7 +216,7 @@ namespace NuKeeper.Inspection.Tests.Sort
             return new PackagePath("c_temp", "projectTwo", PackageReferenceType.PackagesConfig);
         }
 
-        private PackageSearchMedatadata Metadata(string packageId, string version, PackageDependency upstream)
+        private static PackageSearchMedatadata Metadata(string packageId, string version, PackageDependency upstream)
         {
             var upstreams = new List<PackageDependency>();
             if (upstream != null)

--- a/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
+++ b/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
@@ -145,7 +145,7 @@ namespace NuKeeper.Inspection.Tests
                     .ToList());
         }
 
-        private PackageInProject BuildPackageInProject(string packageName)
+        private static PackageInProject BuildPackageInProject(string packageName)
         {
             var path = new PackagePath("c:\\temp", "folder\\src\\project1\\packages.config",
                 PackageReferenceType.PackagesConfig);

--- a/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
+++ b/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
@@ -97,7 +97,8 @@ namespace NuKeeper.Inspection.Tests
 
             logger
                 .Received(1)
-                .Error(Arg.Is<string>(s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.App'")));
+                .Error(Arg.Is<string>(
+                    s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.App'", StringComparison.OrdinalIgnoreCase)));
         }
 
         [Test]
@@ -128,10 +129,10 @@ namespace NuKeeper.Inspection.Tests
 
             logger
                 .Received(1)
-                .Error(Arg.Is<string>(s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.App'")));
+                .Error(Arg.Is<string>(s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.App'", StringComparison.OrdinalIgnoreCase)));
             logger
                 .Received(1)
-                .Error(Arg.Is<string>(s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.All'")));
+                .Error(Arg.Is<string>(s => s.StartsWith("Metapackage 'Microsoft.AspNetCore.All'", StringComparison.OrdinalIgnoreCase)));
         }
 
         private void ReturnsUpdateSetForEachPackage(IPackageUpdatesLookup updater)

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -47,6 +47,8 @@ namespace NuKeeper.Inspection.Report
             return result;
         }
 
+#pragma warning disable CA1822
+
         public string Describe(PackageUpdateSet update)
         {
             var occurrences = update.CurrentPackages.Count;

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -47,8 +47,6 @@ namespace NuKeeper.Inspection.Report
             return result;
         }
 
-#pragma warning disable CA1822
-
         public string Describe(PackageUpdateSet update)
         {
             var occurrences = update.CurrentPackages.Count;

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.Inspection.Report
             return result;
         }
 
-        public static string Describe(PackageUpdateSet update)
+        public string Describe(PackageUpdateSet update)
         {
             var occurrences = update.CurrentPackages.Count;
             var versionsInUse = update.CurrentPackages

--- a/NuKeeper.Inspection/Report/ConsoleReporter.cs
+++ b/NuKeeper.Inspection/Report/ConsoleReporter.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.Inspection.Report
             return result;
         }
 
-        public string Describe(PackageUpdateSet update)
+        public static string Describe(PackageUpdateSet update)
         {
             var occurrences = update.CurrentPackages.Count;
             var versionsInUse = update.CurrentPackages

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -4,6 +4,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
 	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA2007;CA1707</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -53,7 +54,7 @@ namespace NuKeeper.Update.Process
 
             var imports = project.Elements(ns + "Import");
             var importsWithToolsPath = imports
-                .Where(i => i.Attributes("Project").Any(a => a.Value.Contains("$(VSToolsPath)")))
+                .Where(i => i.Attributes("Project").Any(a => a.Value.Contains("$(VSToolsPath)", StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
             var importsWithoutCondition = importsWithToolsPath.Where(i => !i.Attributes("Condition").Any());

--- a/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.Update.Process
             }
         }
 
-        private async Task<IEnumerable<string>> UpdateConditionsOnProjects(Stream fileContents)
+        private static async Task<IEnumerable<string>> UpdateConditionsOnProjects(Stream fileContents)
         {
             var xml = XDocument.Load(fileContents);
             var ns = xml.Root.GetDefaultNamespace();

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -70,7 +70,8 @@ namespace NuKeeper.Commands
                 return -1;
             }
 
-            return await Run(settings);
+            return await Run(settings)
+                .ConfigureAwait(false);
         }
 
         private void InitialiseLogging()

--- a/NuKeeper/Commands/Concat.cs
+++ b/NuKeeper/Commands/Concat.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,7 +13,7 @@ namespace NuKeeper.Commands
 
         public static T FirstValue<T>(params T?[] values) where T: struct 
         {
-            return values.FirstOrDefault(i => i.HasValue) ?? default(T);
+            return values.FirstOrDefault(i => i.HasValue) ?? default;
         }
 
         public static IReadOnlyCollection<string> FirstPopulatedList(string[] list1, string[] list2, string[] list3)
@@ -38,7 +39,7 @@ namespace NuKeeper.Commands
                 return list3;
             }
 
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         private static bool HasElements(string[] strings)

--- a/NuKeeper/Commands/GlobalCommand.cs
+++ b/NuKeeper/Commands/GlobalCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
@@ -29,7 +30,7 @@ namespace NuKeeper.Commands
             }
 
             var apiHost = settings.GithubAuthSettings.ApiBase.Host;
-            if (apiHost.EndsWith("github.com"))
+            if (apiHost.EndsWith("github.com", StringComparison.OrdinalIgnoreCase))
             {
                 return ValidationResult.Failure("Global mode must not use public github");
             }

--- a/NuKeeper/Configuration/FileSettingsCache.cs
+++ b/NuKeeper/Configuration/FileSettingsCache.cs
@@ -23,7 +23,7 @@ namespace NuKeeper.Configuration
             return _settings;
         }
 
-        private string GetFolder()
+        private static string GetFolder()
         {
             return Directory.GetCurrentDirectory();
         }

--- a/NuKeeper/Configuration/GitSettingsReader.cs
+++ b/NuKeeper/Configuration/GitSettingsReader.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Configuration
             }
 
             var repoOwner = pathParts[0];
-            var repoName = pathParts[1].Replace(".git", string.Empty);
+            var repoName = pathParts[1].Replace(".git", string.Empty, StringComparison.OrdinalIgnoreCase);
 
             return new RepositorySettings
                 {
@@ -44,7 +44,7 @@ namespace NuKeeper.Configuration
 
             var path = uri.ToString();
 
-            if (path.EndsWith("/"))
+            if (path.EndsWith("/", StringComparison.OrdinalIgnoreCase))
             {
                 return uri;
             }

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -42,11 +42,13 @@ namespace NuKeeper.Local
 
             var sources = _nuGetSourcesReader.Read(folder, settings.UserSettings.NuGetSources);
 
-            var sortedUpdates = await GetSortedUpdates(folder, sources, settings.UserSettings.AllowedChange);
+            var sortedUpdates = await GetSortedUpdates(folder, sources, settings.UserSettings.AllowedChange)
+                .ConfigureAwait(false);
 
             if (write)
             {
-                await _updater.ApplyUpdates(sortedUpdates, folder, sources, settings);
+                await _updater.ApplyUpdates(sortedUpdates, folder, sources, settings)
+                    .ConfigureAwait(false);
             }
             else
             {


### PR DESCRIPTION
- some more statics
- and in tests, disable warnings about `ConfigureAwait` and about underscores in names