### PR TITLE
Refactor out common regex match

### DIFF
--- a/NuKeeper.Abstractions/RegexMatch.cs
+++ b/NuKeeper.Abstractions/RegexMatch.cs
@@ -11,14 +11,14 @@ namespace NuKeeper.Abstractions
                 && !IsExcluded(target, exclude);
         }
 
-        private static bool IsIncluded(string target, Regex regex)
+        private static bool IsIncluded(string target, Regex include)
         {
-            return regex == null || regex.IsMatch(target);
+            return include == null || include.IsMatch(target);
         }
 
-        private static bool IsExcluded(string target, Regex regex)
+        private static bool IsExcluded(string target, Regex exclude)
         {
-            return regex != null && regex.IsMatch(target);
+            return exclude != null && exclude.IsMatch(target);
         }
     }
 }

--- a/NuKeeper.Abstractions/RegexMatch.cs
+++ b/NuKeeper.Abstractions/RegexMatch.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+
+namespace NuKeeper.Abstractions
+{
+    public static class RegexMatch
+    {
+        public static bool IncludeExclude(string target, Regex include, Regex exclude)
+        {
+            return
+                IsIncluded(target, include)
+                && !IsExcluded(target, exclude);
+        }
+
+        private static bool IsIncluded(string target, Regex regex)
+        {
+            return regex == null || regex.IsMatch(target);
+        }
+
+        private static bool IsExcluded(string target, Regex regex)
+        {
+            return regex != null && regex.IsMatch(target);
+        }
+
+    }
+}

--- a/NuKeeper.Abstractions/RegexMatch.cs
+++ b/NuKeeper.Abstractions/RegexMatch.cs
@@ -5,20 +5,12 @@ namespace NuKeeper.Abstractions
     public static class RegexMatch
     {
         public static bool IncludeExclude(string target, Regex include, Regex exclude)
-        {
-            return
-                IsIncluded(target, include)
-                && !IsExcluded(target, exclude);
-        }
+            => IsIncluded(target, include) && !IsExcluded(target, exclude);
 
         private static bool IsIncluded(string target, Regex include)
-        {
-            return include == null || include.IsMatch(target);
-        }
+            => include?.IsMatch(target) ?? true;
 
         private static bool IsExcluded(string target, Regex exclude)
-        {
-            return exclude != null && exclude.IsMatch(target);
-        }
+            => exclude?.IsMatch(target) ?? false;
     }
 }

--- a/NuKeeper.Abstractions/RegexMatch.cs
+++ b/NuKeeper.Abstractions/RegexMatch.cs
@@ -20,6 +20,5 @@ namespace NuKeeper.Abstractions
         {
             return regex != null && regex.IsMatch(target);
         }
-
     }
 }

--- a/NuKeeper.GitHub/GitHubRepositoryDiscovery.cs
+++ b/NuKeeper.GitHub/GitHubRepositoryDiscovery.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -75,19 +76,7 @@ namespace NuKeeper.GitHub
 
         private static bool MatchesIncludeExclude(Repository repo, SourceControlServerSettings settings)
         {
-            return
-                MatchesInclude(settings.IncludeRepos, repo)
-                && !MatchesExclude(settings.ExcludeRepos, repo);
-        }
-
-        private static bool MatchesInclude(Regex regex, Repository repo)
-        {
-            return regex == null || regex.IsMatch(repo.Name);
-        }
-
-        private static bool MatchesExclude(Regex regex, Repository repo)
-        {
-            return regex != null && regex.IsMatch(repo.Name);
+            return RegexMatch.IncludeExclude(repo.Name, settings.IncludeRepos, settings.ExcludeRepos);
         }
 
         private static bool RepoIsModifiable(Repository repo)

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -120,19 +120,8 @@ namespace NuKeeper.Update.Selection
 
         private bool MatchesIncludeExclude(PackageUpdateSet packageUpdateSet)
         {
-            return 
-                MatchesInclude(_settings.Includes, packageUpdateSet)
-                && ! MatchesExclude(_settings.Excludes, packageUpdateSet);
-        }
-
-        private static bool MatchesInclude(Regex regex, PackageUpdateSet packageUpdateSet)
-        {
-            return regex == null || regex.IsMatch(packageUpdateSet.SelectedId);
-        }
-
-        private static bool MatchesExclude(Regex regex, PackageUpdateSet packageUpdateSet)
-        {
-            return regex != null && regex.IsMatch(packageUpdateSet.SelectedId);
+            return RegexMatch.IncludeExclude(packageUpdateSet.SelectedId,
+                _settings.Includes, _settings.Excludes);
         }
 
         private bool MatchesMinAge(PackageUpdateSet packageUpdateSet)

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRepositoryDiscovery.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRepositoryDiscovery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -70,20 +71,7 @@ namespace NuKeeper.BitBucketLocal
 
         private static bool MatchesIncludeExclude(Repository repo, SourceControlServerSettings settings)
         {
-            return
-                MatchesInclude(settings.IncludeRepos, repo)
-                && !MatchesExclude(settings.ExcludeRepos, repo);
+            return RegexMatch.IncludeExclude(repo.Name, settings.IncludeRepos, settings.ExcludeRepos);
         }
-
-        private static bool MatchesInclude(Regex regex, Repository repo)
-        {
-            return regex == null || regex.IsMatch(repo.Name);
-        }
-
-        private static bool MatchesExclude(Regex regex, Repository repo)
-        {
-            return regex != null && regex.IsMatch(repo.Name);
-        }
-
     }
 }


### PR DESCRIPTION
Refactor out common regex match
Now that the `MatchesIncludeExclude` pattern is used in 3 places