### PR TITLE
Formatting in filter output

### DIFF
--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -54,7 +54,7 @@ namespace NuKeeper.Update.Selection
             if (filteredLocally.Count < filteredByInOut.Count)
             {
                 var agoFormat = TimeSpanFormat.Ago(_settings.MinimumAge);
-                _logger.Normal($"Filtered by minimum package age '{agoFormat}' from {filteredByInOut.Count} to {filteredLocally.Count}");
+                _logger.Normal($"Filtered from {filteredByInOut.Count} to {filteredLocally.Count} by minimum package age '{agoFormat}'");
             }
 
             var remoteFiltered = await ApplyRemoteFilter(filteredLocally, remoteCheck);

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -6,6 +6,7 @@ using NuKeeper.Inspection.RepositoryInspection;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Formats;
 using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Update.Selection
@@ -52,7 +53,8 @@ namespace NuKeeper.Update.Selection
 
             if (filteredLocally.Count < filteredByInOut.Count)
             {
-                _logger.Normal($"Filtered by minimum package age {_settings.MinimumAge} from {filteredByInOut.Count} to {filteredLocally.Count}");
+                var agoFormat = TimeSpanFormat.Ago(_settings.MinimumAge);
+                _logger.Normal($"Filtered by minimum package age '{agoFormat}' from {filteredByInOut.Count} to {filteredLocally.Count}");
             }
 
             var remoteFiltered = await ApplyRemoteFilter(filteredLocally, remoteCheck);


### PR DESCRIPTION
A change to format in a new message (introduced a few days ago, not yet in a release). Format the `TimeSpan` as text using the existing `Ago` function.

Before:
```
Found 1 package update
NUnit3TestAdapter to 3.11.2 from 3.11.0 in 7 places since 2 days ago.
Filtered by minimum package age 7.00:00:00 from 1 to 0
```

After:
```
Found 1 package update
NUnit3TestAdapter to 3.11.2 from 3.11.0 in 7 places since 2 days ago.
Filtered from 1 to 0 by minimum package age '7 days ago'
```