### PR TITLE
Divide by zero bugfix

### DIFF
--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.Git
 
         private bool OnTransferProgress(TransferProgress progress)
         {
-            if (progress.ReceivedObjects % (progress.TotalObjects / 10) == 0 && !_fetchFinished)
+            if (progress.ReceivedObjects % (Math.Max(progress.TotalObjects / 10, 1)) == 0 && !_fetchFinished)
             {
                 _logger.Detailed($"{progress.ReceivedObjects} / {progress.TotalObjects}");
                 _fetchFinished = progress.ReceivedObjects == progress.TotalObjects;


### PR DESCRIPTION
Rare edge case i came across while i was setting up a tiny repo
If you have less than 10 objects in your repo the current code will throw a divide by 0 exception, this stops that from happening