### PR TITLE
Handles packages published in the future relative to NuKeeper

### DIFF
--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -234,6 +234,38 @@ namespace NuKeeper.Update.Tests
             Assert.That(results.Count, Is.EqualTo(0));
         }
 
+        [Test]
+        public async Task WhenThePackageIsFromTheFuture()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(TimeSpan.FromMinutes(-5))
+            };
+
+            var target = CreateUpdateSelection();
+            var settings = MinAgeTargetSelection(TimeSpan.FromDays(7));
+
+            var results = await target.Filter(updateSets, settings, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task WhenMinAgeIsZeroAndThePackageIsFromTheFuture()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(TimeSpan.FromMinutes(-5))
+            };
+
+            var target = CreateUpdateSelection();
+            var settings = MinAgeTargetSelection(TimeSpan.FromDays(0));
+
+            var results = await target.Filter(updateSets, settings, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+        }
+
         private static PackageUpdateSet UpdateFoobarFromOneVersion()
         {
             var newPackage = LatestVersionOfPackageFoobar();


### PR DESCRIPTION
#595 

The suggested `?` check wouldn't compile due to `Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and 'DateTime'` which struck me as odd since I was setting it to a `DateTime?`. I opted for a slightly different approach to the check