### PR TITLE
Fix crash with null exception

### DIFF
--- a/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
+++ b/NuKeeper.Inspection/Logging/ConfigurableLogger.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Inspection.Logging
         {
             CheckLoggerCreated();
             _inner.LogError(message, ex);
-            if (ex.InnerException != null)
+            if (ex?.InnerException != null)
             {
                 Error("Inner Exception", ex.InnerException);
             }


### PR DESCRIPTION
Fix crash with null exception
`ex` can be null at this point