### PR TITLE
Change IGitHub to use abstractions DTO's

### DIFF
--- a/NuKeeper.Abstractions/DTOs/ForkData.cs
+++ b/NuKeeper.Abstractions/DTOs/ForkData.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 
-namespace NuKeeper.Engine
+namespace NuKeeper.Abstractions.DTOs
 {
     public class ForkData
     {

--- a/NuKeeper.Abstractions/DTOs/Organization.cs
+++ b/NuKeeper.Abstractions/DTOs/Organization.cs
@@ -1,0 +1,14 @@
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class Organization
+    {
+        public Organization(string name, string login)
+        {
+            Name = name;
+            Login = login;
+        }
+
+        public string Name { get; set; }
+        public string Login { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/PullRequestRequest.cs
+++ b/NuKeeper.Abstractions/DTOs/PullRequestRequest.cs
@@ -1,0 +1,16 @@
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class PullRequestRequest
+    {
+        public PullRequestRequest(string head, string title, string baseRef)
+        {
+            Head = head;
+            Title = title;
+            BaseRef = baseRef;
+        }
+
+        public string Head { get; }
+        public string Title { get; }
+        public string BaseRef { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/Repository.cs
+++ b/NuKeeper.Abstractions/DTOs/Repository.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class Repository
+    {
+        public Repository(string name, bool archived, UserPermissions userPermissions, Uri htmlUrl, Uri cloneUrl, User owner, bool fork, Repository parent)
+        {
+            Name = name;
+            Archived = archived;
+            UserPermissions = userPermissions;
+            HtmlUrl = htmlUrl;
+            CloneUrl = cloneUrl;
+            Owner = owner;
+            Fork = fork;
+            Parent = parent;
+        }
+
+        public string Name { get; }
+        public bool Archived { get; }
+        public UserPermissions UserPermissions { get; }
+        public Uri HtmlUrl { get; }
+        public User Owner { get; }
+        public bool Fork { get; }
+        public Repository Parent { get; }
+        public Uri CloneUrl { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/SearchCodeRequest.cs
+++ b/NuKeeper.Abstractions/DTOs/SearchCodeRequest.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class SearchCodeRequest
+    {
+        public SearchCodeRequest(string term)
+        {
+            Term = term;
+        }
+
+        public string Term { get; }
+        public IList<(string owner, string name)> Repos { get; set; }
+        public int PerPage { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/SearchCodeResult.cs
+++ b/NuKeeper.Abstractions/DTOs/SearchCodeResult.cs
@@ -1,0 +1,12 @@
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class SearchCodeResult
+    {
+        public SearchCodeResult(int totalCount)
+        {
+            TotalCount = totalCount;
+        }
+
+        public int TotalCount { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/User.cs
+++ b/NuKeeper.Abstractions/DTOs/User.cs
@@ -1,0 +1,16 @@
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class User
+    {
+        public User(string login, string name, string email)
+        {
+            Login = login;
+            Name = name;
+            Email = email;
+        }
+
+        public string Login { get; }
+        public string Name { get; }
+        public string Email { get; }
+    }
+}

--- a/NuKeeper.Abstractions/DTOs/UserPermissions.cs
+++ b/NuKeeper.Abstractions/DTOs/UserPermissions.cs
@@ -1,0 +1,27 @@
+namespace NuKeeper.Abstractions.DTOs
+{
+    public class UserPermissions
+    {
+        public UserPermissions(bool admin, bool push, bool pull)
+        {
+            Admin = admin;
+            Push = push;
+            Pull = pull;
+        }
+
+        /// <summary>
+        /// Whether the current user has administrative permissions
+        /// </summary>
+        public bool Admin { get; protected set; }
+
+        /// <summary>
+        /// Whether the current user has push permissions
+        /// </summary>
+        public bool Push { get; protected set; }
+
+        /// <summary>
+        /// Whether the current user has pull permissions
+        /// </summary>
+        public bool Pull { get; protected set; }
+    }
+}

--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -70,8 +70,8 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
             Assert.That(settings.SourceControlServerSettings.Scope, Is.EqualTo(ServerScope.Repository));
             Assert.That(settings.SourceControlServerSettings.Repository, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Repository.GithubUri, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Repository.GithubUri, Is.EqualTo(new Uri("http://github.com/test/test")));
+            Assert.That(settings.SourceControlServerSettings.Repository.Uri, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings.Repository.Uri, Is.EqualTo(new Uri("http://github.com/test/test")));
             Assert.That(settings.SourceControlServerSettings.OrganisationName, Is.Null);
         }
 

--- a/NuKeeper.Tests/Engine/ForkFinderTests.cs
+++ b/NuKeeper.Tests/Engine/ForkFinderTests.cs
@@ -1,13 +1,12 @@
-using System;
-using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Engine;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
 using NUnit.Framework;
-using Octokit;
+using System;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Tests.Engine
 {
@@ -30,7 +29,7 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsUsedWhenItIsFound()
         {
             var fallbackFork = DefaultFork();
-            var fallbackRepoData = RepositoryBuilder.MakeRepository();
+            var fallbackRepoData = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
@@ -48,7 +47,7 @@ namespace NuKeeper.Tests.Engine
         public async Task FallbackForkIsNotUsedWhenItIsNotPushable()
         {
             var fallbackFork = DefaultFork();
-            var fallbackRepoData = RepositoryBuilder.MakeRepository(true, false);
+            var fallbackRepoData = new GitHubRepository(RepositoryBuilder.MakeRepository(true, false));
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
@@ -66,7 +65,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -85,7 +84,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentHtmlUrl), "testOrg", "someRepo");
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -104,7 +103,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = NoMatchFork();
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -122,7 +121,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -145,7 +144,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -165,11 +164,11 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGitHub>();
 
-            var defaultRepo = RepositoryBuilder.MakeRepository(true, false);
+            var defaultRepo = new GitHubRepository(RepositoryBuilder.MakeRepository(true, false));
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
@@ -187,7 +186,7 @@ namespace NuKeeper.Tests.Engine
         {
             var fallbackFork = DefaultFork();
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             var github = Substitute.For<IGitHub>();
             github.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
@@ -208,11 +207,11 @@ namespace NuKeeper.Tests.Engine
 
             var github = Substitute.For<IGitHub>();
 
-            var defaultRepo = RepositoryBuilder.MakeRepository(true, false);
+            var defaultRepo = new GitHubRepository(RepositoryBuilder.MakeRepository(true, false));
             github.GetUserRepository(fallbackFork.Owner, fallbackFork.Name)
                 .Returns(defaultRepo);
 
-            var userRepo = RepositoryBuilder.MakeRepository();
+            var userRepo = new GitHubRepository(RepositoryBuilder.MakeRepository());
 
             github.GetUserRepository("testUser", fallbackFork.Name)
                 .Returns(userRepo);
@@ -239,7 +238,7 @@ namespace NuKeeper.Tests.Engine
             Assert.That(fork, Is.Not.Null);
             Assert.That(fork.Name, Is.EqualTo(repo.Name));
             Assert.That(fork.Owner, Is.EqualTo(repo.Owner.Login));
-            Assert.That(fork.Uri, Is.EqualTo(new Uri(repo.CloneUrl)));
+            Assert.That(fork.Uri, Is.EqualTo(repo.CloneUrl));
         }
     }
 }

--- a/NuKeeper.Tests/Engine/GitHubEngineTests.cs
+++ b/NuKeeper.Tests/Engine/GitHubEngineTests.cs
@@ -129,8 +129,7 @@ namespace NuKeeper.Tests.Engine
             var repoEngine = Substitute.For<IGitHubRepositoryEngine>();
             var folders = Substitute.For<IFolderFactory>();
 
-            github.GetCurrentUser().Returns(
-                RepositoryBuilder.MakeUser("http://test.user.com"));
+            github.GetCurrentUser().Returns(new GitHubUser(RepositoryBuilder.MakeUser("http://test.user.com")));
 
             repoDiscovery.GetRepositories(Arg.Any<IGitHub>(), Arg.Any<SourceControlServerSettings>())
                 .Returns(repos);

--- a/NuKeeper.Tests/Engine/GitHubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.Tests/Engine/GitHubRepositoryDiscoveryTests.cs
@@ -1,15 +1,15 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
 using NUnit.Framework;
-using Octokit;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Tests.Engine
 {
@@ -43,7 +43,7 @@ namespace NuKeeper.Tests.Engine
             var github = Substitute.For<IGitHub>();
             var settings = new SourceControlServerSettings
             {
-                Repository = new RepositorySettings(RepositoryBuilder.MakeRepository(name: "foo")),
+                Repository = new RepositorySettings(new GitHubRepository(RepositoryBuilder.MakeRepository(name: "foo"))),
                 Scope = ServerScope.Repository,
                 IncludeRepos = new Regex("^foo"),
                 ExcludeRepos = new Regex("^foo")
@@ -80,7 +80,7 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository()
+                new GitHubRepository(RepositoryBuilder.MakeRepository())
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
@@ -98,7 +98,7 @@ namespace NuKeeper.Tests.Engine
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[0].Name));
-            Assert.That(firstRepo.GithubUri.ToString(), Is.EqualTo(inputRepos[0].HtmlUrl));
+            Assert.That(firstRepo.Uri.ToString(), Is.EqualTo(inputRepos[0].HtmlUrl));
         }
 
         [Test]
@@ -106,8 +106,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
-                RepositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
+                new GitHubRepository(RepositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false)),
+                new GitHubRepository(RepositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true))
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
@@ -125,7 +125,7 @@ namespace NuKeeper.Tests.Engine
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[1].Name));
-            Assert.That(firstRepo.GithubUri.ToString(), Is.EqualTo(inputRepos[1].HtmlUrl));
+            Assert.That(firstRepo.Uri.ToString(), Is.EqualTo(inputRepos[1].HtmlUrl));
         }
 
         [Test]
@@ -133,8 +133,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository(name:"foo"),
-                RepositoryBuilder.MakeRepository(name:"bar")
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"foo")),
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"bar"))
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
@@ -161,8 +161,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository(name:"foo"),
-                RepositoryBuilder.MakeRepository(name:"bar")
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"foo")),
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"bar"))
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
@@ -189,8 +189,8 @@ namespace NuKeeper.Tests.Engine
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository(name:"foo"),
-                RepositoryBuilder.MakeRepository(name:"bar")
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"foo")),
+                new GitHubRepository(RepositoryBuilder.MakeRepository(name:"bar"))
             };
             IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
-using NuKeeper.Engine;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Engine.Packages;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.Sort;

--- a/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryFilterTests.cs
@@ -2,12 +2,12 @@ using System;
 using System.Threading.Tasks;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
 using NUnit.Framework;
-using Octokit;
 
 namespace NuKeeper.Tests.Engine
 {
@@ -18,7 +18,7 @@ namespace NuKeeper.Tests.Engine
         public async Task ShouldFilterWhenNoMatchFound()
         {
             var githubClient = Substitute.For<IGitHub>();
-            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(0, false, null)));
+            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(0)));
 
             IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
 
@@ -31,7 +31,7 @@ namespace NuKeeper.Tests.Engine
         public async Task ShouldNotFilterWhenMatchFound()
         {
             var githubClient = Substitute.For<IGitHub>();
-            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(1, false, null)));
+            githubClient.Search(null).ReturnsForAnyArgs(Task.FromResult(new SearchCodeResult(1)));
 
             IRepositoryFilter subject = new RepositoryFilter(githubClient, Substitute.For<INuKeeperLogger>());
 

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Engine.Packages;
@@ -23,6 +24,7 @@ using NuKeeper.Update.Process;
 using NuKeeper.Update.Selection;
 using NUnit.Framework;
 using Octokit;
+using PullRequestRequest = NuKeeper.Abstractions.DTOs.PullRequestRequest;
 
 namespace NuKeeper.Tests.Engine
 {
@@ -105,7 +107,7 @@ namespace NuKeeper.Tests.Engine
             await gitHub.Received(expectedPrs)
                 .OpenPullRequest(
                     Arg.Any<ForkData>(),
-                    Arg.Any<NewPullRequest>(),
+                    Arg.Any<PullRequestRequest>(),
                     Arg.Any<IEnumerable<string>>());
 
             gitDriver.Received(numberOfUpdates)

--- a/NuKeeper/Configuration/GitSettingsReader.cs
+++ b/NuKeeper/Configuration/GitSettingsReader.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Configuration
 
             return new RepositorySettings
                 {
-                    GithubUri = gitHubRepositoryUri,
+                    Uri = gitHubRepositoryUri,
                     RepositoryName = repoName,
                     RepositoryOwner = repoOwner
             };

--- a/NuKeeper/Configuration/RepositorySettings.cs
+++ b/NuKeeper/Configuration/RepositorySettings.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Octokit;
+using System;
+using NuKeeper.Abstractions.DTOs;
 
 namespace NuKeeper.Configuration
 {
@@ -11,12 +11,12 @@ namespace NuKeeper.Configuration
 
         public RepositorySettings(Repository repository)
         {
-            GithubUri = new Uri(repository.HtmlUrl);
+            Uri = repository.HtmlUrl;
             RepositoryOwner = repository.Owner.Login;
             RepositoryName = repository.Name;
         }
 
-        public Uri GithubUri { get; set; }
+        public Uri Uri { get; set; }
 
         public string RepositoryOwner { get; set; }
 

--- a/NuKeeper/Engine/ForkFinder.cs
+++ b/NuKeeper/Engine/ForkFinder.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
-using Octokit;
 
 namespace NuKeeper.Engine
 {
@@ -102,7 +101,7 @@ namespace NuKeeper.Engine
         private async Task<bool> IsPushableRepo(ForkData originFork)
         {
             var originRepo = await _gitHub.GetUserRepository(originFork.Owner, originFork.Name);
-            return originRepo != null && originRepo.Permissions.Push;
+            return originRepo != null && originRepo.UserPermissions.Push;
         }
 
         private async Task<ForkData> TryFindUserFork(string userName, ForkData originFork)
@@ -110,7 +109,7 @@ namespace NuKeeper.Engine
             var userFork = await _gitHub.GetUserRepository(userName, originFork.Name);
             if (userFork != null)
             {
-                if (RepoIsForkOf(userFork, originFork.Uri.ToString()) && userFork.Permissions.Push)
+                if (RepoIsForkOf(userFork, originFork.Uri.ToString()) && userFork.UserPermissions.Push)
                 {
                     // the user has a pushable fork
                     return RepositoryToForkData(userFork);
@@ -139,8 +138,8 @@ namespace NuKeeper.Engine
                 return false;
             }
 
-            return UrlIsMatch(userRepo.Parent?.CloneUrl, parentUrl)
-                || UrlIsMatch(userRepo.Parent?.HtmlUrl, parentUrl);
+            return UrlIsMatch(userRepo.Parent?.CloneUrl.ToString(), parentUrl)
+                || UrlIsMatch(userRepo.Parent?.HtmlUrl.ToString(), parentUrl);
         }
 
         private static bool UrlIsMatch(string test, string expected)
@@ -151,7 +150,7 @@ namespace NuKeeper.Engine
 
         private static ForkData RepositoryToForkData(Repository repo)
         {
-            return new ForkData(new Uri(repo.CloneUrl), repo.Owner.Login, repo.Name);
+            return new ForkData(repo.CloneUrl, repo.Owner.Login, repo.Name);
         }
     }
 }

--- a/NuKeeper/Engine/GitHubEngine.cs
+++ b/NuKeeper/Engine/GitHubEngine.cs
@@ -7,6 +7,7 @@ using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Formats;
 using NuKeeper.Inspection.Logging;
 using Octokit;
+using User = NuKeeper.Abstractions.DTOs.User;
 
 namespace NuKeeper.Engine
 {
@@ -78,7 +79,7 @@ namespace NuKeeper.Engine
             return reposUpdated;
         }
 
-        private Identity GetUserIdentity(Account githubUser)
+        private Identity GetUserIdentity(User githubUser)
         {
             if (string.IsNullOrWhiteSpace(githubUser?.Name))
             {

--- a/NuKeeper/Engine/GitHubExtensions.cs
+++ b/NuKeeper/Engine/GitHubExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.GitHub;
 using Octokit;
@@ -25,7 +25,8 @@ namespace NuKeeper.Engine
                 qualifiedBranch = repository.Push.Owner + ":" + branchWithChanges;
             }
 
-            var pr = new NewPullRequest(title, qualifiedBranch, repository.DefaultBranch) { Body = body };
+            var gitHubPr = new NewPullRequest(title, qualifiedBranch, repository.DefaultBranch) { Body = body };
+            var pr = new GitHubPullRequestRequest(gitHubPr);
 
             await gitHub.OpenPullRequest(repository.Pull, pr, labels);
         }

--- a/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
+++ b/NuKeeper/Engine/GitHubRepositoryDiscovery.cs
@@ -76,28 +76,28 @@ namespace NuKeeper.Engine
                 .ToList();
         }
 
-        private static bool MatchesIncludeExclude(Repository repo, SourceControlServerSettings settings)
+        private static bool MatchesIncludeExclude(Abstractions.DTOs.Repository repo, SourceControlServerSettings settings)
         {
             return
                 MatchesInclude(settings.IncludeRepos, repo)
                 && !MatchesExclude(settings.ExcludeRepos, repo);
         }
 
-        private static bool MatchesInclude(Regex regex, Repository repo)
+        private static bool MatchesInclude(Regex regex, Abstractions.DTOs.Repository repo)
         {
             return regex == null || regex.IsMatch(repo.Name);
         }
 
-        private static bool MatchesExclude(Regex regex, Repository repo)
+        private static bool MatchesExclude(Regex regex, Abstractions.DTOs.Repository repo)
         {
             return regex != null && regex.IsMatch(repo.Name);
         }
 
-        private static bool RepoIsModifiable(Repository repo)
+        private static bool RepoIsModifiable(Abstractions.DTOs.Repository repo)
         {
             return
                 ! repo.Archived &&
-                repo.Permissions.Pull;
+                repo.UserPermissions.Pull;
         }
     }
 }

--- a/NuKeeper/Engine/GitHubRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitHubRepositoryEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.Git;
 using NuKeeper.Inspection.Files;
@@ -69,12 +70,12 @@ namespace NuKeeper.Engine
             ForkMode forkMode,
             string userName)
         {
-            var pullFork = new ForkData(repository.GithubUri, repository.RepositoryOwner, repository.RepositoryName);
+            var pullFork = new ForkData(repository.Uri, repository.RepositoryOwner, repository.RepositoryName);
             var pushFork = await _forkFinder.FindPushFork(forkMode, userName, pullFork);
 
             if (pushFork == null)
             {
-                _logger.Normal($"No pushable fork found for {repository.GithubUri}");
+                _logger.Normal($"No pushable fork found for {repository.Uri}");
                 return null;
             }
 

--- a/NuKeeper/Engine/IForkFinder.cs
+++ b/NuKeeper/Engine/IForkFinder.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 
 namespace NuKeeper.Engine

--- a/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;
@@ -23,8 +24,7 @@ namespace NuKeeper.Engine.Packages
             try
             {
                 var branchName = BranchNamer.MakeSinglePackageName(packageUpdateSet);
-                var githubBranch = await _gitHub.GetRepositoryBranch(pushFork.Owner, pushFork.Name, branchName);
-                return (githubBranch == null);
+                return await _gitHub.RepositoryBranchExists(pushFork.Owner, pushFork.Name, branchName);
             }
             catch(Exception ex)
             {

--- a/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/IExistingBranchFilter.cs
@@ -1,5 +1,6 @@
 using NuKeeper.Inspection.RepositoryInspection;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.DTOs;
 
 namespace NuKeeper.Engine.Packages
 {

--- a/NuKeeper/Engine/Packages/IPackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/IPackageUpdateSelection.cs
@@ -1,6 +1,7 @@
 using NuKeeper.Inspection.RepositoryInspection;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.Update.Selection;
 

--- a/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdateSelection.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Inspection.Sort;
 using NuKeeper.Inspection.Logging;
 using NuKeeper.Inspection.RepositoryInspection;

--- a/NuKeeper/Engine/RepositoryData.cs
+++ b/NuKeeper/Engine/RepositoryData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using NuKeeper.Abstractions.DTOs;
 
 namespace NuKeeper.Engine
 {

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Configuration;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Logging;
-using Octokit;
 
 namespace NuKeeper.Engine
 {
@@ -22,8 +23,7 @@ namespace NuKeeper.Engine
         {
             var request = new SearchCodeRequest("\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"")
             {
-                Repos = new RepositoryCollection {{repository.RepositoryOwner, repository.RepositoryName}},
-                In = new []{CodeInQualifier.Path},
+                Repos = new List<(string owner, string name)> {(repository.RepositoryOwner, repository.RepositoryName)},
                 PerPage = 1
             };
             try

--- a/NuKeeper/GitHub/GitHubOrganization.cs
+++ b/NuKeeper/GitHub/GitHubOrganization.cs
@@ -1,0 +1,13 @@
+using NuKeeper.Abstractions.DTOs;
+using Account = Octokit.Account;
+
+namespace NuKeeper.GitHub
+{
+    public class GitHubOrganization : Organization
+    {
+        public GitHubOrganization(Account account)
+            : base(account.Name, account.Login)
+        {
+        }
+    }
+}

--- a/NuKeeper/GitHub/GitHubPullRequestRequest.cs
+++ b/NuKeeper/GitHub/GitHubPullRequestRequest.cs
@@ -1,0 +1,13 @@
+using NuKeeper.Abstractions.DTOs;
+using Account = Octokit.Account;
+
+namespace NuKeeper.GitHub
+{
+    public class GitHubPullRequestRequest : PullRequestRequest
+    {
+        public GitHubPullRequestRequest(Octokit.NewPullRequest pullRequest)
+            :base(pullRequest.Head, pullRequest.Title,pullRequest.Base)
+        {
+        }
+    }
+}

--- a/NuKeeper/GitHub/GitHubRepository.cs
+++ b/NuKeeper/GitHub/GitHubRepository.cs
@@ -1,0 +1,23 @@
+using NuKeeper.Abstractions.DTOs;
+using System;
+using Repository = NuKeeper.Abstractions.DTOs.Repository;
+
+namespace NuKeeper.GitHub
+{
+    public class GitHubRepository : Repository
+    {
+        public GitHubRepository(Octokit.Repository repository)
+        : base(
+            repository.Name,
+            repository.Archived,
+            new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull),
+            new Uri(repository.HtmlUrl),
+            new Uri(repository.CloneUrl),
+            new GitHubUser(repository.Owner),
+            repository.Fork,
+            repository.Parent != null ? new GitHubRepository(repository.Parent) : null 
+            )
+        {
+        }
+    }
+}

--- a/NuKeeper/GitHub/GitHubSearchCodeResult.cs
+++ b/NuKeeper/GitHub/GitHubSearchCodeResult.cs
@@ -1,0 +1,12 @@
+using NuKeeper.Abstractions.DTOs;
+
+namespace NuKeeper.GitHub
+{
+    public class GitHubSearchCodeResult : SearchCodeResult
+    {
+        public GitHubSearchCodeResult(Octokit.SearchCodeResult result)
+        : base(result.TotalCount)
+        {
+        }
+    }
+}

--- a/NuKeeper/GitHub/GitHubUser.cs
+++ b/NuKeeper/GitHub/GitHubUser.cs
@@ -1,0 +1,13 @@
+using NuKeeper.Abstractions.DTOs;
+using Account = Octokit.Account;
+
+namespace NuKeeper.GitHub
+{
+    public class GitHubUser : User
+    {
+        public GitHubUser(Account user)
+            : base(user.Login, user.Name, user.Email)
+        {
+        }
+    }
+}

--- a/NuKeeper/GitHub/IGitHub.cs
+++ b/NuKeeper/GitHub/IGitHub.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Engine;
-using Octokit;
+using NuKeeper.Abstractions.DTOs;
 
 namespace NuKeeper.GitHub
 {
@@ -10,9 +9,9 @@ namespace NuKeeper.GitHub
     {
         void Initialise(AuthSettings settings);
 
-        Task<Account> GetCurrentUser();
+        Task<User> GetCurrentUser();
 
-        Task<PullRequest> OpenPullRequest(ForkData target, NewPullRequest request, IEnumerable<string> labels);
+        Task OpenPullRequest(ForkData target, PullRequestRequest request, IEnumerable<string> labels);
 
         Task<IReadOnlyList<Organization>> GetOrganizations();
 
@@ -22,7 +21,7 @@ namespace NuKeeper.GitHub
 
         Task<Repository> MakeUserFork(string owner, string repositoryName);
 
-        Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName);
+        Task<bool> RepositoryBranchExists(string userName, string repositoryName, string branchName);
 
         Task<SearchCodeResult> Search(SearchCodeRequest search);
     }


### PR DESCRIPTION
Update IGitHub to use Nukeeper DTOs instead of Octokit

Some changes were made these are as follows:
**In IGithub**
```
Task<PullRequest> OpenPullRequest(ForkData target, NewPullRequest request, IEnumerable<string> labels);
Task OpenPullRequest(ForkData target, PullRequestRequest request, IEnumerable<string> labels);
```
The return type of this method was not used so to keep the number of new classes down i removed it

```
Task<Branch> GetRepositoryBranch(string userName, string repositoryName, string branchName);
Task<bool> RepositoryBranchExists(string userName, string repositoryName, string branchName);
```
The only time we used branch was to check if it was null again to keep new classes down simplified this

**DTOs**
Created new base DTOs in abstractions that accept simple props in the constructor, this is to keep them immutable, we know everything about them when we retrieve them 

Created new GitHub<DTO> classes that have the Octokit type in the constructor, this provides a convenient way to to wrap existing objects to return the new DTOs

At the moment I have tried to keep this PR simple by wrapping all existing objects, in a future PR (or this one if you like)  Updating `RepositoryBuilder` to return the new DTO's would be beneficial 