### PR TITLE
Replace updated nuspec/csproj files completely when writing

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/NuspecFileReaderTests.cs
@@ -62,6 +62,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
 
             var package = packages.FirstOrDefault();
 
+            Assert.That(package, Is.Not.Null);
             Assert.That(package.Id, Is.EqualTo("foo"));
             Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
             Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.Nuspec));

--- a/NuKeeper.Inspection/RepositoryInspection/IPackageReferenceFinder.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/IPackageReferenceFinder.cs
@@ -4,8 +4,8 @@ namespace NuKeeper.Inspection.RepositoryInspection
 {
     public interface IPackageReferenceFinder
     {
-        IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath);
+        IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath);
 
-        IEnumerable<string> GetFilePatterns();
+        IReadOnlyCollection<string> GetFilePatterns();
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
             _logger = logger;
         }
 
-        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
+        public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
             var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.Nuspec);
             try
@@ -33,19 +33,19 @@ namespace NuKeeper.Inspection.RepositoryInspection
             }
         }
 
-        public IEnumerable<string> GetFilePatterns()
+        public IReadOnlyCollection<string> GetFilePatterns()
         {
             return new[] {"*.nuspec"};
         }
 
-        public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)
+        public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, PackagePath path)
         {
             var xml = XDocument.Load(fileContents);
 
             var packagesNode = xml.Element("package")?.Element("metadata")?.Element("dependencies");
             if (packagesNode == null)
             {
-                return Enumerable.Empty<PackageInProject>();
+                return Array.Empty<PackageInProject>();
             }
 
             var packageNodeList = packagesNode.Elements()

--- a/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
             _logger = logger;
         }
 
-        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
+        public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
             var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.PackagesConfig);
             try
@@ -32,19 +32,19 @@ namespace NuKeeper.Inspection.RepositoryInspection
             }
         }
 
-        public IEnumerable<string> GetFilePatterns()
+        public IReadOnlyCollection<string> GetFilePatterns()
         {
             return new[] {"packages.config"};
         }
 
-        public IEnumerable<PackageInProject> Read(Stream fileContents, PackagePath path)
+        public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, PackagePath path)
         {
             var xml = XDocument.Load(fileContents);
 
             var packagesNode = xml.Element("packages");
             if (packagesNode == null)
             {
-                return Enumerable.Empty<PackageInProject>();
+                return Array.Empty<PackageInProject>();
             }
 
             var packageNodeList = packagesNode.Elements()

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
             _logger = logger;
         }
 
-        public IEnumerable<PackageInProject> ReadFile(string baseDirectory, string relativePath)
+        public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
         {
             var filePath = Path.Combine(baseDirectory, relativePath);
             try
@@ -35,12 +35,12 @@ namespace NuKeeper.Inspection.RepositoryInspection
             }
         }
 
-        public IEnumerable<string> GetFilePatterns()
+        public IReadOnlyCollection<string> GetFilePatterns()
         {
             return new[] {"*.csproj", "*.vbproj", "*.fsproj" };
         }
 
-        public IEnumerable<PackageInProject> Read(Stream fileContents, string baseDirectory, string relativePath)
+        public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, string baseDirectory, string relativePath)
         {
             var xml = XDocument.Load(fileContents);
             var ns = xml.Root.GetDefaultNamespace();
@@ -51,7 +51,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
             if (project == null)
             {
-                return Enumerable.Empty<PackageInProject>();
+                return Array.Empty<PackageInProject>();
             }
 
             var itemGroups = project

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -29,8 +29,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
         private static async Task ExecuteValidUpdateTest(string testProjectContents, [CallerMemberName] string memberName = "")
         {
-            const string oldPackageVersion = "5.2.3";
-            const string newPackageVersion = "5.2.4";
+            const string oldPackageVersion = "5.2.31";
+            const string newPackageVersion = "5.3.4";
             const string expectedPackageString =
                 "<dependency id=\"foo\" version=\"{packageVersion}\" />";
 

--- a/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
@@ -18,21 +18,25 @@ namespace NuKeeper.Update.Process
             var projectsToUpdate = new Stack<string>();
             projectsToUpdate.Push(currentPackage.Path.FullName);
 
-            while(projectsToUpdate.Count > 0)
+            while (projectsToUpdate.Count > 0)
             {
                 var currentProject = projectsToUpdate.Pop();
+
+                XDocument xml;
                 using (var projectContents = File.Open(currentProject, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    var projectsToCheck = UpdateConditionsOnProjects(projectContents);
+                    xml = XDocument.Load(projectContents);
+                }
 
-                    foreach (var potentialProject in projectsToCheck)
+                var projectsToCheck = UpdateConditionsOnProjects(xml, currentProject);
+
+                foreach (var potentialProject in projectsToCheck)
+                {
+                    var fullPath =
+                        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(currentProject), potentialProject));
+                    if (File.Exists(fullPath))
                     {
-                        var fullPath =
-                            Path.GetFullPath(Path.Combine(Path.GetDirectoryName(currentProject), potentialProject));
-                        if (File.Exists(fullPath))
-                        {
-                            projectsToUpdate.Push(fullPath);
-                        }
+                        projectsToUpdate.Push(fullPath);
                     }
                 }
             }
@@ -40,9 +44,8 @@ namespace NuKeeper.Update.Process
             return Task.CompletedTask;
         }
 
-        private static IEnumerable<string> UpdateConditionsOnProjects(Stream fileContents)
+        private static IEnumerable<string> UpdateConditionsOnProjects(XDocument xml, string savePath)
         {
-            var xml = XDocument.Load(fileContents);
             var ns = xml.Root.GetDefaultNamespace();
 
             var project = xml.Element(ns + "Project");
@@ -70,8 +73,10 @@ namespace NuKeeper.Update.Process
 
             if (saveRequired)
             {
-                fileContents.Seek(0, SeekOrigin.Begin);
-                xml.Save(fileContents);
+                using (var xmlOutput = File.Open(savePath, FileMode.Truncate))
+                {
+                    xml.Save(xmlOutput);
+                }
             }
 
             return FindProjectReferences(project, ns);


### PR DESCRIPTION
Previous write mode would leave characters from the old file behind if the new file was shorter.