### PR TITLE
Refactored the CollaborationFactory

### DIFF
--- a/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationFactory.cs
@@ -1,11 +1,13 @@
 using System;
+using NuKeeper.Abstractions.Configuration;
 
 namespace NuKeeper.Abstractions.CollaborationPlatform
 {
     public interface ICollaborationFactory
     {
+        void Initialise(Uri apiUri, string token, ForkMode? forkModeFromSettings);
+
         CollaborationPlatformSettings Settings { get; }
-        void Initialise(Uri apiUri, string token);
         IForkFinder ForkFinder { get; }
         IRepositoryDiscovery RepositoryDiscovery { get; }
         ICollaborationPlatform CollaborationPlatform { get; }

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.GitHub
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
             UpdateTokenSettings(settings);
-            settings.ForkMode = ForkMode.PreferFork;
+            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
         }
 
         private static void UpdateTokenSettings(CollaborationPlatformSettings settings)

--- a/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
@@ -70,7 +70,6 @@ namespace NuKeeper.Tests.Engine
             Assert.That(count, Is.EqualTo(2));
         }
 
-
         [Test]
         public async Task CountIsNotIncrementedWhenRepoEngineFails()
         {
@@ -133,7 +132,6 @@ namespace NuKeeper.Tests.Engine
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
 
             collaborationFactory.RepositoryDiscovery.GetRepositories(Arg.Any<SourceControlServerSettings>()).Returns(repos);
-
 
             repoEngine.Run(null, null, null, null).ReturnsForAnyArgs(repoEngineResult);
 

--- a/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
@@ -67,7 +67,9 @@ namespace NuKeeper.Tests.Engine
             var collaborationFactory = GetCollaborationFactory();
 
             var exception = Assert.Throws<NuKeeperException>(
-                () => collaborationFactory.Initialise(new Uri("https://unknown.com/"), null));
+                () => collaborationFactory.Initialise(
+                    new Uri("https://unknown.com/"), null, ForkMode.SingleRepositoryOnly));
+
             Assert.AreEqual(exception.Message, "Unable to find collaboration platform for uri https://unknown.com/");
         }
 
@@ -75,8 +77,9 @@ namespace NuKeeper.Tests.Engine
         public void AzureDevOpsUrlReturnsAzureDevOps()
         {
             var collaborationFactory = GetCollaborationFactory();
-            collaborationFactory.Initialise(new Uri("https://dev.azure.com"), "token");
-            collaborationFactory.Settings.ForkMode = ForkMode.SingleRepositoryOnly;
+
+            collaborationFactory.Initialise(new Uri("https://dev.azure.com"), "token", ForkMode.SingleRepositoryOnly);
+
             AssertAzureDevOps(collaborationFactory);
             AssertAreSameObject(collaborationFactory);
         }
@@ -85,8 +88,9 @@ namespace NuKeeper.Tests.Engine
         public void GithubUrlReturnsGitHub()
         {
             var collaborationFactory = GetCollaborationFactory();
-            collaborationFactory.Initialise(new Uri("https://api.github.com"), "token");
-            collaborationFactory.Settings.ForkMode = ForkMode.PreferFork;
+
+            collaborationFactory.Initialise(new Uri("https://api.github.com"), "token", ForkMode.PreferFork);
+
             AssertGithub(collaborationFactory);
             AssertAreSameObject(collaborationFactory);
         }

--- a/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
@@ -34,30 +34,14 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public void UnitialisedForkFinderIsNotValid()
+        public void UnitialisedFactoryHasNulls()
         {
-            Assert.Throws<NuKeeperException>(() =>
-            {
-                var f = GetCollaborationFactory().ForkFinder;
-            });
-        }
+            var f = GetCollaborationFactory();
 
-        [Test]
-        public void UnitialisedCollaborationPlatformIsNotValid()
-        {
-            Assert.Throws<NuKeeperException>(() =>
-            {
-                var f = GetCollaborationFactory().CollaborationPlatform;
-            });
-        }
-
-        [Test]
-        public void UnitialisedRepositoryDiscoveryIsNotValid()
-        {
-            Assert.Throws<NuKeeperException>(() =>
-            {
-                var f = GetCollaborationFactory().RepositoryDiscovery;
-            });
+            Assert.That(f, Is.Not.Null);
+            Assert.That(f.CollaborationPlatform, Is.Null);
+            Assert.That(f.ForkFinder, Is.Null);
+            Assert.That(f.RepositoryDiscovery, Is.Null);
         }
 
 

--- a/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationFactoryTests.cs
@@ -34,10 +34,32 @@ namespace NuKeeper.Tests.Engine
         }
 
         [Test]
-        public void NoInitialiseReturnsEmptyProps()
+        public void UnitialisedForkFinderIsNotValid()
         {
-            Assert.IsNull(GetCollaborationFactory().ForkFinder);
+            Assert.Throws<NuKeeperException>(() =>
+            {
+                var f = GetCollaborationFactory().ForkFinder;
+            });
         }
+
+        [Test]
+        public void UnitialisedCollaborationPlatformIsNotValid()
+        {
+            Assert.Throws<NuKeeperException>(() =>
+            {
+                var f = GetCollaborationFactory().CollaborationPlatform;
+            });
+        }
+
+        [Test]
+        public void UnitialisedRepositoryDiscoveryIsNotValid()
+        {
+            Assert.Throws<NuKeeperException>(() =>
+            {
+                var f = GetCollaborationFactory().RepositoryDiscovery;
+            });
+        }
+
 
         [Test]
         public void UnknownApiReturnsUnableToFindPlatform()

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -28,7 +28,6 @@ namespace NuKeeper.Collaboration
         {
             get
             {
-                CheckCreate();
                 return _forkFinder;
             }
         }
@@ -37,7 +36,6 @@ namespace NuKeeper.Collaboration
         {
             get
             {
-                CheckCreate();
                 return _repositoryDiscovery;
 
             }
@@ -47,7 +45,6 @@ namespace NuKeeper.Collaboration
         {
             get
             {
-                CheckCreate();
                 return _collaborationPlatform;
             }
         }
@@ -74,6 +71,7 @@ namespace NuKeeper.Collaboration
             platformSettingsReader.UpdateCollaborationPlatformSettings(Settings);
 
             ValidateSettings();
+            CreateForPlatform();
         }
 
         private ISettingsReader SettingsReaderForPlatform(Uri apiEndpoint)
@@ -89,16 +87,6 @@ namespace NuKeeper.Collaboration
             return platformSettingsReader;
         }
 
-        private void CheckCreate()
-        {
-            if (_forkFinder == null ||
-                _repositoryDiscovery == null ||
-                _collaborationPlatform == null)
-            {
-                CreateForPlatform();
-            }
-        }
-
         private void ValidateSettings()
         {
             if (!Settings.BaseApiUrl.IsWellFormedOriginalString()
@@ -106,19 +94,20 @@ namespace NuKeeper.Collaboration
             {
                 throw new NuKeeperException($"Api is not of correct format {Settings.BaseApiUrl}");
             }
-        }
 
-        private void CreateForPlatform()
-        {
             if (!Settings.ForkMode.HasValue)
             {
                 throw new NuKeeperException("Fork Mode was not set");
             }
+
             if (!_platform.HasValue)
             {
                 throw new NuKeeperException("Platform was not set");
             }
+        }
 
+        private void CreateForPlatform()
+        {
             var forkMode = Settings.ForkMode.Value;
 
             switch (_platform.Value)

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -60,7 +60,7 @@ namespace NuKeeper.Collaboration
             Settings = new CollaborationPlatformSettings();
         }
 
-        public void Initialise(Uri apiEndpoint, string token)
+        public void Initialise(Uri apiEndpoint, string token, ForkMode? forkModeFromSettings)
         {
             var platformSettingsReader = SettingsReaderForPlatform(apiEndpoint);
 
@@ -70,6 +70,7 @@ namespace NuKeeper.Collaboration
 
             Settings.BaseApiUrl = UriFormats.EnsureTrailingSlash(apiEndpoint);
             Settings.Token = token;
+            Settings.ForkMode = forkModeFromSettings;
             platformSettingsReader.UpdateCollaborationPlatformSettings(Settings);
 
             ValidateSettings();

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -22,32 +22,13 @@ namespace NuKeeper.Collaboration
         private IRepositoryDiscovery _repositoryDiscovery;
         private ICollaborationPlatform _collaborationPlatform;
 
+        public IForkFinder ForkFinder => _forkFinder;
+
+        public IRepositoryDiscovery RepositoryDiscovery => _repositoryDiscovery;
+
+        public ICollaborationPlatform CollaborationPlatform => _collaborationPlatform;
+
         public CollaborationPlatformSettings Settings { get; }
-
-        public IForkFinder ForkFinder
-        {
-            get
-            {
-                return _forkFinder;
-            }
-        }
-
-        public IRepositoryDiscovery RepositoryDiscovery
-        {
-            get
-            {
-                return _repositoryDiscovery;
-
-            }
-        }
-
-        public ICollaborationPlatform CollaborationPlatform
-        {
-            get
-            {
-                return _collaborationPlatform;
-            }
-        }
 
         public CollaborationFactory(IEnumerable<ISettingsReader> settingReaders,
             INuKeeperLogger nuKeeperLogger)

--- a/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
@@ -67,7 +67,14 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Bad Api Base '{endpoint}'");
             }
 
-            CollaborationFactory.Initialise(baseUri, PersonalAccessToken, ForkMode);
+            try
+            {
+                CollaborationFactory.Initialise(baseUri, PersonalAccessToken, ForkMode);
+            }
+            catch (Exception ex)
+            {
+                return ValidationResult.Failure(ex.Message);
+            }
 
             if (CollaborationFactory.Settings.Token == null)
             {

--- a/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
@@ -67,7 +67,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Bad Api Base '{endpoint}'");
             }
 
-            CollaborationFactory.Initialise(baseUri, PersonalAccessToken);
+            CollaborationFactory.Initialise(baseUri, PersonalAccessToken, ForkMode);
 
             if (CollaborationFactory.Settings.Token == null)
             {
@@ -80,8 +80,6 @@ namespace NuKeeper.Commands
             const int defaultMaxPullRequests = 3;
             settings.PackageFilters.MaxPackageUpdates =
                 Concat.FirstValue(MaxPullRequestsPerRepository, fileSettings.MaxPr, defaultMaxPullRequests);
-
-            CollaborationFactory.Settings.ForkMode = ForkMode ?? CollaborationFactory.Settings.ForkMode;
 
             var defaultLabels = new List<string> {"nukeeper"};
 

--- a/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformNuKeeperCommand.cs
@@ -77,7 +77,6 @@ namespace NuKeeper.Commands
             settings.UserSettings.ConsolidateUpdatesInSinglePullRequest =
                 Concat.FirstValue(Consolidate, fileSettings.Consolidate, false);
 
-
             const int defaultMaxPullRequests = 3;
             settings.PackageFilters.MaxPackageUpdates =
                 Concat.FirstValue(MaxPullRequestsPerRepository, fileSettings.MaxPr, defaultMaxPullRequests);


### PR DESCRIPTION
Only one `switch` statement on the platform.
This was a difficult class, with properties that trigger actions that trigger the properties again.
I have tried to flatten that,  so that there is a clear "initialise" step and it's populated afterwards.
