### PR TITLE
Package and tool lower case

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
+    <PackageId>nukeeper</PackageId>
+    <ToolCommandName>nukeeper</ToolCommandName>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;CA2007</NoWarn>


### PR DESCRIPTION
The package name and the tool name should both be all lower-case to avoid issues and work around this particular bug https://github.com/NuKeeperDotNet/NuKeeper/issues/433