### PR TITLE
String.Contains extension method allowing StringComparison

### DIFF
--- a/NuKeeper.Abstractions.Tests/Formats/StringExtensionsTests.cs
+++ b/NuKeeper.Abstractions.Tests/Formats/StringExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NuKeeper.Abstractions.Formats;
 using NUnit.Framework;
 
@@ -15,17 +16,23 @@ namespace NuKeeper.Abstractions.Tests.Formats
         [TestCase("", "")]
         public void DoesContainOrdinal(string value, string substring)
         {
-            Assert.That(value.ContainsOrdinal(substring));
+            Assert.That(value.Contains(substring, StringComparison.OrdinalIgnoreCase));
         }
 
         [TestCase("foobar", "x")]
         [TestCase("", "bar")]
-        [TestCase(null, "a")]
         [TestCase("", "a")]
         [TestCase("foobar", "foobarfish")]
         public void DoesNotContainOrdinal(string value, string substring)
         {
-            Assert.That(value.ContainsOrdinal(substring), Is.False);
+            Assert.That(value.Contains(substring, StringComparison.OrdinalIgnoreCase), Is.False);
+        }
+
+        [Test]
+        public void ShouldThrowOnNull()
+        {
+            Assert.Throws<NullReferenceException>(
+                () => ((string) null).Contains("sth", StringComparison.CurrentCulture));
         }
     }
 }

--- a/NuKeeper.Abstractions/Formats/StringExtensions.cs
+++ b/NuKeeper.Abstractions/Formats/StringExtensions.cs
@@ -15,19 +15,13 @@ namespace NuKeeper.Abstractions.Formats
             return values == null ? string.Empty : string.Join(separator, values);
         }
 
-        public static bool ContainsOrdinal(this string value, string substring)
+        // copied from netcoreapp2.1 profile
+        public static bool Contains(
+            this string subject,
+            string value,
+            StringComparison comparisonType)
         {
-            if (value == null)
-            {
-                return false;
-            }
-
-            if (substring == null)
-            {
-                throw new ArgumentNullException(nameof(substring));
-            }
-
-            return value.IndexOf(substring, StringComparison.OrdinalIgnoreCase) >= 0;
+            return subject.IndexOf(value, 0, subject.Length, comparisonType) >= 0;
         }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             // Did we specify a Azure DevOps url?
-            return repositoryUri?.Host.ContainsOrdinal(PlatformHost) == true;
+            return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
         public override RepositorySettings RepositorySettings(Uri repositoryUri)

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -38,8 +38,8 @@ namespace NuKeeper.AzureDevOps
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();
 
-            var tfsInPath = pathParts.Count > 0 && pathParts[0].ContainsOrdinal(PlatformHost);
-            var tfsInHost = repositoryUri.Host.ContainsOrdinal(PlatformHost);
+            var tfsInPath = pathParts.Count > 0 && pathParts[0].Contains(PlatformHost, StringComparison.OrdinalIgnoreCase);
+            var tfsInHost = repositoryUri.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase);
             return tfsInPath || tfsInHost;
         }
 

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.AzureDevOps
                 _isFromLocalGitRepo = true;
             }
        
-            return repositoryUri?.Host.ContainsOrdinal(PlatformHost) == true;
+            return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
         public override RepositorySettings RepositorySettings(Uri repositoryUri)

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -15,7 +15,7 @@ namespace NuKeeper.BitBucket
         
         public bool CanRead(Uri repositoryUri)
         {
-            return repositoryUri?.Host.ContainsOrdinal("bitbucket.org") == true;
+            return repositoryUri?.Host.Contains("bitbucket.org", StringComparison.OrdinalIgnoreCase) == true;
         }
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)

--- a/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDiscoveryDriver.cs
@@ -71,7 +71,7 @@ namespace NuKeeper.Git
         {
             var remotes = GetRemotes(repositoryUri);
             return remotes
-                .FirstOrDefault(rm => rm.Url.Host.ContainsOrdinal(platformHost));
+                .FirstOrDefault(rm => rm.Url.Host.Contains(platformHost, StringComparison.OrdinalIgnoreCase));
         }
     }
 

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -13,7 +13,7 @@ namespace NuKeeper.GitHub
 
         public bool CanRead(Uri repositoryUri)
         {
-            return repositoryUri?.Host.ContainsOrdinal("github") == true;
+            return repositoryUri?.Host.Contains("github", StringComparison.OrdinalIgnoreCase) == true;
         }
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)

--- a/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateProjectImportsCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -5,6 +6,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Configuration;
 using NuGet.Versioning;
+using NuKeeper.Abstractions.Formats;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.RepositoryInspection;
 
@@ -54,7 +56,7 @@ namespace NuKeeper.Update.Process
 
             var imports = project.Elements(ns + "Import");
             var importsWithToolsPath = imports
-                .Where(i => i.Attributes("Project").Any(a => a.Value.Contains("$(VSToolsPath)")))
+                .Where(i => i.Attributes("Project").Any(a => a.Value.Contains("$(VSToolsPath)", StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
             var importsWithoutCondition = importsWithToolsPath.Where(i => !i.Attributes("Condition").Any());


### PR DESCRIPTION
Follows https://docs.microsoft.com/en-us/dotnet/api/system.string.contains?view=netcore-2.1#System_String_Contains_System_String_System_StringComparison_ but works on netstandard2.0

Regarding String.Replace usage in https://github.com/NuKeeperDotNet/NuKeeper/pull/482/files#diff-8a791fc9d6f84fcd97659a3d22de5bb3 : turns out this was only added when the additional code analyzers were introduced, we don't have a bug/use case so far hitting this (and it's quite unlikely).

This method skips the checks on purpose - they're done in `IndexOf` anyhow, and this also keeps exceptions consistent with the netcore2.1 version.