### PR TITLE
Relative path support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,9 +21,4 @@
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
-
-  <PropertyGroup>
-   <LangVersion>8</LangVersion>
- </PropertyGroup>
- 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,4 +21,9 @@
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+   <LangVersion>8</LangVersion>
+ </PropertyGroup>
+ 
 </Project>

--- a/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
+++ b/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
@@ -1,7 +1,6 @@
 using System;
 using NuKeeper.Abstractions.Formats;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace NuKeeper.Abstractions.Tests.Formats
 {

--- a/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
+++ b/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NuKeeper.Abstractions.Formats;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace NuKeeper.Abstractions.Tests.Formats
 {
@@ -26,6 +27,33 @@ namespace NuKeeper.Abstractions.Tests.Formats
 
             Assert.That(output.ToString(), Is.EqualTo("http://test.com/api/path/"));
         }
+        
+        [Test]
+        public void IsLocalUri()
+        {
+            var input = "./";
+            var output = input.ToUri();
 
+            Assert.That(output.IsFile, Is.EqualTo(true));
+        }
+        
+        [Test]
+        public void IsRemoteUri()
+        {
+            var input = "https://www.google.com";
+            var output = input.ToUri();
+            
+            Assert.That(output.Host, Is.EqualTo("www.google.com"));
+        }
+        
+        [Test]
+        public void IsNonExistingUri()
+        {
+            var input = "../../../invalidpath/test/1234/abcde";
+            
+            Assert.That(() => input.ToUri(), 
+                Throws.Exception
+                    .TypeOf<NuKeeperException>());
+        }
     }
 }

--- a/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
+++ b/NuKeeper.Abstractions.Tests/Formats/UriFormatsTests.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.Abstractions.Tests.Formats
         [Test]
         public void IsLocalUri()
         {
-            var input = "./";
+            var input = ".";
             var output = input.ToUri();
 
             Assert.That(output.IsFile, Is.EqualTo(true));

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using NuKeeper.Abstractions.Git;
 
 namespace NuKeeper.Abstractions.Formats
@@ -32,6 +33,22 @@ namespace NuKeeper.Abstractions.Formats
                 if (origin != null)
                     return origin.Url;
             }
+            
+            return repositoryUri;
+        }
+
+        public static Uri ToUri(this string test)
+        {
+            var calledFrom = Environment.CurrentDirectory;
+            
+            var repositoryUri = new Uri(test, UriKind.RelativeOrAbsolute);
+
+            if (repositoryUri.IsAbsoluteUri) return repositoryUri;
+            
+            var absoluteUri = Path.Combine(calledFrom, repositoryUri.OriginalString);
+            
+            if (!Directory.Exists(absoluteUri))
+                throw new NuKeeperException($"Local uri doesn't exist: {absoluteUri}");
             
             return repositoryUri;
         }

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -38,11 +38,11 @@ namespace NuKeeper.Abstractions.Formats
             return repositoryUri;
         }
 
-        public static Uri ToUri(this string test)
+        public static Uri ToUri(this string repositoryString)
         {
             var calledFrom = Environment.CurrentDirectory;
             
-            var repositoryUri = new Uri(test, UriKind.RelativeOrAbsolute);
+            var repositoryUri = new Uri(repositoryString, UriKind.RelativeOrAbsolute);
 
             if (repositoryUri.IsAbsoluteUri) return repositoryUri;
             

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using NuGet.Common;
 using NuKeeper.Abstractions.Git;
 
 namespace NuKeeper.Abstractions.Formats
@@ -50,7 +51,7 @@ namespace NuKeeper.Abstractions.Formats
             if (!Directory.Exists(absoluteUri))
                 throw new NuKeeperException($"Local uri doesn't exist: {absoluteUri}");
             
-            return repositoryUri;
+            return new Uri(absoluteUri);
         }
     }
 }

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -40,17 +40,18 @@ namespace NuKeeper.Abstractions.Formats
 
         public static Uri ToUri(this string repositoryString)
         {
-            var calledFrom = Environment.CurrentDirectory;
-            
             var repositoryUri = new Uri(repositoryString, UriKind.RelativeOrAbsolute);
-
-            if (repositoryUri.IsAbsoluteUri) return repositoryUri;
+            if (repositoryUri.IsAbsoluteUri)
+            {
+                return repositoryUri;
+            }
             
-            var absoluteUri = Path.Combine(calledFrom, repositoryUri.OriginalString);
-            
+            var absoluteUri = Path.Combine(Environment.CurrentDirectory, repositoryUri.OriginalString);
             if (!Directory.Exists(absoluteUri))
+            {
                 throw new NuKeeperException($"Local uri doesn't exist: {absoluteUri}");
-            
+            }
+
             return new Uri(absoluteUri);
         }
     }

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -32,7 +32,9 @@ namespace NuKeeper.Abstractions.Formats
                 var origin = discoveryDriver.GetRemoteForPlatform(repositoryUri, shouldMatchTo);
                 
                 if (origin != null)
+                {
                     return origin.Url;
+                }
             }
             
             return repositoryUri;

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -4,7 +4,6 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Inspection.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using NuKeeper.Abstractions.Formats;
 using NuKeeper.Collaboration;
 
@@ -14,7 +13,7 @@ namespace NuKeeper.Commands
     internal class RepositoryCommand : CollaborationPlatformCommand
     {
         [Argument(0, Name = "Repository URI", Description = "The URI of the repository to scan.")]
-        public string RepositoryUri { get; set; } 
+        public string RepositoryUri { get; set; }
         
         private readonly IEnumerable<ISettingsReader> _settingsReaders;
 

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -39,10 +39,11 @@ namespace NuKeeper.Commands
             var didRead = false;
             foreach (var reader in _settingsReaders)
             {
-                if (!reader.CanRead(repoUri)) continue;
-                
-                didRead = true;
-                settings.SourceControlServerSettings.Repository = reader.RepositorySettings(repoUri);
+                if (reader.CanRead(repoUri))
+                {
+                    didRead = true;
+                    settings.SourceControlServerSettings.Repository = reader.RepositorySettings(repoUri);
+                }
             }
 
             if (!didRead)

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -1,8 +1,8 @@
 using System.Text;
+using SimpleInjector;
 using NuGet.Common;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
-using SimpleInjector;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;


### PR DESCRIPTION
This adds relative path support for when using the repo command.
For example: `nukeeper repo ../ {token}` or `nukeeper repo . {token}`

In the end it will just get the directory that you are calling it from and concats the arguments to make a new absolute path.

