### PR TITLE
Handling Directory.Build.props/targets

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NSubstitute;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class DirectoryBuildTargetsReaderTests
+    {
+        const string PackagesFileWithSinglePackage =
+            @"<Project><ItemGroup><PackageReference Include=""foo"" Version=""1.2.3.4"" /></ItemGroup></Project>";
+
+        private const string PackagesFileWithTwoPackages = @"<Project><ItemGroup>
+<PackageReference Include=""foo"" Version=""1.2.3.4"" />
+<PackageReference Update=""bar"" Version=""2.3.4.5"" /></ItemGroup></Project>";
+
+        [Test]
+        public void EmptyPackagesListShouldBeParsed()
+        {
+            const string emptyContents =
+                @"<Project/>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(emptyContents), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Not.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeCorrect()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Id, Is.EqualTo("foo"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
+        public void TwoPackagesShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            PackageAssert.IsPopulated(packages[0]);
+            PackageAssert.IsPopulated(packages[1]);
+        }
+
+        [Test]
+        public void TwoPackagesShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+
+            Assert.That(packages[1].Id, Is.EqualTo("bar"));
+            Assert.That(packages[1].Version, Is.EqualTo(new NuGetVersion("2.3.4.5")));
+        }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            var path = TempPath();
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), path);
+
+            foreach (var package in packages)
+            {
+                PackageAssert.IsPopulated(package);
+            }
+
+            Assert.That(packages.Select(p => p.Path), Is.All.EqualTo(path));
+        }
+
+        [Test]
+        public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
+        {
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(badVersion), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(1));
+            PackageAssert.IsPopulated(packages[0]);
+        }
+
+        private static PackagePath TempPath()
+        {
+            return new PackagePath(
+                OsSpecifics.GenerateBaseDirectory(),
+                Path.Combine("src", "Directory.Build.Props"),
+                PackageReferenceType.DirectoryBuildTargets);
+        }
+
+        private static DirectoryBuildTargetsReader MakeReader()
+        {
+            return new DirectoryBuildTargetsReader(Substitute.For<INuKeeperLogger>());
+        }
+
+        private static Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public class DirectoryBuildTargetsReader : IPackageReferenceFinder
+
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public DirectoryBuildTargetsReader(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
+        {
+            var packagePath = new PackagePath(baseDirectory, relativePath, PackageReferenceType.DirectoryBuildTargets);
+            try
+            {
+                using (var fileContents = File.OpenRead(packagePath.FullName))
+                {
+                    return Read(fileContents, packagePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new NuKeeperException($"Unable to parse file {packagePath.FullName}", ex);
+            }
+        }
+
+        public IReadOnlyCollection<string> GetFilePatterns()
+        {
+            return new[] {"Directory.Build.props", "Directory.Build.targets"};
+        }
+
+        public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, PackagePath path)
+        {
+            var xml = XDocument.Load(fileContents);
+
+            var packagesNode = xml.Element("Project")?.Element("ItemGroup");
+            if (packagesNode == null)
+            {
+                return Array.Empty<PackageInProject>();
+            }
+
+            var packageNodeList = packagesNode.Elements()
+                .Where(x => x.Name == "PackageReference");
+
+            return packageNodeList
+                .Select(el => XmlToPackage(el, path))
+                .Where(el => el != null)
+                .ToList();
+        }
+
+        private PackageInProject XmlToPackage(XElement el, PackagePath path)
+        {
+            try
+            {
+                var id = el.Attribute("Include")?.Value;
+                if (id == null)
+                {
+                    id = el.Attribute("Update")?.Value;
+                }
+                var version = el.Attribute("Version")?.Value;
+
+                return new PackageInProject(id, version, path);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
@@ -5,6 +5,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
         PackagesConfig,
         ProjectFile,
         ProjectFileOldStyle,
-        Nuspec
+        Nuspec,
+        DirectoryBuildTargets
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/RepositoryScanner.cs
@@ -11,9 +11,11 @@ namespace NuKeeper.Inspection.RepositoryInspection
     {
         private readonly IReadOnlyCollection<IPackageReferenceFinder> _finders;
 
-        public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader, NuspecFileReader nuspecFileReader)
+        public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader,
+            NuspecFileReader nuspecFileReader, DirectoryBuildTargetsReader directoryBuildTargetsReader)
         {
-            _finders = new IPackageReferenceFinder[] {projectFileReader, packagesFileReader, nuspecFileReader};
+            _finders = new IPackageReferenceFinder[]
+                {projectFileReader, packagesFileReader, nuspecFileReader, directoryBuildTargetsReader};
         }
 
         public IReadOnlyCollection<PackageInProject> FindAllNuGetPackages(IFolder workingFolder)

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.NuGet.Process
+{
+    [TestFixture]
+    public class UpdateDirectoryBuildTargetsCommandTests
+    {
+        private readonly string _testFileWithUpdate =
+@"<Project><ItemGroup><PackageReference Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+
+        private readonly string _testFileWithInclude =
+@"<Project><ItemGroup><PackageReference Include=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithUpdateAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithUpdate, "<PackageReference Update=\"foo\" Version=\"{packageVersion}\" />");
+        }
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithIncludeAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageReference Include=\"foo\" Version=\"{packageVersion}\" />");
+        }
+
+        private static async Task ExecuteValidUpdateTest(string testProjectContents, string expectedPackageString, [CallerMemberName] string memberName = "")
+        {
+            const string oldPackageVersion = "5.2.31";
+            const string newPackageVersion = "5.3.4";
+
+            var testFolder = memberName;
+            var testFile = "Directory.Build.props";
+            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            Directory.CreateDirectory(workDirectory);
+            var projectContents = testProjectContents.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase);
+            var projectPath = Path.Combine(workDirectory, testFile);
+            await File.WriteAllTextAsync(projectPath, projectContents);
+
+            var command = new UpdateDirectoryBuildTargetsCommand(Substitute.For<INuKeeperLogger>());
+
+            var package = new PackageInProject("foo", oldPackageVersion,
+                new PackagePath(workDirectory, testFile, PackageReferenceType.DirectoryBuildTargets));
+
+            await command.Invoke(package, new NuGetVersion(newPackageVersion), null, NuGetSources.GlobalFeed);
+
+            var contents = await File.ReadAllTextAsync(projectPath);
+            Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion, StringComparison.OrdinalIgnoreCase)));
+            Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -183,7 +183,8 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             return new RepositoryScanner(
                 new ProjectFileReader(logger),
                 new PackagesFileReader(logger),
-                new NuspecFileReader(logger));
+                new NuspecFileReader(logger),
+                new DirectoryBuildTargetsReader(logger));
         }
 
         private static void WriteFile(IFolder path, string fileName, string contents)

--- a/NuKeeper.Update/Process/IUpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/IUpdateDirectoryBuildTargetsCommand.cs
@@ -1,0 +1,6 @@
+namespace NuKeeper.Update.Process
+{
+    public interface IUpdateDirectoryBuildTargetsCommand : IPackageCommand
+    {
+    }
+}

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -30,13 +30,13 @@ namespace NuKeeper.Update.Process
 
             using (var xmlOutput = File.Open(currentPackage.Path.FullName, FileMode.Truncate))
             {
-                UpdateNuspec(xmlOutput, newVersion, currentPackage, xml);
+                UpdateFile(xmlOutput, newVersion, currentPackage, xml);
             }
 
             return Task.CompletedTask;
         }
 
-        private void UpdateNuspec(Stream fileContents, NuGetVersion newVersion,
+        private void UpdateFile(Stream fileContents, NuGetVersion newVersion,
             PackageInProject currentPackage, XDocument xml)
         {
             var packagesNode = xml.Element("Project")?.Element("ItemGroup");

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Configuration;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.Update.Process
+{
+    public class UpdateDirectoryBuildTargetsCommand : IUpdateDirectoryBuildTargetsCommand
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public UpdateDirectoryBuildTargetsCommand(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Invoke(PackageInProject currentPackage, NuGetVersion newVersion, PackageSource packageSource,
+            NuGetSources allSources)
+        {
+            XDocument xml;
+            using (var xmlInput = File.OpenRead(currentPackage.Path.FullName))
+            {
+                xml = XDocument.Load(xmlInput);
+            }
+
+            using (var xmlOutput = File.Open(currentPackage.Path.FullName, FileMode.Truncate))
+            {
+                UpdateNuspec(xmlOutput, newVersion, currentPackage, xml);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void UpdateNuspec(Stream fileContents, NuGetVersion newVersion,
+            PackageInProject currentPackage, XDocument xml)
+        {
+            var packagesNode = xml.Element("Project")?.Element("ItemGroup");
+            if (packagesNode == null)
+            {
+                return;
+            }
+
+            var packageNodeList = packagesNode.Elements()
+                .Where(x => x.Name == "PackageReference" && (x.Attributes("Include")
+                                                                 .Any(a => a.Value == currentPackage.Id)
+                                                             || x.Attributes("Update")
+                                                                 .Any(a => a.Value == currentPackage.Id)));
+
+            foreach (var dependencyToUpdate in packageNodeList)
+            {
+                _logger.Detailed(
+                    $"Updating directory-level dependencies: {currentPackage.Id} in path {currentPackage.Path.FullName}");
+                dependencyToUpdate.Attribute("Version").Value = newVersion.ToString();
+            }
+
+            xml.Save(fileContents);
+        }
+    }
+}

--- a/NuKeeper.Update/UpdateRunner.cs
+++ b/NuKeeper.Update/UpdateRunner.cs
@@ -18,6 +18,7 @@ namespace NuKeeper.Update
         private readonly IDotNetUpdatePackageCommand _dotNetUpdatePackageCommand;
         private readonly IUpdateProjectImportsCommand _updateProjectImportsCommand;
         private readonly IUpdateNuspecCommand _updateNuspecCommand;
+        private readonly IUpdateDirectoryBuildTargetsCommand _updateDirectoryBuildTargetsCommand;
 
         public UpdateRunner(
             INuKeeperLogger logger,
@@ -25,7 +26,8 @@ namespace NuKeeper.Update
             INuGetUpdatePackageCommand nuGetUpdatePackageCommand,
             IDotNetUpdatePackageCommand dotNetUpdatePackageCommand,
             IUpdateProjectImportsCommand updateProjectImportsCommand,
-            IUpdateNuspecCommand updateNuspecCommand)
+            IUpdateNuspecCommand updateNuspecCommand,
+            IUpdateDirectoryBuildTargetsCommand updateDirectoryBuildTargetsCommand)
         {
             _logger = logger;
             _fileRestoreCommand = fileRestoreCommand;
@@ -33,6 +35,7 @@ namespace NuKeeper.Update
             _dotNetUpdatePackageCommand = dotNetUpdatePackageCommand;
             _updateProjectImportsCommand = updateProjectImportsCommand;
             _updateNuspecCommand = updateNuspecCommand;
+            _updateDirectoryBuildTargetsCommand = updateDirectoryBuildTargetsCommand;
         }
 
         public async Task Update(PackageUpdateSet updateSet, NuGetSources sources)
@@ -85,6 +88,9 @@ namespace NuKeeper.Update
 
                 case PackageReferenceType.Nuspec:
                     return new[] { _updateNuspecCommand };
+
+                case PackageReferenceType.DirectoryBuildTargets:
+                    return new[] { _updateDirectoryBuildTargetsCommand };
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(packageReferenceType));

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -14,6 +14,7 @@ namespace NuKeeper
             container.Register<IDotNetUpdatePackageCommand, DotNetUpdatePackageCommand>();
             container.Register<IUpdateProjectImportsCommand, UpdateProjectImportsCommand>();
             container.Register<IUpdateNuspecCommand, UpdateNuspecCommand>();
+            container.Register<IUpdateDirectoryBuildTargetsCommand, UpdateDirectoryBuildTargetsCommand>();
             container.Register<IExternalProcess, ExternalProcess>();
             container.Register<IUpdateRunner, UpdateRunner>();
             container.Register<INuGetPath, NuGetPath>();


### PR DESCRIPTION
Handles basic scenarios of `Include` (which NuKeeper uses) and `Update` (which was used in the issue created.

Sample PR for Include: https://github.com/skolima/NuKeeper/pull/11/files
Sample PR for Update: https://github.com/skolima/NuKeeper/pull/10/files

Resolves #478 