### PR TITLE
Move 2 pieces of helper code into Abstractions

### DIFF
--- a/NuKeeper.Abstractions/LinqAsync.cs
+++ b/NuKeeper.Abstractions/LinqAsync.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace NuKeeper.Update
+namespace NuKeeper.Abstractions
 {
     public static class LinqAsync
     {

--- a/NuKeeper.Abstractions/ListHelper.cs
+++ b/NuKeeper.Abstractions/ListHelper.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace NuKeeper.Tests
+namespace NuKeeper.Abstractions
 {
     public static class ListHelper
     {

--- a/NuKeeper.Tests/Engine/BranchNamerTests.cs
+++ b/NuKeeper.Tests/Engine/BranchNamerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NuKeeper.Abstractions;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;

--- a/NuKeeper.Tests/Engine/CommitWordingTests.cs
+++ b/NuKeeper.Tests/Engine/CommitWordingTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.Abstractions;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Engine.Packages;

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Abstractions.Logging;

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;

--- a/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
+++ b/NuKeeper.Tests/Engine/Sort/PackageUpdateSortTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NSubstitute;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Inspection.Sort;
 using NuKeeper.Inspection.RepositoryInspection;

--- a/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
+++ b/NuKeeper.Tests/Engine/UpdateConsolidatorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using NuKeeper.Abstractions;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;

--- a/NuKeeper.Tests/Engine/VersionChangesTests.cs
+++ b/NuKeeper.Tests/Engine/VersionChangesTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Inspection.NuGetApi;
 using NUnit.Framework;

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NuKeeper.Inspection.RepositoryInspection;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Update.Selection


### PR DESCRIPTION
Move 2 bits of helper code: `LinqAsync` and `InList` into the abstractions project.

You might say that `Abstractions`  is in danger of becoming a "GeneralFunctions" / "helpers" project and I agree that this is a smell worth keeping an eye on. However I think that it is an improvement - i.e. `LinqAsync` was where it was, not because it was really an "update" function, but because that allowed it to be called from an "update" function, although it is generic infrastructure.  Better to have it with the other "loosely coupled" code pieces.

`InList` was only used in test, but it's small and I think generally useful.