### PR TITLE
Temporary directory path from environment vars

### DIFF
--- a/NuKeeper.Inspection/Files/FolderFactory.cs
+++ b/NuKeeper.Inspection/Files/FolderFactory.cs
@@ -15,7 +15,17 @@ namespace NuKeeper.Inspection.Files
         public FolderFactory(INuKeeperLogger logger)
         {
             _logger = logger;
-            _systemTempPath = Path.GetTempPath();
+            _systemTempPath = GetSystemTempPath();
+        }
+
+        private static string GetSystemTempPath()
+        {
+            var tempFromEnv = Environment.GetEnvironmentVariable("temp");
+            if (!string.IsNullOrWhiteSpace(tempFromEnv) && Directory.Exists(tempFromEnv))
+            {
+                return tempFromEnv;
+            }
+            return Path.GetTempPath();
         }
 
         public IFolder UniqueTemporaryFolder()

--- a/NuKeeper.Inspection/Files/FolderFactory.cs
+++ b/NuKeeper.Inspection/Files/FolderFactory.cs
@@ -10,10 +10,12 @@ namespace NuKeeper.Inspection.Files
     public class FolderFactory : IFolderFactory
     {
         private readonly INuKeeperLogger _logger;
+        private readonly string _systemTempPath;
 
         public FolderFactory(INuKeeperLogger logger)
         {
             _logger = logger;
+            _systemTempPath = Path.GetTempPath();
         }
 
         public IFolder UniqueTemporaryFolder()
@@ -23,12 +25,12 @@ namespace NuKeeper.Inspection.Files
             return new Folder(_logger, tempDir);
         }
 
-        private static string NuKeeperTempFilesPath()
+        private string NuKeeperTempFilesPath()
         {
-            return Path.Combine(Path.GetTempPath(), "NuKeeper");
+            return Path.Combine(_systemTempPath, "NuKeeper");
         }
 
-        private static string GetUniqueTemporaryPath()
+        private string GetUniqueTemporaryPath()
         {
             var uniqueName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
             return Path.Combine(NuKeeperTempFilesPath(), uniqueName);

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -24,7 +24,7 @@ namespace NuKeeper
             container.Register<ILogger, NuGetLogger>();
 
             container.Register<IFolder, Folder>();
-            container.Register<IFolderFactory, FolderFactory>();
+            container.RegisterSingleton<IFolderFactory, FolderFactory>();
 
             container.Register<IPackageUpdatesLookup, PackageUpdatesLookup>();
             container.Register<IBulkPackageLookup, BulkPackageLookup>();


### PR DESCRIPTION
A workaround for #582 Path too long.
By setting the environment variable `temp`  to a folder with a shorter path, you can gain more chars for the checkout.

In most scenarios, the var `temp` is either not set (linux) or set to the same value as `Path.GetTempPath()` anyway (my windows machine) i.e. `C:\Users\ANTHONY.STEELE\AppData\Local\Temp` so you can make this shorter by pointing it at `c:\temp` or the like.

* We only need one folder factory. It's state doesn't change during the run
*  Get the system temp path at startup
* Check the env var `temp`.

Do not merge yet, let's check if this is the correct environment var to use.