### PR TITLE
Filter format revert

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -38,10 +38,10 @@ namespace NuKeeper.AzureDevOps
             var response = await _client.GetAsync(fullUrl);
             var responseBody = await response.Content.ReadAsStringAsync();
 
-            _logger.Detailed(responseBody);
-
             if (!response.IsSuccessStatusCode)
             {
+                _logger.Detailed($"Response {response.StatusCode} is not success, body:\n{responseBody}");
+
                 switch (response.StatusCode)
                 {
                     case HttpStatusCode.Unauthorized:
@@ -110,117 +110,5 @@ namespace NuKeeper.AzureDevOps
             var resource = JsonConvert.DeserializeObject<PullRequest>(result);
             return resource;
         }
-    }
-
-#pragma warning disable CA1056 // Uri properties should not be strings
-#pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable CA2227 // Collection properties should be read only
-
-
-    public class Avatar
-    {
-        public string href { get; set; }
-    }
-
-    public class Links
-    {
-        public Avatar avatar { get; set; }
-    }
-
-    public class Creator
-    {
-        public string displayName { get; set; }
-        public string url { get; set; }
-        public Links _links { get; set; }
-        public string id { get; set; }
-        public string uniqueName { get; set; }
-        public string imageUrl { get; set; }
-        public string descriptor { get; set; }
-    }
-
-    public class GitRefs
-    {
-        public string name { get; set; }
-        public string objectId { get; set; }
-        public Creator creator { get; set; }
-        public string url { get; set; }
-    }
-
-    public class GitRefsResource
-    {
-        public List<GitRefs> value { get; set; }
-        public int count { get; set; }
-    }
-
-    public class PullRequestErrorResource
-    {
-        public string id { get; set; }
-        public object innerException { get; set; }
-        public string message { get; set; }
-        public string typeName { get; set; }
-        public string typeKey { get; set; }
-        public int errorCode { get; set; }
-        public int eventId { get; set; }
-    }
-    public class PullRequest
-    {
-        public AzureRepository AzureRepository { get; set; }
-        public int PullRequestId { get; set; }
-        public int CodeReviewId { get; set; }
-        public string Status { get; set; }
-        // public CreatedBy CreatedBy { get; set; }
-        public DateTime CreationDate { get; set; }
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public string SourceRefName { get; set; }
-        public string TargetRefName { get; set; }
-        public string MergeStatus { get; set; }
-        public string MergeId { get; set; }
-
-        // public Lastmergesourcecommit LastMergeSourceCommit { get; set; }
-        // public Lastmergetargetcommit LastMergeTargetCommit { get; set; }
-        //public Lastmergecommit LastMergeCommit { get; set; }
-        // public IEnumerable<Reviewer> Reviewers { get; set; }
-        #pragma warning disable CA1056 // Uri properties should not be strings
-        public string Url { get; set; }
-        public bool SupportsIterations { get; set; }
-    }
-    public class ProjectResource
-    {
-        public int Count { get; set; }
-        public IEnumerable<Project> value { get; set; }
-    }
-    public class Project
-    {
-        public string id { get; set; }
-        public string name { get; set; }
-        public string url { get; set; }
-        public string state { get; set; }
-        public int revision { get; set; }
-        public string visibility { get; set; }
-    }
-    public class PRRequest
-    {
-        public string sourceRefName { get; set; }
-        public string targetRefName { get; set; }
-        public string title { get; set; }
-        public string description { get; set; }
-    }
-    public class AzureRepository
-    {
-        public string id { get; set; }
-        public string name { get; set; }
-        public string url { get; set; }
-        public Project project { get; set; }
-        public string defaultBranch { get; set; }
-        public int size { get; set; }
-        public string remoteUrl { get; set; }
-        public string sshUrl { get; set; }
-    }
-
-    public class GitRepositories
-    {
-        public IEnumerable<AzureRepository> value { get; set; }
-        public int count { get; set; }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+
+namespace NuKeeper.AzureDevOps
+{
+#pragma warning disable CA1056 // Uri properties should not be strings
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable CA2227 // Collection properties should be read only
+
+    public class Avatar
+    {
+        public string href { get; set; }
+    }
+
+    public class Links
+    {
+        public Avatar avatar { get; set; }
+    }
+
+    public class Creator
+    {
+        public string displayName { get; set; }
+        public string url { get; set; }
+        public Links _links { get; set; }
+        public string id { get; set; }
+        public string uniqueName { get; set; }
+        public string imageUrl { get; set; }
+        public string descriptor { get; set; }
+    }
+
+    public class GitRefs
+    {
+        public string name { get; set; }
+        public string objectId { get; set; }
+        public Creator creator { get; set; }
+        public string url { get; set; }
+    }
+
+    public class GitRefsResource
+    {
+        public List<GitRefs> value { get; set; }
+        public int count { get; set; }
+    }
+
+    public class PullRequestErrorResource
+    {
+        public string id { get; set; }
+        public object innerException { get; set; }
+        public string message { get; set; }
+        public string typeName { get; set; }
+        public string typeKey { get; set; }
+        public int errorCode { get; set; }
+        public int eventId { get; set; }
+    }
+    public class PullRequest
+    {
+        public AzureRepository AzureRepository { get; set; }
+        public int PullRequestId { get; set; }
+        public int CodeReviewId { get; set; }
+        public string Status { get; set; }
+        // public CreatedBy CreatedBy { get; set; }
+        public DateTime CreationDate { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string SourceRefName { get; set; }
+        public string TargetRefName { get; set; }
+        public string MergeStatus { get; set; }
+        public string MergeId { get; set; }
+
+        // public Lastmergesourcecommit LastMergeSourceCommit { get; set; }
+        // public Lastmergetargetcommit LastMergeTargetCommit { get; set; }
+        //public Lastmergecommit LastMergeCommit { get; set; }
+        // public IEnumerable<Reviewer> Reviewers { get; set; }
+#pragma warning disable CA1056 // Uri properties should not be strings
+        public string Url { get; set; }
+        public bool SupportsIterations { get; set; }
+    }
+    public class ProjectResource
+    {
+        public int Count { get; set; }
+        public IEnumerable<Project> value { get; set; }
+    }
+    public class Project
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+        public string url { get; set; }
+        public string state { get; set; }
+        public int revision { get; set; }
+        public string visibility { get; set; }
+    }
+    public class PRRequest
+    {
+        public string sourceRefName { get; set; }
+        public string targetRefName { get; set; }
+        public string title { get; set; }
+        public string description { get; set; }
+    }
+    public class AzureRepository
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+        public string url { get; set; }
+        public Project project { get; set; }
+        public string defaultBranch { get; set; }
+        public int size { get; set; }
+        public string remoteUrl { get; set; }
+        public string sshUrl { get; set; }
+    }
+
+    public class GitRepositories
+    {
+        public IEnumerable<AzureRepository> value { get; set; }
+        public int count { get; set; }
+    }
+}

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -54,7 +54,7 @@ namespace NuKeeper.Update.Selection
             if (filteredLocally.Count < filteredByInOut.Count)
             {
                 var agoFormat = TimeSpanFormat.Ago(_settings.MinimumAge);
-                _logger.Normal($"Filtered from {filteredByInOut.Count} to {filteredLocally.Count} by minimum package age '{agoFormat}'");
+                _logger.Normal($"Filtered by minimum package age '{agoFormat}' from {filteredByInOut.Count} to {filteredLocally.Count}");
             }
 
             var remoteFiltered = await ApplyRemoteFilter(filteredLocally, remoteCheck);


### PR DESCRIPTION
After:

```

Found 3 package updates
Microsoft.NETCore.Platforms to 2.1.2 from 1.0.2 in 1 place since 11 days ago.
Microsoft.Extensions.DependencyInjection.Abstractions to 2.1.1 from 2.0.0 in 1 place since 5 months ago.
BenchmarkDotNet to 0.11.3 from 0.11.2 in 1 place since 4 days ago.
Filtered by Include '(Test|xunit|Moq|Shouldly|BenchmarkDotNet)' from 3 to 1
Filtered by minimum package age '7 days ago' from 1 to 0
Selection of package updates: 3 candidates, filtered to 0
No updates can be applied. Exiting.
```


This should be clearer and constent.