### PR TITLE
Multipackage wordings

### DIFF
--- a/NuKeeper.Tests/Engine/BranchNamerTests.cs
+++ b/NuKeeper.Tests/Engine/BranchNamerTests.cs
@@ -49,6 +49,28 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
+        public void EquivalentInputs_HaveSameHash()
+        {
+            var packages1 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
+            };
+
+            var packages2 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
+            };
+
+            var branchName1 = BranchNamer.MakeName(packages1);
+            var branchName2 = BranchNamer.MakeName(packages2);
+
+            Assert.That(branchName1, Is.EqualTo(branchName2));
+        }
+
+
+        [Test]
         public void VersionChange_ChangesHash()
         {
             var packages1 = new List<PackageUpdateSet>
@@ -83,7 +105,7 @@ namespace NuKeeper.Tests.Engine
                 PackageUpdates.MakeUpdateSet("ZomePackage", "2.3.4"),
                 PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
             };
-
+            
             var branchName1 = BranchNamer.MakeName(packages1);
             var branchName2 = BranchNamer.MakeName(packages2);
 

--- a/NuKeeper.Tests/Engine/BranchNamerTests.cs
+++ b/NuKeeper.Tests/Engine/BranchNamerTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using NuKeeper.Engine;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class BranchNamerTests
+    {
+        [Test]
+        public void TestWithSinglePackage()
+        {
+            var packages = PackageUpdates.MakeUpdateSet("SomePackage")
+                .InList();
+
+            var branchName = BranchNamer.MakeName(packages);
+
+            Assert.That(branchName, Is.EqualTo("nukeeper-update-SomePackage-to-1.2.3"));
+        }
+
+        [Test]
+        public void TestWithTwoPackages()
+        {
+            var packages = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage"),
+                PackageUpdates.MakeUpdateSet("OtherPackage")
+            };
+
+            var branchName = BranchNamer.MakeName(packages);
+
+            Assert.That(branchName, Is.EqualTo("nukeeper-update-2-packages-AA9F9828431C8BFB7A18D3D8F0CF229D"));
+        }
+
+        [Test]
+        public void TestWithThreePackages()
+        {
+            var packages = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage"),
+                PackageUpdates.MakeUpdateSet("OtherPackage"),
+                PackageUpdates.MakeUpdateSet("SomethingElse"),
+            };
+
+            var branchName = BranchNamer.MakeName(packages);
+
+            Assert.That(branchName, Is.EqualTo("nukeeper-update-3-packages-BBBB3BF2315D6111CFCBF6A4A7A29DD8"));
+        }
+
+        [Test]
+        public void VersionChange_ChangesHash()
+        {
+            var packages1 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
+            };
+
+            var packages2 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.5")
+            };
+
+            var branchName1 = BranchNamer.MakeName(packages1);
+            var branchName2 = BranchNamer.MakeName(packages2);
+
+            Assert.That(branchName1, Is.Not.EqualTo(branchName2));
+        }
+
+        [Test]
+        public void NameChange_ChangesHash()
+        {
+            var packages1 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("SomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
+            };
+
+            var packages2 = new List<PackageUpdateSet>
+            {
+                PackageUpdates.MakeUpdateSet("ZomePackage", "2.3.4"),
+                PackageUpdates.MakeUpdateSet("OtherPackage", "2.3.4")
+            };
+
+            var branchName1 = BranchNamer.MakeName(packages1);
+            var branchName2 = BranchNamer.MakeName(packages2);
+
+            Assert.That(branchName1, Is.Not.EqualTo(branchName2));
+        }
+
+    }
+}

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -298,7 +298,12 @@ namespace NuKeeper.Tests.Engine
 
             var report = CommitWording.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.StartWith("2 packages were updated: `foo.bar`, `packageTwo`"));
+            Assert.That(report, Does.StartWith("2 packages were updated in 1 project:"));
+            Assert.That(report, Does.Contain("`foo.bar`, `packageTwo`"));
+            Assert.That(report, Does.Contain("<details>"));
+            Assert.That(report, Does.Contain("</details>"));
+            Assert.That(report, Does.Contain("<summary>"));
+            Assert.That(report, Does.Contain("</summary>"));
             Assert.That(report, Does.Contain("NuKeeper has generated a major update of `foo.bar` to `2.1.1` from `1.1.0`"));
             Assert.That(report, Does.Contain("NuKeeper has generated a major update of `packageTwo` to `3.4.5` from `1.1.0`"));
         }

--- a/NuKeeper.Tests/Engine/HasherTests.cs
+++ b/NuKeeper.Tests/Engine/HasherTests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+using NuKeeper.Engine;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class HasherTests
+    {
+        [Test]
+        public void CanHash()
+        {
+            var output = Hasher.Hash("test");
+
+            Assert.That(output, Is.EqualTo("098F6BCD4621D373CADE4E832627B4F6"));
+        }
+    }
+}

--- a/NuKeeper/Engine/BranchNamer.cs
+++ b/NuKeeper/Engine/BranchNamer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuKeeper.Inspection.RepositoryInspection;
@@ -6,16 +5,19 @@ using NuKeeper.Inspection.RepositoryInspection;
 namespace NuKeeper.Engine
 {
     public static class BranchNamer
-    {        public static string MakeName(IReadOnlyCollection<PackageUpdateSet> updates)
+    {
+        public static string MakeName(IReadOnlyCollection<PackageUpdateSet> updates)
         {
             return updates.Count > 1 ?
-                MakeMultiPackageName(updates.Count) :
+                MakeMultiPackageName(updates) :
                 MakeSinglePackageName(updates.First());
         }
 
-        private static string MakeMultiPackageName(int updateCount)
+        private static string MakeMultiPackageName(IReadOnlyCollection<PackageUpdateSet> updates)
         {
-            return $"nukeeper-update-{updateCount}-packages-{UniqueTimeString()}";
+            var updatesHash = Hasher.Hash(PackageVersionStrings(updates));
+
+            return $"nukeeper-update-{updates.Count}-packages-{updatesHash}";
         }
 
         public static string MakeSinglePackageName(PackageUpdateSet updateSet)
@@ -23,10 +25,14 @@ namespace NuKeeper.Engine
             return $"nukeeper-update-{updateSet.SelectedId}-to-{updateSet.SelectedVersion}";
         }
 
-        private static string UniqueTimeString()
+        private static string PackageVersionStrings(IReadOnlyCollection<PackageUpdateSet> updates)
         {
-            var now = DateTime.UtcNow;
-            return $"{now.Year}{now.Month:00}{now.Day:00}T{now.Hour:00}{now.Minute:00}{now.Second:00}";
+            return string.Join(",", updates.Select(PackageVersionString));
+        }
+
+        private static string PackageVersionString(PackageUpdateSet updateSet)
+        {
+            return $"{updateSet.SelectedId}-v{updateSet.SelectedVersion}";
         }
     }
 }

--- a/NuKeeper/Engine/BranchNamer.cs
+++ b/NuKeeper/Engine/BranchNamer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuKeeper.Inspection.RepositoryInspection;
@@ -5,15 +6,27 @@ using NuKeeper.Inspection.RepositoryInspection;
 namespace NuKeeper.Engine
 {
     public static class BranchNamer
-    {
-        public static string MakeName(PackageUpdateSet updateSet)
+    {        public static string MakeName(IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            return updates.Count > 1 ?
+                MakeMultiPackageName(updates.Count) :
+                MakeSinglePackageName(updates.First());
+        }
+
+        private static string MakeMultiPackageName(int updateCount)
+        {
+            return $"nukeeper-update-{updateCount}-packages-{UniqueTimeString()}";
+        }
+
+        public static string MakeSinglePackageName(PackageUpdateSet updateSet)
         {
             return $"nukeeper-update-{updateSet.SelectedId}-to-{updateSet.SelectedVersion}";
         }
 
-        public static string MakeName(IReadOnlyCollection<PackageUpdateSet> updates)
+        private static string UniqueTimeString()
         {
-            return updates.Count > 1 ? "nukeeper-update-packages" : MakeName(updates.First());
+            var now = DateTime.UtcNow;
+            return $"{now.Year}{now.Month:00}{now.Day:00}T{now.Hour:00}{now.Minute:00}{now.Second:00}";
         }
     }
 }

--- a/NuKeeper/Engine/CommitWording.cs
+++ b/NuKeeper/Engine/CommitWording.cs
@@ -47,6 +47,11 @@ namespace NuKeeper.Engine
                 builder.AppendLine(MakeCommitVersionDetails(update));
             }
 
+            if (updates.Count > 1)
+            {
+                MultiPackageFooter(builder);
+            }
+
             AddCommitFooter(builder);
 
             return builder.ToString();
@@ -57,7 +62,24 @@ namespace NuKeeper.Engine
             var packageNames = updates
                 .Select(p => CodeQuote(p.SelectedId))
                 .JoinWithCommas();
-            builder.AppendLine($"{updates.Count} packages were updated: {packageNames}");
+
+            var projects = updates.SelectMany(
+                    u => u.CurrentPackages)
+                .Select(p => p.Path.FullName)
+                .Distinct()
+                .ToList();
+
+            builder.AppendLine($"{updates.Count} packages were updated in {projects.Count} projects:");
+            builder.AppendLine(packageNames);
+            builder.AppendLine("<details>");
+            builder.AppendLine("<summary>Details of updated packages</summary>");
+            builder.AppendLine("");
+        }
+
+        private static void MultiPackageFooter(StringBuilder builder)
+        {
+            builder.AppendLine("</details>");
+            builder.AppendLine("");
         }
 
         private static string MakeCommitVersionDetails(PackageUpdateSet updates)

--- a/NuKeeper/Engine/CommitWording.cs
+++ b/NuKeeper/Engine/CommitWording.cs
@@ -69,7 +69,9 @@ namespace NuKeeper.Engine
                 .Distinct()
                 .ToList();
 
-            builder.AppendLine($"{updates.Count} packages were updated in {projects.Count} projects:");
+            var projectOptS = (projects.Count > 1) ? "s" : string.Empty;
+
+            builder.AppendLine($"{updates.Count} packages were updated in {projects.Count} project{projectOptS}:");
             builder.AppendLine(packageNames);
             builder.AppendLine("<details>");
             builder.AppendLine("<summary>Details of updated packages</summary>");

--- a/NuKeeper/Engine/Hasher.cs
+++ b/NuKeeper/Engine/Hasher.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NuKeeper.Engine
+{
+    public static class Hasher
+    {
+#pragma warning disable CA5351
+        private static MD5 md5 = MD5.Create();
+
+        public static string Hash(string input)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(input);
+            var hash = md5.ComputeHash(inputBytes);
+            return BytesToString(hash);
+        }
+
+        private static string BytesToString(byte[] bytes)
+        {
+            var result = new StringBuilder();
+
+            foreach (var b in bytes)
+            {
+                result.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Engine.Packages
         {
             try
             {
-                var branchName = BranchNamer.MakeName(packageUpdateSet);
+                var branchName = BranchNamer.MakeSinglePackageName(packageUpdateSet);
                 var githubBranch = await _gitHub.GetRepositoryBranch(pushFork.Owner, pushFork.Name, branchName);
                 return (githubBranch == null);
             }


### PR DESCRIPTION
Update to mutlipackage commit wording, 
 * Header says how many packages _and projects_ are affected.
 * The long details is under a collapse / expand element, [similar to this](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab).
 * a unique branch name for consolidated update PR, containing 2 or more package updates.

A unique branch name is needed because you can't use the same branch name each time, it will fail the second time because the branch already exists. Unless you're diligent about removing branches.

When there are 2 more more updates in the PR, the branch name has a  MD5 Hash on the end.
The input to the hash is the list of target package names and versions.

We want the same set of updates to generate the same branch name, but we also don't want the branch name to be arbitrarily long. So we hash the names and versions into a fixed-length string.
 
Yes, we know that the MD5 hash fn isn't secure, but we don't see a security implication for using this to try to make branch names unique. It's hard to give it bad input data, as this is read from the nuget api. Worst case is that the branch name isn't unique and so NuKeeper can't make the PR. 

Prompted by the good and bad parts of this PR: https://github.com/justeat/AwsWatchman/pull/214

