### PR TITLE
Update libgit2sharp

### DIFF
--- a/NuKeeper.Git/NuKeeper.Git.csproj
+++ b/NuKeeper.Git/NuKeeper.Git.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -3,7 +3,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />


### PR DESCRIPTION
Update libgit2sharp
as per this comment: https://github.com/NuKeeperDotNet/NuKeeper/issues/539#issuecomment-443431379

It should no longer need `libcurl` installed on linux systems.