### PR TITLE
Added logdestination option

### DIFF
--- a/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
+++ b/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
@@ -1,6 +1,4 @@
 using System;
-using NuGet.Common;
-using NuKeeper.Inspection.Report;
 
 namespace NuKeeper.Inspection.Logging
 {

--- a/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
+++ b/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
@@ -1,4 +1,6 @@
 using System;
+using NuGet.Common;
+using NuKeeper.Inspection.Report;
 
 namespace NuKeeper.Inspection.Logging
 {
@@ -6,12 +8,8 @@ namespace NuKeeper.Inspection.Logging
     {
         private IInternalLogger _inner;
 
-        public void Initialise(LogLevel logLevel, string filePath)
+        public void Initialise(LogLevel logLevel, LogDestination destination, string filePath)
         {
-            var destination = string.IsNullOrWhiteSpace(filePath) ?
-                LogDestination.Console :
-                LogDestination.File;
-
             _inner = CreateLogger(logLevel, destination, filePath);
         }
 
@@ -58,6 +56,9 @@ namespace NuKeeper.Inspection.Logging
 
                 case LogDestination.File:
                     return new FileLogger(filePath, logLevel);
+
+                case LogDestination.Off:
+                    return new NullLogger();
 
                 default:
                     throw new Exception($"Unknown log destination {destination}");

--- a/NuKeeper.Inspection/Logging/FileLogger.cs
+++ b/NuKeeper.Inspection/Logging/FileLogger.cs
@@ -10,6 +10,11 @@ namespace NuKeeper.Inspection.Logging
 
         public FileLogger(string filePath, LogLevel logLevel)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("File logger has no file path", nameof(filePath));
+            }
+
             _filePath = filePath;
             _logLevel = logLevel;
         }

--- a/NuKeeper.Inspection/Logging/IConfigureLogger.cs
+++ b/NuKeeper.Inspection/Logging/IConfigureLogger.cs
@@ -1,8 +1,7 @@
 namespace NuKeeper.Inspection.Logging
 {
-
     public interface IConfigureLogger
     {
-        void Initialise(LogLevel logLevel, string filePath);
+        void Initialise(LogLevel logLevel, LogDestination dest, string filePath);
     }
 }

--- a/NuKeeper.Inspection/Logging/LogDestination.cs
+++ b/NuKeeper.Inspection/Logging/LogDestination.cs
@@ -1,8 +1,9 @@
-﻿namespace NuKeeper.Inspection.Logging
+namespace NuKeeper.Inspection.Logging
 {
     public enum LogDestination
     {
         Console,
-        File
+        File,
+        Off
     }
 }

--- a/NuKeeper.Inspection/Logging/NullLogger.cs
+++ b/NuKeeper.Inspection/Logging/NullLogger.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace NuKeeper.Inspection.Logging
+{
+    public class NullLogger : IInternalLogger
+    {
+        public void Log(LogLevel level, string message)
+        {
+        }
+
+        public void LogError(string message, Exception ex)
+        {
+        }
+    }
+}

--- a/NuKeeper.Inspection/Report/OutputFormat.cs
+++ b/NuKeeper.Inspection/Report/OutputFormat.cs
@@ -2,7 +2,7 @@ namespace NuKeeper.Inspection.Report
 {
     public enum OutputFormat
     {
-        None,
+        Off,
         Text,
         Csv,
         Metrics,

--- a/NuKeeper.Inspection/Report/Reporter.cs
+++ b/NuKeeper.Inspection/Report/Reporter.cs
@@ -43,7 +43,7 @@ namespace NuKeeper.Inspection.Report
         {
             switch (format)
             {
-                case OutputFormat.None:
+                case OutputFormat.Off:
                     return new NullReportFormat();
 
                 case OutputFormat.Text:

--- a/NuKeeper.Tests/Commands/InspectCommandTests.cs
+++ b/NuKeeper.Tests/Commands/InspectCommandTests.cs
@@ -116,7 +116,7 @@ namespace NuKeeper.Tests.Commands
 
             logger
                 .Received(1)
-                .Initialise(LogLevel.Normal, null);
+                .Initialise(LogLevel.Normal, LogDestination.Console, Arg.Any<string>());
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NuKeeper.Tests.Commands
 
             logger
                 .Received(1)
-                .Initialise(LogLevel.Minimal, null);
+                .Initialise(LogLevel.Minimal, LogDestination.Console, Arg.Any<string>());
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace NuKeeper.Tests.Commands
 
             logger
                 .Received(1)
-                .Initialise(LogLevel.Detailed, null);
+                .Initialise(LogLevel.Detailed, LogDestination.Console, Arg.Any<string>());
         }
 
         [Test]
@@ -182,7 +182,49 @@ namespace NuKeeper.Tests.Commands
 
             logger
                 .Received(1)
-                .Initialise(LogLevel.Minimal, null);
+                .Initialise(LogLevel.Minimal, LogDestination.Console, Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task LogToFileBySettingFileName()
+        {
+            var engine = Substitute.For<ILocalEngine>();
+            var logger = Substitute.For<IConfigureLogger>();
+            var fileSettings = Substitute.For<IFileSettingsCache>();
+
+            var settings = FileSettings.Empty();
+
+            fileSettings.GetSettings().Returns(settings);
+
+            var command = new InspectCommand(engine, logger, fileSettings);
+            command.LogFile = "somefile.log";
+
+            await command.OnExecute();
+
+            logger
+                .Received(1)
+                .Initialise(LogLevel.Normal, LogDestination.File, "somefile.log");
+        }
+
+        [Test]
+        public async Task LogToFileBySettingLogDestination()
+        {
+            var engine = Substitute.For<ILocalEngine>();
+            var logger = Substitute.For<IConfigureLogger>();
+            var fileSettings = Substitute.For<IFileSettingsCache>();
+
+            var settings = FileSettings.Empty();
+
+            fileSettings.GetSettings().Returns(settings);
+
+            var command = new InspectCommand(engine, logger, fileSettings);
+            command.LogDestination = LogDestination.File;
+
+            await command.OnExecute();
+
+            logger
+                .Received(1)
+                .Initialise(LogLevel.Normal, LogDestination.File, "nukeeper.log");
         }
 
         [Test]

--- a/NuKeeper.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Tests/Configuration/FileSettingsReaderTests.cs
@@ -34,6 +34,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.OutputDestination, Is.Null);
             Assert.That(data.OutputFormat, Is.Null);
             Assert.That(data.OutputFileName, Is.Null);
+            Assert.That(data.LogDestination, Is.Null);
         }
 
         [Test]
@@ -58,6 +59,7 @@ namespace NuKeeper.Tests.Configuration
             Assert.That(data.OutputDestination, Is.Null);
             Assert.That(data.OutputFormat, Is.Null);
             Assert.That(data.OutputFileName, Is.Null);
+            Assert.That(data.LogDestination, Is.Null);
         }
 
         private const string FullFileData = @"{
@@ -75,7 +77,8 @@ namespace NuKeeper.Tests.Configuration
                ""Change"": ""Minor"",
                ""OutputFormat"": ""Text"",
                ""OutputDestination"": ""Console"",
-               ""OutputFileName"" : ""out_42.txt""
+               ""OutputFileName"" : ""out_42.txt"",
+               ""LogDestination"" : ""file""
 }";
 
         [Test]
@@ -138,8 +141,11 @@ namespace NuKeeper.Tests.Configuration
 
             var data = fsr.Read(path);
 
-            Assert.That(data.Verbosity, Is.EqualTo(LogLevel.Detailed));
             Assert.That(data.Change, Is.EqualTo(VersionChange.Minor));
+
+            Assert.That(data.Verbosity, Is.EqualTo(LogLevel.Detailed));
+            Assert.That(data.LogDestination, Is.EqualTo(LogDestination.File));
+
             Assert.That(data.OutputDestination, Is.EqualTo(OutputDestination.Console));
             Assert.That(data.OutputFormat, Is.EqualTo(OutputFormat.Text));
         }

--- a/NuKeeper/Configuration/FileSettings.cs
+++ b/NuKeeper/Configuration/FileSettings.cs
@@ -32,6 +32,8 @@ namespace NuKeeper.Configuration
         public OutputDestination? OutputDestination { get; set; }
         public string OutputFileName { get; set; }
 
+        public LogDestination? LogDestination { get; set; }
+
         public static FileSettings Empty()
         {
             return new FileSettings();


### PR DESCRIPTION
Added `logdestination` option, which works like `outputdestination`. Symmetry!

All of this logic below already applies to `outputdestination` and `outputfile` options, but now in this PR it also applies to `logdestination` and `logfile` options.

* Both  `logdestination` and `logfile` options can be specified on the command-line or in the settings file. The usual fallback applies - values taken are (in order) from command line, from settings file, from a default value.
* `logdestination` is an enum, one of `Console`, `File` or `Off`. `Console` is the default, the usual output to console.  `Off` makes a null logger that does not record the output at all. `File` appends to the named log file.
* If the destination is `File` and no file name is given, then a default file name is used, "nukeeper.log" (for output it is "nukeeper.out") So if you specify `--logdestination file`  on the command-line and nothing else log-related, logging will go to the file "nukeeper.log".
* The default log destination is `Console`, unless a log file name is given on the command-line, in which case the default is `File`. So if you specify `--logfile somefile.log` on the command-line and nothing else log-related, logging will go to the file "somefile.log".