### PR TITLE
Add a Settings reader for the older VSTS URL format

### DIFF
--- a/NuKeeper.AzureDevOps/BaseSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/BaseSettingsReader.cs
@@ -1,0 +1,28 @@
+using System;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+
+namespace NuKeeper.AzureDevOps
+{
+    public abstract class BaseSettingsReader : ISettingsReader
+    {
+        public Platform Platform => Platform.AzureDevOps;
+
+        public abstract bool CanRead(Uri repositoryUri);
+
+        public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
+        {
+            UpdateTokenSettings(settings);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
+        }
+
+        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
+        {
+            var envToken = Environment.GetEnvironmentVariable("NuKeeper_azure_devops_token");
+            settings.Token = Concat.FirstValue(envToken, settings.Token);
+        }
+
+        public abstract RepositorySettings RepositorySettings(Uri repositoryUri);
+    }
+}

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -39,7 +39,7 @@ namespace NuKeeper
             container.Register<IFileSettingsCache, FileSettingsCache>();
 
             container.RegisterSingleton<ICollaborationFactory,CollaborationFactory>();
-            container.Collection.Register<ISettingsReader>(typeof(GitHubSettingsReader), typeof(AzureDevOpsSettingsReader));
+            container.Collection.Register<ISettingsReader>(typeof(GitHubSettingsReader), typeof(AzureDevOpsSettingsReader), typeof(VstsSettingsReader));
         }
     }
 }

--- a/Nukeeper.AzureDevOps.Tests/VstsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/VstsSettingsReaderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.AzureDevOps;
+using NUnit.Framework;
+
+namespace Nukeeper.AzureDevOps.Tests
+{
+    [TestFixture]
+    public class VstsSettingsReaderTests
+    {
+        private static ISettingsReader AzureSettingsReader => new VstsSettingsReader();
+
+        [Test]
+        public void ReturnsTrueIfCanRead()
+        {
+            var canRead = AzureSettingsReader.CanRead(new Uri("https://org.visualstudio.com"));
+            Assert.IsTrue(canRead);
+        }
+
+        [Test]
+        public void ReturnsCorrectPlatform()
+        {
+            var platform = AzureSettingsReader.Platform;
+            Assert.IsNotNull(platform);
+            Assert.AreEqual(platform, Platform.AzureDevOps);
+        }
+
+        [Test]
+        public void UpdateSettings_UpdatesSettings()
+        {
+            var settings = new CollaborationPlatformSettings
+            {
+                Token = "accessToken",
+                BaseApiUrl = new Uri("https://dev.azure.com/")
+            };
+            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
+
+            Assert.IsNotNull(settings);
+            Assert.AreEqual(settings.BaseApiUrl, "https://dev.azure.com/");
+            Assert.AreEqual(settings.Token, "accessToken");
+            Assert.AreEqual(settings.ForkMode, ForkMode.SingleRepositoryOnly);
+        }
+
+        [Test]
+        public void AuthSettings_GetsCorrectSettingsFromEnvironment()
+        {
+            var settings = new CollaborationPlatformSettings
+            {
+                Token = "accessToken",
+            };
+            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", "envToken");
+            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
+            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", null);
+
+            Assert.AreEqual(settings.Token, "envToken");
+        }
+
+        [TestCase(null)]
+        [TestCase("htps://dev.azure.com")]
+        public void InvalidUrlReturnsNull(string value)
+        {
+            var uriToTest = value == null ? null : new Uri(value);
+            var canRead = AzureSettingsReader.CanRead(uriToTest);
+
+            Assert.IsFalse(canRead);
+        }
+
+        [Test]
+        public void RepositorySettings_GetsCorrectSettings()
+        {
+            var settings = AzureSettingsReader.RepositorySettings(new Uri("https://org.visualstudio.com/project/_git/reponame"));
+
+            Assert.IsNotNull(settings);
+            Assert.AreEqual(settings.ApiUri, "https://dev.azure.com/org/");
+            Assert.AreEqual(settings.RepositoryUri, "https://dev.azure.com/org/project/_git/reponame/");
+            Assert.AreEqual(settings.RepositoryName, "reponame");
+            Assert.AreEqual(settings.RepositoryOwner, "project");
+        }
+
+        [Test]
+        public void RepositorySettings_ReturnsNull()
+        {
+            var settings = AzureSettingsReader.RepositorySettings(null);
+            Assert.IsNull(settings);
+        }
+
+        [Test]
+        public void RepositorySettings_PathTooLong()
+        {
+            var settings = AzureSettingsReader.RepositorySettings(new Uri("https://org.visualstudio.com/project/_git/reponame/thisShouldNotBeHere/"));
+            Assert.IsNull(settings);
+        }
+    }
+}


### PR DESCRIPTION
This will allow the `https://{org}.visualstudio.com/{project}/_git/{repo}` style format to be used with NuKeeper. Will make it easier to just "copy + paste" the URL from the clone box in AzureDevOPs