### PR TITLE
Fix null parent perms

### DIFF
--- a/NuKeeper.GitHub/GitHubRepository.cs
+++ b/NuKeeper.GitHub/GitHubRepository.cs
@@ -10,12 +10,14 @@ namespace NuKeeper.GitHub
         : base(
             repository.Name,
             repository.Archived,
-            new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull),
+            repository.Permissions != null ?
+                new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull) : null,
             new Uri(repository.HtmlUrl),
             new Uri(repository.CloneUrl),
             new User(repository.Owner.Login, repository.Owner.Name, repository.Owner.Email),
             repository.Fork,
-            repository.Parent != null ? new GitHubRepository(repository.Parent) : null
+            repository.Parent != null ?
+                new GitHubRepository(repository.Parent) : null
             )
         {
         }


### PR DESCRIPTION
`repository.Permissions` can be null in the case where you have moved up to the parent repo.
Easy fix for null reference exception, found in test run