### PR TITLE
Collaboration factory

### DIFF
--- a/NuKeeper.Abstractions/CollaborationPlatform/CollaborationPlatformSettings.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/CollaborationPlatformSettings.cs
@@ -6,6 +6,5 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
     {
         public Uri BaseApiUrl { get; set; }
         public string Token { get; set; }
-
     }
 }

--- a/NuKeeper.Abstractions/CollaborationPlatform/CollaborationPlatformSettings.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/CollaborationPlatformSettings.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NuKeeper.Abstractions.CollaborationPlatform
+{
+    public class CollaborationPlatformSettings
+    {
+        public Uri BaseApiUrl { get; set; }
+        public string Token { get; set; }
+
+    }
+}

--- a/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NuKeeper.Abstractions.CollaborationPlatform
+{
+    public interface ICollaborationFactory
+    {
+        CollaborationPlatformSettings Settings { get; }
+        ISettingsReader SettingsReader { get; }
+        void Initialise(Uri apiUri, string token);
+    }
+}

--- a/NuKeeper.Abstractions/CollaborationPlatform/IForkFinder.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/IForkFinder.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.DTOs;
 
-namespace NuKeeper.Engine
+namespace NuKeeper.Abstractions.CollaborationPlatform
 {
     public interface IForkFinder
     {

--- a/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
@@ -6,7 +6,10 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
 {
     public interface ISettingsReader
     {
+        Platform Platform { get; }
+        bool CanRead(Uri repositoryUri);
+
         RepositorySettings RepositorySettings(Uri repositoryUri);
-        AuthSettings AuthSettings(string apiEndpoint, string accessToken);
+        AuthSettings AuthSettings(Uri apiUri, string accessToken);
     }
 }

--- a/NuKeeper.Abstractions/CollaborationPlatform/Platform.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/Platform.cs
@@ -1,0 +1,8 @@
+namespace NuKeeper.Abstractions.CollaborationPlatform
+{
+    public enum Platform
+    {
+        GitHub,
+        AzureDevOps
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
+++ b/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
@@ -21,5 +21,7 @@ namespace NuKeeper.Abstractions.Configuration
         public string RepositoryOwner { get; set; }
 
         public string RepositoryName { get; set; }
+        
+        public Uri ApiUri { get; set; }
     }
 }

--- a/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
+++ b/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
@@ -11,12 +11,12 @@ namespace NuKeeper.Abstractions.Configuration
 
         public RepositorySettings(Repository repository)
         {
-            Uri = repository.HtmlUrl;
+            RepositoryUri = repository.HtmlUrl;
             RepositoryOwner = repository.Owner.Login;
             RepositoryName = repository.Name;
         }
 
-        public Uri Uri { get; set; }
+        public Uri RepositoryUri { get; set; }
 
         public string RepositoryOwner { get; set; }
 

--- a/NuKeeper.Abstractions/Configuration/SettingsContainer.cs
+++ b/NuKeeper.Abstractions/Configuration/SettingsContainer.cs
@@ -4,8 +4,6 @@ namespace NuKeeper.Abstractions.Configuration
     {
         public SourceControlServerSettings SourceControlServerSettings { get; set; }
 
-        public AuthSettings AuthSettings { get; set; }
-
         public UserSettings UserSettings { get; set; }
 
         public FilterSettings PackageFilters { get; set; }

--- a/NuKeeper.AzureDevOps/AzureDevOpsForkFinder.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsForkFinder.cs
@@ -4,7 +4,6 @@ using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Abstractions.Logging;
-using NuKeeper.Engine;
 
 namespace NuKeeper.AzureDevOps
 {

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -11,7 +11,8 @@ namespace NuKeeper.AzureDevOps
     // https://dev.azure.com/{org}/{project}/_git/{repo}/
     public class AzureDevOpsSettingsReader : ISettingsReader
     {
-        public Platform Platform => Platform.AzureDevOps;
+        private const Platform AzureDevOps = Platform.AzureDevOps;
+        public Platform Platform => AzureDevOps;
 
         public bool CanRead(Uri repositoryUri)
         {

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -7,8 +7,6 @@ using NuKeeper.Abstractions.Formats;
 
 namespace NuKeeper.AzureDevOps
 {
-    // URL pattern is
-    // https://dev.azure.com/{org}/{project}/_git/{repo}/
     public class AzureDevOpsSettingsReader : ISettingsReader
     {
         private const Platform AzureDevOps = Platform.AzureDevOps;
@@ -26,7 +24,6 @@ namespace NuKeeper.AzureDevOps
 
         public AuthSettings AuthSettings(Uri apiUri, string accessToken)
         {
-
             if (apiUri == null)
             {
                 return null;
@@ -53,6 +50,8 @@ namespace NuKeeper.AzureDevOps
                 return null;
             }
 
+            // URL pattern is
+            // https://dev.azure.com/{org}/{project}/_git/{repo}/
             var path = repositoryUri.AbsolutePath;
             var pathParts = path.Split('/')
                 .Where(s => !string.IsNullOrWhiteSpace(s))

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -9,8 +9,7 @@ namespace NuKeeper.AzureDevOps
 {
     public class AzureDevOpsSettingsReader : ISettingsReader
     {
-        private const Platform AzureDevOps = Platform.AzureDevOps;
-        public Platform Platform => AzureDevOps;
+        public Platform Platform => Platform.AzureDevOps;
 
         public bool CanRead(Uri repositoryUri)
         {

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -38,9 +38,9 @@ namespace NuKeeper.AzureDevOps
             var req = new PRRequest
             {
                 title = request.Title,
-                sourceRefName = $"refs/heads/{request.BaseRef}",
+                sourceRefName = $"refs/heads/{request.Head}",
                 description = request.Body,
-                targetRefName = $"refs/heads/{request.Head}"
+                targetRefName = $"refs/heads/{request.BaseRef}"
             };
 
             await _client.CreatePullRequest(req, target.Owner, repo.id);

--- a/NuKeeper.GitHub.Tests/AuthSettingsGitHubSettingsReaderTests.cs
+++ b/NuKeeper.GitHub.Tests/AuthSettingsGitHubSettingsReaderTests.cs
@@ -1,6 +1,4 @@
 using System;
-using NSubstitute;
-using NuKeeper.Abstractions.Configuration;
 using NUnit.Framework;
 
 namespace NuKeeper.GitHub.Tests
@@ -11,20 +9,12 @@ namespace NuKeeper.GitHub.Tests
 #pragma warning disable CA1054 // Uri parameters should not be strings
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-        private static GitHubSettingsReader GitHubSettingsReader
-        {
-            get
-            {
-                var settingsCache = Substitute.For<IFileSettingsCache>();
-                settingsCache.GetSettings().Returns(FileSettings.Empty());
-                return new GitHubSettingsReader(settingsCache);
-            }
-        }
+        private static GitHubSettingsReader GitHubSettingsReader => new GitHubSettingsReader();
 
         [Test]
         public void AuthSettings_GetsCorrectSettings()
         {
-            var settings = GitHubSettingsReader.AuthSettings("https://github.custom.com/", "accessToken");
+            var settings = GitHubSettingsReader.AuthSettings(new Uri("https://github.custom.com/"), "accessToken");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiBase, "https://github.custom.com/");
@@ -35,27 +25,13 @@ namespace NuKeeper.GitHub.Tests
         public void AuthSettings_GetsCorrectSettingsFromEnvironment()
         {
             Environment.SetEnvironmentVariable("NuKeeper_github_token","envToken");
-            var settings = GitHubSettingsReader.AuthSettings("https://github.custom.com/", "accessToken");
+            var settings = GitHubSettingsReader.AuthSettings(new Uri("https://github.custom.com/"), "accessToken");
             Environment.SetEnvironmentVariable("NuKeeper_github_token",null);
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiBase, "https://github.custom.com/");
             Assert.AreEqual(settings.Token, "envToken");
 
-        }
-
-        [Test]
-        public void GetsCorrectSettingsFromFile()
-        {
-            var settingsCache = Substitute.For<IFileSettingsCache>();
-            settingsCache.GetSettings().Returns(new FileSettings { Api = "https://github.fromfile.com/" });
-            var gitHubSettingsReader = new GitHubSettingsReader(settingsCache);
-
-            var settings = gitHubSettingsReader.AuthSettings(null, "accessToken");
-
-            Assert.IsNotNull(settings);
-            Assert.AreEqual(settings.ApiBase, "https://github.fromfile.com/");
-            Assert.AreEqual(settings.Token, "accessToken");
         }
 
         [Test]
@@ -71,22 +47,17 @@ namespace NuKeeper.GitHub.Tests
         [Test]
         public void GetsCorrectSettingWithMissingSlash()
         {
-            var settings = GitHubSettingsReader.AuthSettings("https://api.github.com", "accessToken");
+            var settings = GitHubSettingsReader.AuthSettings(new Uri("https://api.github.com"), "accessToken");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiBase, "https://api.github.com/");
             Assert.AreEqual(settings.Token, "accessToken");
         }
 
-        [DatapointSource]
-        public string[] AuthSettingBadUrlValues = {
-            "https://github.com/owner/",
-            "htps://github.com/"
-        };
         [Theory]
-        public void InvalidUrlReturnsNull(string uri)
+        public void InvalidUrlReturnsNull()
         {
-            var settings = GitHubSettingsReader.AuthSettings(uri, "accessToken");
+            var settings = GitHubSettingsReader.AuthSettings(new Uri("htps://github.com/"), "accessToken");
 
             Assert.IsNull(settings);
         }

--- a/NuKeeper.GitHub.Tests/AuthSettingsGitHubSettingsReaderTests.cs
+++ b/NuKeeper.GitHub.Tests/AuthSettingsGitHubSettingsReaderTests.cs
@@ -35,16 +35,6 @@ namespace NuKeeper.GitHub.Tests
         }
 
         [Test]
-        public void GetsCorrectSettingFromFallback()
-        {
-            var settings = GitHubSettingsReader.AuthSettings(null, "accessToken");
-
-            Assert.IsNotNull(settings);
-            Assert.AreEqual(settings.ApiBase, "https://api.github.com/");
-            Assert.AreEqual(settings.Token, "accessToken");
-        }
-
-        [Test]
         public void GetsCorrectSettingWithMissingSlash()
         {
             var settings = GitHubSettingsReader.AuthSettings(new Uri("https://api.github.com"), "accessToken");
@@ -54,10 +44,15 @@ namespace NuKeeper.GitHub.Tests
             Assert.AreEqual(settings.Token, "accessToken");
         }
 
+        [DatapointSource]
+        public Uri[] Values = {
+            null,
+            new Uri("htps://missingt.com"),
+        };
         [Theory]
-        public void InvalidUrlReturnsNull()
+        public void InvalidUrlReturnsNull(Uri uri)
         {
-            var settings = GitHubSettingsReader.AuthSettings(new Uri("htps://github.com/"), "accessToken");
+            var settings = GitHubSettingsReader.AuthSettings(uri, "accessToken");
 
             Assert.IsNull(settings);
         }

--- a/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
@@ -96,7 +96,7 @@ namespace NuKeeper.GitHub.Tests
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[0].Name));
-            Assert.That(firstRepo.Uri.ToString(), Is.EqualTo(inputRepos[0].HtmlUrl));
+            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[0].HtmlUrl));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NuKeeper.GitHub.Tests
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[1].Name));
-            Assert.That(firstRepo.Uri.ToString(), Is.EqualTo(inputRepos[1].HtmlUrl));
+            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[1].HtmlUrl));
         }
 
         [Test]

--- a/NuKeeper.GitHub.Tests/RepositorySettingsGitHubSettingsReaderTests.cs
+++ b/NuKeeper.GitHub.Tests/RepositorySettingsGitHubSettingsReaderTests.cs
@@ -1,6 +1,4 @@
 using System;
-using NSubstitute;
-using NuKeeper.Abstractions.Configuration;
 using NUnit.Framework;
 
 namespace NuKeeper.GitHub.Tests
@@ -9,15 +7,7 @@ namespace NuKeeper.GitHub.Tests
     public class RepositorySettingsGitHubSettingsReaderTests
     {
 #pragma warning disable CA1051 // Do not declare visible instance fields
-        private static GitHubSettingsReader GitHubSettingsReader
-        {
-            get
-            {
-                var settingsCache = Substitute.For<IFileSettingsCache>();
-                settingsCache.GetSettings().Returns(FileSettings.Empty());
-                return new GitHubSettingsReader(settingsCache);
-            }
-        }
+        private static GitHubSettingsReader GitHubSettingsReader => new GitHubSettingsReader();
 
         [Test]
         public void RepositorySettings_GetsCorrectSettings()
@@ -25,7 +15,7 @@ namespace NuKeeper.GitHub.Tests
             var settings = GitHubSettingsReader.RepositorySettings(new Uri("https://github.com/owner/reponame.git"));
 
             Assert.IsNotNull(settings);
-            Assert.AreEqual(settings.Uri, "https://github.com/owner/reponame.git");
+            Assert.AreEqual(settings.RepositoryUri, "https://github.com/owner/reponame.git");
             Assert.AreEqual(settings.RepositoryName, "reponame");
             Assert.AreEqual(settings.RepositoryOwner, "owner");
         }

--- a/NuKeeper.GitHub/GitHubForkFinder.cs
+++ b/NuKeeper.GitHub/GitHubForkFinder.cs
@@ -4,7 +4,6 @@ using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Abstractions.Logging;
-using NuKeeper.Engine;
 
 namespace NuKeeper.GitHub
 {

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -9,7 +9,8 @@ namespace NuKeeper.GitHub
 {
     public class GitHubSettingsReader : ISettingsReader
     {
-        public Platform Platform => Platform.GitHub;
+        private const Platform GitHub = Platform.GitHub;
+        public Platform Platform => GitHub;
 
         public bool CanRead(Uri repositoryUri)
         {
@@ -23,10 +24,10 @@ namespace NuKeeper.GitHub
                 return null;
             }
 
-            var testUri = UriFormats.EnsureTrailingSlash(apiUri);
+            apiUri = UriFormats.EnsureTrailingSlash(apiUri);
 
-            if (!testUri.IsWellFormedOriginalString()
-                || (testUri.Scheme != "http" && testUri.Scheme != "https"))
+            if (!apiUri.IsWellFormedOriginalString()
+                || (apiUri.Scheme != "http" && apiUri.Scheme != "https"))
             {
                 return null;
             }
@@ -34,7 +35,7 @@ namespace NuKeeper.GitHub
             var envToken = Environment.GetEnvironmentVariable("NuKeeper_github_token");
             var token = Concat.FirstValue(envToken, accessToken);
 
-            return new AuthSettings(testUri, token);
+            return new AuthSettings(apiUri, token);
         }
 
         public RepositorySettings RepositorySettings(Uri repositoryUri)

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -9,8 +9,7 @@ namespace NuKeeper.GitHub
 {
     public class GitHubSettingsReader : ISettingsReader
     {
-        private const Platform GitHub = Platform.GitHub;
-        public Platform Platform => GitHub;
+        public Platform Platform => Platform.GitHub;
 
         public bool CanRead(Uri repositoryUri)
         {

--- a/NuKeeper.Tests/Commands/GlobalCommandTests.cs
+++ b/NuKeeper.Tests/Commands/GlobalCommandTests.cs
@@ -49,7 +49,7 @@ namespace NuKeeper.Tests.Commands
             var command = new GlobalCommand(engine, logger, fileSettings, collaborationFactory);
             command.GitHubToken = "testToken";
             command.Include = "testRepos";
-            command.GithubApiEndpoint = "https://github.contoso.com";
+            command.ApiEndpoint = "https://github.contoso.com";
 
             var status = await command.OnExecute();
 
@@ -217,7 +217,7 @@ namespace NuKeeper.Tests.Commands
             var command = new GlobalCommand(engine, logger, fileSettings, collaborationFactory)
             {
                 GitHubToken = "testToken",
-                GithubApiEndpoint = settingsIn.Api ?? "http://github.contoso.com/",
+                ApiEndpoint = settingsIn.Api ?? "http://github.contoso.com/",
                 Include = settingsIn.Include ?? "testRepos"
             };
 

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -24,9 +24,10 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var settingsReader = new GitHubSettingsReader(fileSettings);
+            var collaborationFactory = Substitute.For<ICollaborationFactory>();
+            collaborationFactory.SettingsReader.Returns(new GitHubSettingsReader());
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, settingsReader);
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory);
 
             var status = await command.OnExecute();
 
@@ -44,11 +45,13 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var settingsReader = new GitHubSettingsReader(fileSettings);
+            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, settingsReader);
-            command.GitHubToken = "abc";
-            command.GitHubRepositoryUri = "http://github.com/abc/abc";
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory)
+            {
+                GitHubToken = "abc",
+                GitHubRepositoryUri = "http://github.com/abc/abc"
+            };
 
             var status = await command.OnExecute();
 
@@ -63,12 +66,13 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = FileSettings.Empty();
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, platformSettings) = await CaptureSettings(fileSettings);
+
+            Assert.That(platformSettings, Is.Not.Null);
+            Assert.That(platformSettings.Token, Is.Not.Null);
+            Assert.That(platformSettings.Token, Is.EqualTo("testToken"));
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.AuthSettings, Is.Not.Null);
-            Assert.That(settings.AuthSettings.Token, Is.EqualTo("testToken"));
-
             Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
             Assert.That(settings.SourceControlServerSettings.Scope, Is.EqualTo(ServerScope.Repository));
             Assert.That(settings.SourceControlServerSettings.OrganisationName, Is.Null);
@@ -79,22 +83,21 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = FileSettings.Empty();
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, _) = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.PackageFilters, Is.Not.Null);
-            Assert.That(settings.UserSettings, Is.Not.Null);
 
+            Assert.That(settings.PackageFilters, Is.Not.Null);
             Assert.That(settings.PackageFilters.MinimumAge, Is.EqualTo(TimeSpan.FromDays(7)));
             Assert.That(settings.PackageFilters.Excludes, Is.Null);
             Assert.That(settings.PackageFilters.Includes, Is.Null);
             Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(3));
 
+            Assert.That(settings.UserSettings, Is.Not.Null);
             Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
             Assert.That(settings.UserSettings.NuGetSources, Is.Null);
             Assert.That(settings.UserSettings.OutputDestination, Is.EqualTo(OutputDestination.Console));
             Assert.That(settings.UserSettings.OutputFormat, Is.EqualTo(OutputFormat.Text));
-
             Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
             Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.False);
 
@@ -110,12 +113,11 @@ namespace NuKeeper.Tests.Commands
                 Api = "http://github.contoso.com/"
             };
 
-            var settings = await CaptureSettings(fileSettings);
+            var (_, platformSettings) = await CaptureSettings(fileSettings);
 
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.AuthSettings, Is.Not.Null);
-            Assert.That(settings.AuthSettings.ApiBase, Is.Not.Null);
-            Assert.That(settings.AuthSettings.ApiBase, Is.EqualTo(new Uri("http://github.contoso.com/")));
+            Assert.That(platformSettings, Is.Not.Null);
+            Assert.That(platformSettings.BaseApiUrl, Is.Not.Null);
+            Assert.That(platformSettings.BaseApiUrl, Is.EqualTo(new Uri("http://github.contoso.com/")));
         }
 
         [Test]
@@ -123,10 +125,10 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                Label = new List<string> { "testLabel" }
+                Label = new List<string> {"testLabel"}
             };
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, _) = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
@@ -143,7 +145,7 @@ namespace NuKeeper.Tests.Commands
                 MaxPr = 42
             };
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, _) = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.PackageFilters, Is.Not.Null);
@@ -158,7 +160,7 @@ namespace NuKeeper.Tests.Commands
                 Consolidate = true
             };
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, _) = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.True);
@@ -172,7 +174,7 @@ namespace NuKeeper.Tests.Commands
                 MaxRepo = 42
             };
 
-            var settings = await CaptureSettings(fileSettings);
+            var (settings, _) = await CaptureSettings(fileSettings);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.PackageFilters, Is.Not.Null);
@@ -187,7 +189,7 @@ namespace NuKeeper.Tests.Commands
                 MaxPr = 42
             };
 
-            var settings = await CaptureSettings(fileSettings, false, 101);
+            var (settings, _) = await CaptureSettings(fileSettings, false, 101);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.PackageFilters, Is.Not.Null);
@@ -199,10 +201,10 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                Label = new List<string> { "testLabel" }
+                Label = new List<string> {"testLabel"}
             };
 
-            var settings = await CaptureSettings(fileSettings, true);
+            var (settings, _) = await CaptureSettings(fileSettings, true);
 
             Assert.That(settings, Is.Not.Null);
             Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
@@ -213,33 +215,34 @@ namespace NuKeeper.Tests.Commands
             Assert.That(settings.SourceControlServerSettings.Labels, Does.Not.Contain("testLabel"));
         }
 
-        public static async Task<SettingsContainer> CaptureSettings(FileSettings settingsIn,
+        public static async Task<(SettingsContainer settingsContainer, CollaborationPlatformSettings platformSettings)> CaptureSettings(FileSettings settingsIn,
             bool addLabels = false,
             int? maxPr = null)
         {
             var logger = Substitute.For<IConfigureLogger>();
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(settingsIn);
-            var settingsReader = new GitHubSettingsReader(fileSettings);
+
+            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
 
             SettingsContainer settingsOut = null;
             var engine = Substitute.For<ICollaborationEngine>();
             await engine.Run(Arg.Do<SettingsContainer>(x => settingsOut = x));
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, settingsReader);
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory);
             command.GitHubToken = "testToken";
             command.GitHubRepositoryUri = "http://github.com/test/test";
 
             if (addLabels)
             {
-                command.Label = new List<string> { "runLabel1", "runLabel2"};
+                command.Label = new List<string> {"runLabel1", "runLabel2"};
             }
 
             command.MaxPullRequestsPerRepository = maxPr;
 
             await command.OnExecute();
 
-            return settingsOut;
+            return (settingsOut, collaborationFactory.Settings);
         }
     }
 }

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -24,10 +24,11 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = Substitute.For<ICollaborationFactory>();
-            collaborationFactory.SettingsReader.Returns(new GitHubSettingsReader());
+            var settingReader = new GitHubSettingsReader();
+            var settingsReaders = new List<ISettingsReader> {settingReader};
+            var collaborationFactory = new CollaborationFactory(settingsReaders);
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory);
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
 
             var status = await command.OnExecute();
 
@@ -45,9 +46,11 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var settingReader = new GitHubSettingsReader();
+            var settingsReaders = new List<ISettingsReader> {settingReader};
+            var collaborationFactory = new CollaborationFactory(settingsReaders);
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory)
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders)
             {
                 GitHubToken = "abc",
                 GitHubRepositoryUri = "http://github.com/abc/abc"
@@ -223,13 +226,15 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(settingsIn);
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var settingReader = new GitHubSettingsReader();
+            var settingsReaders = new List<ISettingsReader> {settingReader};
+            var collaborationFactory = new CollaborationFactory(settingsReaders);
 
             SettingsContainer settingsOut = null;
             var engine = Substitute.For<ICollaborationEngine>();
             await engine.Run(Arg.Do<SettingsContainer>(x => settingsOut = x));
 
-            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory);
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
             command.GitHubToken = "testToken";
             command.GitHubRepositoryUri = "http://github.com/test/test";
 

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -61,8 +61,7 @@ namespace NuKeeper.Commands
 
             var fileSettings = FileSettingsCache.GetSettings();
 
-            //Fallback for global and Org commands (for now)
-            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, settings.SourceControlServerSettings.Repository?.ApiUri.ToString(),"https://api.github.com/"); 
+            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, settings.SourceControlServerSettings.Repository?.ApiUri.ToString()); 
 
             if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var baseUri))
             {

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -22,7 +22,6 @@ namespace NuKeeper.Commands
         [Option(CommandOptionType.SingleValue, ShortName = "f", LongName = "fork",
             Description =
                 "Prefer to make branches on a fork of the writer repository, or on that repository itself. Allowed values are PreferFork, PreferSingleRepository, SingleRepositoryOnly. Defaults to PreferFork.")]
-        // ReSharper disable once MemberCanBePrivate.Global
         protected ForkMode ForkMode { get; } = ForkMode.PreferFork;
 
         [Option(CommandOptionType.SingleValue, ShortName = "p", LongName = "maxpr",
@@ -40,8 +39,8 @@ namespace NuKeeper.Commands
 
         [Option(CommandOptionType.SingleValue, ShortName = "g", LongName = "api",
             Description =
-                "GitHub Api Base Url. If you are using an internal GitHub server and not the public one, you must set it to the api url for your GitHub server.")]
-        public string GithubApiEndpoint { get; set; }
+                "Api Base Url. If you are using an internal server and not a public one, you must set it to the api url of your server.")]
+        public string ApiEndpoint { get; set; }
 
         protected GitHubNuKeeperCommand(ICollaborationEngine engine, IConfigureLogger logger,
             IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory) :
@@ -61,7 +60,7 @@ namespace NuKeeper.Commands
 
             var fileSettings = FileSettingsCache.GetSettings();
 
-            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, settings.SourceControlServerSettings.Repository?.ApiUri.ToString()); 
+            var endpoint = Concat.FirstValue(ApiEndpoint, fileSettings.Api, settings.SourceControlServerSettings.Repository?.ApiUri.ToString()); 
 
             if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var baseUri))
             {

--- a/NuKeeper/Commands/GitHubNuKeeperCommand.cs
+++ b/NuKeeper/Commands/GitHubNuKeeperCommand.cs
@@ -62,11 +62,11 @@ namespace NuKeeper.Commands
             var fileSettings = FileSettingsCache.GetSettings();
 
             //Fallback for global and Org commands (for now)
-            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api ?? "https://api.github.com/"); 
+            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, settings.SourceControlServerSettings.Repository?.ApiUri.ToString(),"https://api.github.com/"); 
 
             if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var baseUri))
             {
-                return ValidationResult.Failure($"Bad Api Base '{GithubApiEndpoint}'");
+                return ValidationResult.Failure($"Bad Api Base '{endpoint}'");
             }
 
             CollaborationFactory.Initialise(baseUri, GitHubToken);

--- a/NuKeeper/Commands/GlobalCommand.cs
+++ b/NuKeeper/Commands/GlobalCommand.cs
@@ -10,8 +10,8 @@ namespace NuKeeper.Commands
     [Command(Description = "Performs version checks and generates pull requests for all repositories the provided token can access.")]
     internal class GlobalCommand : MultipleRepositoryCommand
     {
-        public GlobalCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ISettingsReader settingsReader)
-            : base(engine, logger, fileSettingsCache, settingsReader)
+        public GlobalCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
+            : base(engine, logger, fileSettingsCache, collaborationFactory)
         {
         }
 
@@ -30,7 +30,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure("Global mode must have an include regex");
             }
 
-            var apiHost = settings.AuthSettings.ApiBase.Host;
+            var apiHost = CollaborationFactory.Settings.BaseApiUrl.Host;
             if (apiHost.EndsWith("github.com", StringComparison.OrdinalIgnoreCase))
             {
                 return ValidationResult.Failure("Global mode must not use public github");

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -22,8 +22,8 @@ namespace NuKeeper.Commands
         public int? AllowedMaxRepositoriesChangedChange { get; set; }
 
 
-        protected MultipleRepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ISettingsReader settingsReader)
-            : base(engine, logger, fileSettingsCache, settingsReader)
+        protected MultipleRepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
+            : base(engine, logger, fileSettingsCache, collaborationFactory)
         {
         }
 

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -1,4 +1,5 @@
 using McMaster.Extensions.CommandLineUtils;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Engine;
@@ -19,6 +20,9 @@ namespace NuKeeper.Commands
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
+            var fileSettings = FileSettingsCache.GetSettings();
+            GithubApiEndpoint =  Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, "https://api.github.com"); 
+
             var baseResult = base.PopulateSettings(settings);
             if (!baseResult.IsSuccess)
             {

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -12,8 +12,8 @@ namespace NuKeeper.Commands
         [Argument(0, Name = "GitHub organisation name", Description = "The organisation to scan.")]
         public string GithubOrganisationName { get; set; }
 
-        public OrganisationCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ISettingsReader settingsReader)
-            : base(engine, logger, fileSettingsCache, settingsReader)
+        public OrganisationCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
+            : base(engine, logger, fileSettingsCache, collaborationFactory)
         {
         }
 

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Commands
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
             var fileSettings = FileSettingsCache.GetSettings();
-            GithubApiEndpoint =  Concat.FirstValue(GithubApiEndpoint, fileSettings.Api, "https://api.github.com"); 
+            ApiEndpoint =  Concat.FirstValue(ApiEndpoint, fileSettings.Api, "https://api.github.com"); 
 
             var baseResult = base.PopulateSettings(settings);
             if (!baseResult.IsSuccess)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Commands
 
             if (!didRead)
             {
-                return ValidationResult.Failure($"Unable to work out which platform to use");
+                return ValidationResult.Failure($"Unable to work out which platform to use {GitHubRepositoryUri} could not be matched");
             }
 
             var baseResult = base.PopulateSettings(settings);

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -1,45 +1,62 @@
-using System;
 using McMaster.Extensions.CommandLineUtils;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.Logging;
+using System;
+using System.Linq;
+using NuKeeper.Abstractions;
 
 namespace NuKeeper.Commands
 {
     [Command(Description = "Performs version checks and generates pull requests for a single repository.")]
     internal class RepositoryCommand : GitHubNuKeeperCommand
     {
-
         [Argument(0, Name = "Repository URI", Description = "The URI of the repository to scan.")]
         public string GitHubRepositoryUri { get; set; }
 
-        public RepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ISettingsReader settingsReader)
-            : base(engine, logger, fileSettingsCache, settingsReader)
+        public RepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
+            : base(engine, logger, fileSettingsCache, collaborationFactory)
         {
         }
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
+            if (!Uri.TryCreate(GitHubRepositoryUri, UriKind.Absolute, out var repoUri))
+            {
+                return ValidationResult.Failure($"Bad repository URI: '{GitHubRepositoryUri}'");
+            }
+            var fileSettings = FileSettingsCache.GetSettings();
+            var endpoint = Concat.FirstValue(GithubApiEndpoint, fileSettings.Api);
+
+            if (repoUri.Host == "github.com")
+            {
+                GithubApiEndpoint = endpoint ?? "https://api.github.com/";
+            }
+
+            if (repoUri.Host == "dev.azure.com")
+            {
+                var path = repoUri.AbsolutePath;
+                var pathParts = path.Split('/')
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToList();
+                GithubApiEndpoint = endpoint ?? $"https://dev.azure.com/{pathParts[0]}";
+            }
+
             var baseResult = base.PopulateSettings(settings);
             if (!baseResult.IsSuccess)
             {
                 return baseResult;
             }
 
-            if (!Uri.TryCreate(GitHubRepositoryUri, UriKind.Absolute, out var repoUri))
-            {
-                return ValidationResult.Failure($"Bad repository URI: '{GitHubRepositoryUri}'");
-            }
-
-            settings.SourceControlServerSettings.Repository = SettingsReader.RepositorySettings(repoUri);
+            settings.SourceControlServerSettings.Repository = CollaborationFactory.SettingsReader.RepositorySettings(repoUri);
             if (settings.SourceControlServerSettings.Repository == null)
             {
                 return ValidationResult.Failure($"Could not read repository URI: '{GitHubRepositoryUri}'");
             }
 
-            settings.UserSettings.MaxRepositoriesChanged = 1;
             settings.SourceControlServerSettings.Scope = ServerScope.Repository;
+            settings.UserSettings.MaxRepositoriesChanged = 1;
             return ValidationResult.Success;
         }
     }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -42,14 +42,14 @@ namespace NuKeeper
             container.Collection.Register<ISettingsReader>(typeof(GitHubSettingsReader), typeof(AzureDevOpsSettingsReader));
 
             //GitHub Registrations
-            //container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
-            //container.Register<IForkFinder, GitHubForkFinder>();
-            //container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
+            container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
+            container.Register<IForkFinder, GitHubForkFinder>();
+            container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
 
             //Azure Registrations
-            container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
-            container.Register<IForkFinder, AzureDevOpsForkFinder>();
-            container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
+            //container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
+            //container.Register<IForkFinder, AzureDevOpsForkFinder>();
+            //container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
         }
     }
 }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -38,17 +38,18 @@ namespace NuKeeper
             container.Register<IUpdateSelection, UpdateSelection>();
             container.Register<IFileSettingsCache, FileSettingsCache>();
 
+            container.RegisterSingleton<ICollaborationFactory,CollaborationFactory>();
+            container.Collection.Register<ISettingsReader>(typeof(GitHubSettingsReader), typeof(AzureDevOpsSettingsReader));
+
             //GitHub Registrations
-            container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
-            container.Register<ISettingsReader, GitHubSettingsReader>();
-            container.Register<IForkFinder, GitHubForkFinder>();
-            container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
+            //container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
+            //container.Register<IForkFinder, GitHubForkFinder>();
+            //container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
 
             //Azure Registrations
-            //container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
-            //container.Register<ISettingsReader, AzureDevOpsSettingsReader>();
-            //container.Register<IForkFinder, AzureDevOpsForkFinder>();
-            //container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
+            container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
+            container.Register<IForkFinder, AzureDevOpsForkFinder>();
+            container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
         }
     }
 }

--- a/NuKeeper/Engine/CollaborationFactory.cs
+++ b/NuKeeper/Engine/CollaborationFactory.cs
@@ -1,0 +1,43 @@
+using NuKeeper.Abstractions.CollaborationPlatform;
+using System;
+using System.Collections.Generic;
+using NuKeeper.Abstractions;
+
+namespace NuKeeper.Engine
+{
+    public class CollaborationFactory : ICollaborationFactory
+    {
+        private readonly IEnumerable<ISettingsReader> _settingReaders;
+        public ISettingsReader SettingsReader { get; private set; }
+        public CollaborationPlatformSettings Settings { get; }
+        public Platform Platform { get; private set; }
+
+        public CollaborationFactory(IEnumerable<ISettingsReader> settingReaders)
+        {
+            _settingReaders = settingReaders;
+            SettingsReader = null;
+            Settings = new CollaborationPlatformSettings();
+        }
+
+        public void Initialise(Uri apiEndpoint, string token)
+        {
+            foreach (var settingReader in _settingReaders)
+            {
+                if (settingReader.CanRead(apiEndpoint))
+                {
+                    SettingsReader = settingReader;
+                    Platform = settingReader.Platform;
+                }
+            }
+
+            if (SettingsReader == null)
+            {
+                throw new NuKeeperException("Unable to work out platform");
+            }
+
+            var settings = SettingsReader.AuthSettings(apiEndpoint, token);
+            Settings.BaseApiUrl = settings.ApiBase;
+            Settings.Token = settings.Token;
+        }
+    }
+}

--- a/NuKeeper/Engine/CollaborationFactory.cs
+++ b/NuKeeper/Engine/CollaborationFactory.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.Engine
 
             if (SettingsReader == null)
             {
-                throw new NuKeeperException("Unable to work out platform");
+                throw new NuKeeperException($"Unable to work out platform for uri {apiEndpoint}");
             }
 
             var settings = SettingsReader.AuthSettings(apiEndpoint, token);

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -69,12 +69,12 @@ namespace NuKeeper.Engine
             ForkMode forkMode,
             string userName)
         {
-            var pullFork = new ForkData(repository.Uri, repository.RepositoryOwner, repository.RepositoryName);
+            var pullFork = new ForkData(repository.RepositoryUri, repository.RepositoryOwner, repository.RepositoryName);
             var pushFork = await _forkFinder.FindPushFork(forkMode, userName, pullFork);
 
             if (pushFork == null)
             {
-                _logger.Normal($"No pushable fork found for {repository.Uri}");
+                _logger.Normal($"No pushable fork found for {repository.RepositoryUri}");
                 return null;
             }
 

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using LibGit2Sharp;
+using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.DTOs;
 using NuKeeper.Abstractions.Logging;


### PR DESCRIPTION
Add the start of the collaboration factory,

Have spit this into sections as it was getting too large to submit in one go.

After swapping registrations in `ContainerRegistration` allows you to run:
`repo https://dev.azure.com/<org>/<project>/_git/<repo> <token> --fork=SingleRepositoryOnly`

Only works for new style Azure uri's, support could be added for legacy scheme by implementing a new setting reader in a future PR

**Changes**

- Move auth settings into the CollaborationFactory
- Use an IEnumerable<ISettingReaders>> to find which platform a Uri is for and set the default api accordingly.
- Added a `Platform` enum to be able to easily tell which platform is being used



