### PR TITLE
Enhance collaboration factory

### DIFF
--- a/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
@@ -7,5 +7,6 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
         CollaborationPlatformSettings Settings { get; }
         ISettingsReader SettingsReader { get; }
         void Initialise(Uri apiUri, string token);
+        IForkFinder ForkFinder { get; }
     }
 }

--- a/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
@@ -8,5 +8,6 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
         ISettingsReader SettingsReader { get; }
         void Initialise(Uri apiUri, string token);
         IForkFinder ForkFinder { get; }
+        IRepositoryDiscovery RepositoryDiscovery { get; }
     }
 }

--- a/NuKeeper.Abstractions/CollaborationPlatform/IRepositoryDiscovery.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/IRepositoryDiscovery.cs
@@ -6,6 +6,6 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
 {
     public interface IRepositoryDiscovery
     {
-        Task<IEnumerable<RepositorySettings>> GetRepositories(ICollaborationPlatform collaborationPlatform, SourceControlServerSettings settings);
+        Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings);
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
@@ -12,14 +12,12 @@ namespace NuKeeper.AzureDevOps
     {
         private readonly INuKeeperLogger _logger;
 
-        public AzureDevOpsRepositoryDiscovery(
-            INuKeeperLogger logger)
+        public AzureDevOpsRepositoryDiscovery(INuKeeperLogger logger)
         {
             _logger = logger;
         }
 
-        public Task<IEnumerable<RepositorySettings>> GetRepositories(
-            ICollaborationPlatform collaborationPlatform, SourceControlServerSettings settings)
+        public Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings)
         {
             switch (settings.Scope)
             {

--- a/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
@@ -17,7 +17,6 @@ namespace NuKeeper.GitHub.Tests
         [Test]
         public async Task SuccessInRepoMode()
         {
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
             var settings = new SourceControlServerSettings
             {
                 Repository = new RepositorySettings(),
@@ -26,7 +25,7 @@ namespace NuKeeper.GitHub.Tests
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
 
-            var reposResponse = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, settings);
+            var reposResponse = await githubRepositoryDiscovery.GetRepositories(settings);
 
             var repos = reposResponse.ToList();
 
@@ -38,7 +37,6 @@ namespace NuKeeper.GitHub.Tests
         [Test]
         public async Task RepoModeIgnoresIncludesAndExcludes()
         {
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
             var settings = new SourceControlServerSettings
             {
                 Repository = new RepositorySettings(RepositoryBuilder.MakeRepository(name: "foo")),
@@ -49,7 +47,7 @@ namespace NuKeeper.GitHub.Tests
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
 
-            var reposResponse = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, settings);
+            var reposResponse = await githubRepositoryDiscovery.GetRepositories(settings);
 
             var repos = reposResponse.ToList();
 
@@ -63,11 +61,9 @@ namespace NuKeeper.GitHub.Tests
         [Test]
         public async Task SuccessInOrgMode()
         {
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
 
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, OrgModeSettings());
+            var repos = await githubRepositoryDiscovery.GetRepositories(OrgModeSettings());
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Empty);
@@ -80,15 +76,10 @@ namespace NuKeeper.GitHub.Tests
             {
                 RepositoryBuilder.MakeRepository()
             };
-            IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
-                .Returns(Task.FromResult(readOnlyRepos));
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
 
-            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
-
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, OrgModeSettings());
+            var repos = await githubRepositoryDiscovery.GetRepositories(OrgModeSettings());
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -107,15 +98,10 @@ namespace NuKeeper.GitHub.Tests
                 RepositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
                 RepositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
             };
-            IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
-                .Returns(Task.FromResult(readOnlyRepos));
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
 
-            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
-
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, OrgModeSettings());
+            var repos = await githubRepositoryDiscovery.GetRepositories(OrgModeSettings());
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -134,17 +120,12 @@ namespace NuKeeper.GitHub.Tests
                 RepositoryBuilder.MakeRepository(name:"foo"),
                 RepositoryBuilder.MakeRepository(name:"bar")
             };
-            IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
-                .Returns(Task.FromResult(readOnlyRepos));
-
-            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
 
             var settings = OrgModeSettings();
             settings.IncludeRepos = new Regex("^bar");
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, settings);
+            var repos = await githubRepositoryDiscovery.GetRepositories(settings);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -162,17 +143,12 @@ namespace NuKeeper.GitHub.Tests
                 RepositoryBuilder.MakeRepository(name:"foo"),
                 RepositoryBuilder.MakeRepository(name:"bar")
             };
-            IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
-                .Returns(Task.FromResult(readOnlyRepos));
-
-            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
 
             var settings = OrgModeSettings();
             settings.ExcludeRepos = new Regex("^bar");
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, settings);
+            var repos = await githubRepositoryDiscovery.GetRepositories(settings);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos, Is.Not.Empty);
@@ -190,26 +166,24 @@ namespace NuKeeper.GitHub.Tests
                 RepositoryBuilder.MakeRepository(name:"foo"),
                 RepositoryBuilder.MakeRepository(name:"bar")
             };
-            IReadOnlyList<Repository> readOnlyRepos = inputRepos.AsReadOnly();
 
-            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
-                .Returns(Task.FromResult(readOnlyRepos));
-
-            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery();
+            var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
 
             var settings = OrgModeSettings();
             settings.IncludeRepos = new Regex("^bar");
             settings.ExcludeRepos = new Regex("^bar");
-            var repos = await githubRepositoryDiscovery.GetRepositories(collaborationPlatform, settings);
+            var repos = await githubRepositoryDiscovery.GetRepositories(settings);
 
             Assert.That(repos, Is.Not.Null);
             Assert.That(repos.Count(), Is.EqualTo(0));
         }
 
-        private static IRepositoryDiscovery MakeGithubRepositoryDiscovery()
+        private static IRepositoryDiscovery MakeGithubRepositoryDiscovery(IReadOnlyList<Repository> repositories = null)
         {
-            return new GitHubRepositoryDiscovery(Substitute.For<INuKeeperLogger>());
+            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
+            collaborationPlatform.GetRepositoriesForOrganisation(Arg.Any<string>())
+                .Returns(Task.FromResult(repositories ?? new List<Repository>()));
+            return new GitHubRepositoryDiscovery(Substitute.For<INuKeeperLogger>(), collaborationPlatform);
         }
 
         private static SourceControlServerSettings OrgModeSettings()

--- a/NuKeeper.Tests/Commands/GlobalCommandTests.cs
+++ b/NuKeeper.Tests/Commands/GlobalCommandTests.cs
@@ -10,12 +10,22 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Tests.Commands
 {
     [TestFixture]
     public class GlobalCommandTests
     {
+        private static CollaborationFactory GetCollaborationFactory()
+        {
+            return new CollaborationFactory(
+                new ISettingsReader[] {new GitHubSettingsReader()},
+                Substitute.For<ICollaborationPlatform>(),
+                Substitute.For<INuKeeperLogger>()
+            );
+        }
+
         [Test]
         public async Task ShouldCallEngineAndNotSucceedWithoutParams()
         {
@@ -24,7 +34,7 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var collaborationFactory = GetCollaborationFactory();
 
             var command = new GlobalCommand(engine, logger, fileSettings, collaborationFactory);
 
@@ -44,7 +54,7 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var collaborationFactory = GetCollaborationFactory();
 
             var command = new GlobalCommand(engine, logger, fileSettings, collaborationFactory);
             command.GitHubToken = "testToken";
@@ -208,7 +218,7 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(settingsIn);
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var collaborationFactory = GetCollaborationFactory();
 
             SettingsContainer settingsOut = null;
             var engine = Substitute.For<ICollaborationEngine>();

--- a/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
+++ b/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.Logging;
 using NuKeeper.GitHub;
 
 namespace NuKeeper.Tests.Commands
@@ -16,6 +17,15 @@ namespace NuKeeper.Tests.Commands
     [TestFixture]
     public class OrganisationCommandTests
     {
+        private static CollaborationFactory GetCollaborationFactory()
+        {
+            return new CollaborationFactory(
+                new ISettingsReader[] {new GitHubSettingsReader()},
+                Substitute.For<ICollaborationPlatform>(),
+                Substitute.For<INuKeeperLogger>()
+            );
+        }
+
         [Test]
         public async Task ShouldCallEngineAndNotSucceedWithoutParams()
         {
@@ -23,7 +33,7 @@ namespace NuKeeper.Tests.Commands
             var logger = Substitute.For<IConfigureLogger>();
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var collaborationFactory = GetCollaborationFactory();
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
 
@@ -43,7 +53,7 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+            var collaborationFactory = GetCollaborationFactory();
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
             command.GitHubToken = "abc";
@@ -249,9 +259,9 @@ namespace NuKeeper.Tests.Commands
             var engine = Substitute.For<ICollaborationEngine>();
             await engine.Run(Arg.Do<SettingsContainer>(x => settingsOut = x));
 
-
             fileSettings.GetSettings().Returns(settingsIn);
-            var collaborationFactory = new CollaborationFactory(new ISettingsReader[] {new GitHubSettingsReader()});
+
+            var collaborationFactory = GetCollaborationFactory();
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
             command.GitHubToken = "testToken";

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.Output;
 using NuKeeper.Commands;
 using NuKeeper.Engine;
@@ -16,6 +17,15 @@ namespace NuKeeper.Tests.Commands
     [TestFixture]
     public class RepositoryCommandTests
     {
+        private static CollaborationFactory GetCollaborationFactory(IEnumerable<ISettingsReader> settingReaders = null)
+        {
+            return new CollaborationFactory(
+                settingReaders ?? new ISettingsReader[] {new GitHubSettingsReader()},
+                Substitute.For<ICollaborationPlatform>(),
+                Substitute.For<INuKeeperLogger>()
+            );
+        }
+
         [Test]
         public async Task ShouldCallEngineAndNotSucceedWithoutParams()
         {
@@ -26,7 +36,7 @@ namespace NuKeeper.Tests.Commands
 
             var settingReader = new GitHubSettingsReader();
             var settingsReaders = new List<ISettingsReader> {settingReader};
-            var collaborationFactory = new CollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(settingsReaders);
 
             var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
 
@@ -48,7 +58,7 @@ namespace NuKeeper.Tests.Commands
 
             var settingReader = new GitHubSettingsReader();
             var settingsReaders = new List<ISettingsReader> {settingReader};
-            var collaborationFactory = new CollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(settingsReaders);
 
             var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders)
             {
@@ -228,7 +238,7 @@ namespace NuKeeper.Tests.Commands
 
             var settingReader = new GitHubSettingsReader();
             var settingsReaders = new List<ISettingsReader> {settingReader};
-            var collaborationFactory = new CollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(settingsReaders);
 
             SettingsContainer settingsOut = null;
             var engine = Substitute.For<ICollaborationEngine>();

--- a/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
@@ -124,7 +124,6 @@ namespace NuKeeper.Tests.Engine
         {
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
-            var repoDiscovery = Substitute.For<IRepositoryDiscovery>();
             var repoEngine = Substitute.For<IGitRepositoryEngine>();
             var folders = Substitute.For<IFolderFactory>();
 
@@ -133,13 +132,12 @@ namespace NuKeeper.Tests.Engine
 
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
 
-            repoDiscovery.GetRepositories(Arg.Any<ICollaborationPlatform>(), Arg.Any<SourceControlServerSettings>())
-                .Returns(repos);
+            collaborationFactory.RepositoryDiscovery.GetRepositories(Arg.Any<SourceControlServerSettings>()).Returns(repos);
 
 
             repoEngine.Run(null, null, null, null).ReturnsForAnyArgs(repoEngineResult);
 
-            var engine = new CollaborationEngine(collaborationFactory, collaborationPlatform, repoDiscovery, repoEngine,
+            var engine = new CollaborationEngine(collaborationFactory, collaborationPlatform, repoEngine,
                 folders, Substitute.For<INuKeeperLogger>());
             return engine;
         }

--- a/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using NSubstitute;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.AzureDevOps;
+using NuKeeper.Engine;
+using NuKeeper.GitHub;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class CollaborationFactoryTests
+    {
+        private static CollaborationFactory GetCollaborationFactory()
+        {
+            var azureUri = new Uri("https://dev.azure.com");
+            var gitHubUri = new Uri("https://api.github.com");
+
+            var settingReader1 = Substitute.For<ISettingsReader>();
+            settingReader1.CanRead(azureUri).Returns(true);
+            settingReader1.Platform.Returns(Platform.AzureDevOps);
+            settingReader1.AuthSettings(Arg.Any<Uri>(), Arg.Any<string>()).Returns(new AuthSettings(azureUri, "token"));
+
+            var settingReader2 = Substitute.For<ISettingsReader>();
+            settingReader2.CanRead(gitHubUri).Returns(true);
+            settingReader2.Platform.Returns(Platform.GitHub);
+            settingReader2.AuthSettings(Arg.Any<Uri>(), Arg.Any<string>()).Returns(new AuthSettings(gitHubUri, "token"));
+
+
+            var readers = new List<ISettingsReader> {settingReader1, settingReader2};
+            var logger = Substitute.For<INuKeeperLogger>();
+            var platform = Substitute.For<ICollaborationPlatform>();
+            return new CollaborationFactory(readers, platform, logger);
+        }
+
+        [Test]
+        public void NoInitialiseReturnsEmptyProps()
+        {
+            Assert.IsNull(GetCollaborationFactory().ForkFinder);
+        }
+
+        [Test]
+        public void UnknownApiReturnsUnableToWorkOutPlatform()
+        {
+            var collaborationFactory = GetCollaborationFactory();
+
+            var exception = Assert.Throws<NuKeeperException>(() => collaborationFactory.Initialise(new Uri("https://unknown.com/"), null));
+            Assert.AreEqual(exception.Message, "Unable to work out platform for uri https://unknown.com/");
+        }
+
+        [Test]
+        public void AzureDevOpsUrlReturnsAzureDevOps()
+        {
+            var collaborationFactory = GetCollaborationFactory();
+            collaborationFactory.Initialise(new Uri("https://dev.azure.com"), "token");
+            AssertAzureDevOps(collaborationFactory);
+            AssertAreSameObject(collaborationFactory);
+        }
+
+        [Test]
+        public void GithubUrlReturnsGitHub()
+        {
+            var collaborationFactory = GetCollaborationFactory();
+            collaborationFactory.Initialise(new Uri("https://api.github.com"), "token");
+            AssertGithub(collaborationFactory);
+            AssertAreSameObject(collaborationFactory);
+        }
+
+        private static void AssertAreSameObject(ICollaborationFactory collaborationFactory)
+        {
+            var forkFinder = collaborationFactory.ForkFinder;
+            Assert.AreSame(forkFinder, collaborationFactory.ForkFinder);
+
+            var settings = collaborationFactory.Settings;
+            Assert.AreSame(settings, collaborationFactory.Settings);
+        }
+
+        private static void AssertGithub(ICollaborationFactory collaborationFactory)
+        {
+            Assert.IsInstanceOf<GitHubForkFinder>(collaborationFactory.ForkFinder);
+            Assert.IsInstanceOf<CollaborationPlatformSettings>(collaborationFactory.Settings);
+        }
+
+        private static void AssertAzureDevOps(ICollaborationFactory collaborationFactory)
+        {
+            Assert.IsInstanceOf<AzureDevOpsForkFinder>(collaborationFactory.ForkFinder);
+            Assert.IsInstanceOf<CollaborationPlatformSettings>(collaborationFactory.Settings);
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
@@ -72,6 +72,9 @@ namespace NuKeeper.Tests.Engine
 
         private static void AssertAreSameObject(ICollaborationFactory collaborationFactory)
         {
+            var repositoryDiscovery = collaborationFactory.RepositoryDiscovery;
+            Assert.AreSame(repositoryDiscovery, collaborationFactory.RepositoryDiscovery);
+
             var forkFinder = collaborationFactory.ForkFinder;
             Assert.AreSame(forkFinder, collaborationFactory.ForkFinder);
 
@@ -82,12 +85,14 @@ namespace NuKeeper.Tests.Engine
         private static void AssertGithub(ICollaborationFactory collaborationFactory)
         {
             Assert.IsInstanceOf<GitHubForkFinder>(collaborationFactory.ForkFinder);
+            Assert.IsInstanceOf<GitHubRepositoryDiscovery>(collaborationFactory.RepositoryDiscovery);
             Assert.IsInstanceOf<CollaborationPlatformSettings>(collaborationFactory.Settings);
         }
 
         private static void AssertAzureDevOps(ICollaborationFactory collaborationFactory)
         {
             Assert.IsInstanceOf<AzureDevOpsForkFinder>(collaborationFactory.ForkFinder);
+            Assert.IsInstanceOf<AzureDevOpsRepositoryDiscovery>(collaborationFactory.RepositoryDiscovery);
             Assert.IsInstanceOf<CollaborationPlatformSettings>(collaborationFactory.Settings);
         }
     }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -43,12 +43,10 @@ namespace NuKeeper
 
             //GitHub Registrations
             container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
-            container.Register<IForkFinder, GitHubForkFinder>();
             container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
 
             //Azure Registrations
             //container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
-            //container.Register<IForkFinder, AzureDevOpsForkFinder>();
             //container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
         }
     }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -43,11 +43,9 @@ namespace NuKeeper
 
             //GitHub Registrations
             container.RegisterSingleton<ICollaborationPlatform, OctokitClient>();
-            container.Register<IRepositoryDiscovery, GitHubRepositoryDiscovery>();
 
             //Azure Registrations
             //container.RegisterSingleton<ICollaborationPlatform, AzureDevOpsPlatform>();
-            //container.Register<IRepositoryDiscovery, AzureDevOpsRepositoryDiscovery>();
         }
     }
 }

--- a/NuKeeper/Engine/CollaborationEngine.cs
+++ b/NuKeeper/Engine/CollaborationEngine.cs
@@ -14,7 +14,6 @@ namespace NuKeeper.Engine
     {
         private readonly ICollaborationFactory _collaborationFactory;
         private readonly ICollaborationPlatform _collaborationPlatform;
-        private readonly IRepositoryDiscovery _repositoryDiscovery;
         private readonly IGitRepositoryEngine _repositoryEngine;
         private readonly IFolderFactory _folderFactory;
         private readonly INuKeeperLogger _logger;
@@ -22,14 +21,12 @@ namespace NuKeeper.Engine
         public CollaborationEngine(
             ICollaborationFactory collaborationFactory,
             ICollaborationPlatform collaborationPlatform,
-            IRepositoryDiscovery repositoryDiscovery,
             IGitRepositoryEngine repositoryEngine,
             IFolderFactory folderFactory,
             INuKeeperLogger logger)
         {
             _collaborationFactory = collaborationFactory;
             _collaborationPlatform = collaborationPlatform;
-            _repositoryDiscovery = repositoryDiscovery;
             _repositoryEngine = repositoryEngine;
             _folderFactory = folderFactory;
             _logger = logger;
@@ -52,7 +49,7 @@ namespace NuKeeper.Engine
 
             var userIdentity = GetUserIdentity(githubUser);
 
-            var repositories = await _repositoryDiscovery.GetRepositories(_collaborationPlatform, settings.SourceControlServerSettings);
+            var repositories = await _collaborationFactory.RepositoryDiscovery.GetRepositories(settings.SourceControlServerSettings);
 
             var reposUpdated = 0;
 

--- a/NuKeeper/Engine/CollaborationFactory.cs
+++ b/NuKeeper/Engine/CollaborationFactory.cs
@@ -50,6 +50,7 @@ namespace NuKeeper.Engine
         }
 
         private IForkFinder _forkFinder;
+
         public IForkFinder ForkFinder
         {
             get
@@ -58,11 +59,12 @@ namespace NuKeeper.Engine
                 {
                     return null;
                 }
+
                 if (_forkFinder != null)
                 {
                     return _forkFinder;
                 }
-                
+
                 switch (_platform.Value)
                 {
                     case Platform.AzureDevOps:
@@ -71,11 +73,39 @@ namespace NuKeeper.Engine
                     case Platform.GitHub:
                         _forkFinder = new GitHubForkFinder(_collaborationPlatform, _nuKeeperLogger);
                         break;
-                    default:
-                        return null;
                 }
 
                 return _forkFinder;
+            }
+        }
+
+        private IRepositoryDiscovery _repositoryDiscovery;
+
+        public IRepositoryDiscovery RepositoryDiscovery
+        {
+            get
+            {
+                if (!_platform.HasValue)
+                {
+                    return null;
+                }
+
+                if (_repositoryDiscovery != null)
+                {
+                    return _repositoryDiscovery;
+                }
+
+                switch (_platform.Value)
+                {
+                    case Platform.AzureDevOps:
+                        _repositoryDiscovery = new AzureDevOpsRepositoryDiscovery(_nuKeeperLogger);
+                        break;
+                    case Platform.GitHub:
+                        _repositoryDiscovery = new GitHubRepositoryDiscovery(_nuKeeperLogger, _collaborationPlatform);
+                        break;
+                }
+
+                return _repositoryDiscovery;
             }
         }
     }

--- a/NuKeeper/Engine/CollaborationFactory.cs
+++ b/NuKeeper/Engine/CollaborationFactory.cs
@@ -2,19 +2,28 @@ using NuKeeper.Abstractions.CollaborationPlatform;
 using System;
 using System.Collections.Generic;
 using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.AzureDevOps;
+using NuKeeper.GitHub;
 
 namespace NuKeeper.Engine
 {
     public class CollaborationFactory : ICollaborationFactory
     {
         private readonly IEnumerable<ISettingsReader> _settingReaders;
+        private readonly ICollaborationPlatform _collaborationPlatform;
+        private readonly INuKeeperLogger _nuKeeperLogger;
+
         public ISettingsReader SettingsReader { get; private set; }
         public CollaborationPlatformSettings Settings { get; }
-        public Platform Platform { get; private set; }
+        private Platform? _platform;
 
-        public CollaborationFactory(IEnumerable<ISettingsReader> settingReaders)
+
+        public CollaborationFactory(IEnumerable<ISettingsReader> settingReaders, ICollaborationPlatform collaborationPlatform, INuKeeperLogger nuKeeperLogger)
         {
             _settingReaders = settingReaders;
+            _collaborationPlatform = collaborationPlatform;
+            _nuKeeperLogger = nuKeeperLogger;
             SettingsReader = null;
             Settings = new CollaborationPlatformSettings();
         }
@@ -26,7 +35,7 @@ namespace NuKeeper.Engine
                 if (settingReader.CanRead(apiEndpoint))
                 {
                     SettingsReader = settingReader;
-                    Platform = settingReader.Platform;
+                    _platform = settingReader.Platform;
                 }
             }
 
@@ -38,6 +47,36 @@ namespace NuKeeper.Engine
             var settings = SettingsReader.AuthSettings(apiEndpoint, token);
             Settings.BaseApiUrl = settings.ApiBase;
             Settings.Token = settings.Token;
+        }
+
+        private IForkFinder _forkFinder;
+        public IForkFinder ForkFinder
+        {
+            get
+            {
+                if (!_platform.HasValue)
+                {
+                    return null;
+                }
+                if (_forkFinder != null)
+                {
+                    return _forkFinder;
+                }
+                
+                switch (_platform.Value)
+                {
+                    case Platform.AzureDevOps:
+                        _forkFinder = new AzureDevOpsForkFinder(_collaborationPlatform, _nuKeeperLogger);
+                        break;
+                    case Platform.GitHub:
+                        _forkFinder = new GitHubForkFinder(_collaborationPlatform, _nuKeeperLogger);
+                        break;
+                    default:
+                        return null;
+                }
+
+                return _forkFinder;
+            }
         }
     }
 }

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -13,20 +13,20 @@ namespace NuKeeper.Engine
     public class GitRepositoryEngine: IGitRepositoryEngine
     {
         private readonly IRepositoryUpdater _repositoryUpdater;
-        private readonly IForkFinder _forkFinder;
+        private readonly ICollaborationFactory _collaborationFactory;
         private readonly IFolderFactory _folderFactory;
         private readonly INuKeeperLogger _logger;
         private readonly IRepositoryFilter _repositoryFilter;
 
         public GitRepositoryEngine(
             IRepositoryUpdater repositoryUpdater,
-            IForkFinder forkFinder,
+            ICollaborationFactory collaborationFactory,
             IFolderFactory folderFactory,
             INuKeeperLogger logger,
             IRepositoryFilter repositoryFilter)
         {
             _repositoryUpdater = repositoryUpdater;
-            _forkFinder = forkFinder;
+            _collaborationFactory = collaborationFactory;
             _folderFactory = folderFactory;
             _logger = logger;
             _repositoryFilter = repositoryFilter;
@@ -71,7 +71,7 @@ namespace NuKeeper.Engine
             string userName)
         {
             var pullFork = new ForkData(repository.RepositoryUri, repository.RepositoryOwner, repository.RepositoryName);
-            var pushFork = await _forkFinder.FindPushFork(forkMode, userName, pullFork);
+            var pushFork = await _collaborationFactory.ForkFinder.FindPushFork(forkMode, userName, pullFork);
 
             if (pushFork == null)
             {


### PR DESCRIPTION
Moves `IForkFinder` and `IRepositoryDiscovery` into the factory.

`IForkFinder` was a simple move

`IRepositoryDiscovery` needed `ICollaborationPlatform` removing as an argument from a method and putting into the constructor.

Tests fixed and new test class for `CollaborationFactory` added to ensure right platform components are returned

This should mean the only bit left is moving `ICollaborationPlatform` into the factory and then we will have AzureDevOps support for the repo command