### PR TITLE
Simplify the org class

### DIFF
--- a/NuKeeper.Abstractions/CollaborationModels/Organization.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/Organization.cs
@@ -2,13 +2,11 @@ namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class Organization
     {
-        public Organization(string name, string login)
+        public Organization(string name)
         {
             Name = name;
-            Login = login;
         }
 
         public string Name { get; set; }
-        public string Login { get; set; }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -47,12 +47,13 @@ namespace NuKeeper.AzureDevOps
             };
 
             await _client.CreatePullRequest(req, target.Owner, repo.id);
-        }
 
         public async Task<IReadOnlyList<Organization>> GetOrganizations()
         {
             var projects = await _client.GetProjects();
-            return projects.Select(project => new Organization(project.name, "")).ToList();
+            return projects
+                .Select(project => new Organization(project.name))
+                .ToList();
         }
 
         public async Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string projectName)

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -47,6 +47,7 @@ namespace NuKeeper.AzureDevOps
             };
 
             await _client.CreatePullRequest(req, target.Owner, repo.id);
+        }
 
         public async Task<IReadOnlyList<Organization>> GetOrganizations()
         {

--- a/NuKeeper.BitBucket/BitbucketPlatform.cs
+++ b/NuKeeper.BitBucket/BitbucketPlatform.cs
@@ -70,7 +70,9 @@ namespace NuKeeper.BitBucket
         public async Task<IReadOnlyList<Organization>> GetOrganizations()
         {
             var projects = await _client.GetProjects(_settings.Username);
-            return projects.Select(project => new Organization("", "")).ToList();
+            return projects
+                .Select(project => new Organization(project.name))
+                .ToList();
         }
 
         public async Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string projectName)

--- a/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
@@ -70,8 +70,8 @@ namespace NuKeeper.Git
         public GitRemote GetRemoteForPlatform(Uri repositoryUri, string platformHost)
         {
             var remotes = GetRemotes(repositoryUri);
-            var origin = remotes.FirstOrDefault(rm => rm.Url.Host.ContainsOrdinal(platformHost) == true);
-            return origin;
+            return remotes
+                .FirstOrDefault(rm => rm?.Url?.Host.ContainsOrdinal(platformHost) == true);
         }
     }
 

--- a/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
@@ -71,7 +71,7 @@ namespace NuKeeper.Git
         {
             var remotes = GetRemotes(repositoryUri);
             return remotes
-                .FirstOrDefault(rm => rm?.Url?.Host.ContainsOrdinal(platformHost) == true);
+                .FirstOrDefault(rm => rm.Url.Host.ContainsOrdinal(platformHost));
         }
     }
 

--- a/NuKeeper.GitHub/GitHubRepositoryDiscovery.cs
+++ b/NuKeeper.GitHub/GitHubRepositoryDiscovery.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.GitHub
 
             foreach (var org in allOrgs)
             {
-                var repos = await FromOrganisation(org.Name ?? org.Login, settings);
+                var repos = await FromOrganisation(org.Name, settings);
                 allRepos.AddRange(repos);
             }
 

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -66,9 +66,12 @@ namespace NuKeeper.GitHub
         {
             CheckInitialised();
 
-            var orgs = await _client.Organization.GetAll();
-            _logger.Normal($"Read {orgs.Count} organisations");
-            return orgs.Select(gitHubOrg => new Organization(gitHubOrg.Name, gitHubOrg.Login)).ToArray();
+            var githubOrgs = await _client.Organization.GetAll();
+            _logger.Normal($"Read {githubOrgs.Count} organisations");
+
+            return githubOrgs
+                .Select(org => new Organization(org.Name ?? org.Login))
+                .ToList();
         }
 
         public async Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string organisationName)


### PR DESCRIPTION
Now that we don't use the octokit types throughout, the coalescence, `org.Name ?? org.Login` can move up from `GitHubRepositoryDiscovery` to `OctokitClient`