### PR TITLE
Review  "IsPrerelease" enum

### DIFF
--- a/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
@@ -32,6 +32,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
             Assert.That(data.ForkMode, Is.Null);
+            Assert.That(data.UsePrerelease, Is.Null);
 
             Assert.That(data.OutputDestination, Is.Null);
             Assert.That(data.OutputFormat, Is.Null);
@@ -59,6 +60,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
             Assert.That(data.ForkMode, Is.Null);
+            Assert.That(data.UsePrerelease, Is.Null);
 
             Assert.That(data.OutputDestination, Is.Null);
             Assert.That(data.OutputFormat, Is.Null);
@@ -80,6 +82,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
                ""verbosity"": ""Detailed"",
                ""Change"": ""Minor"",
                ""ForkMode"": ""PreferFork"",
+               ""UsePrerelease"": ""Never"",
                ""OutputFormat"": ""Text"",
                ""OutputDestination"": ""Console"",
                ""OutputFileName"" : ""out_42.txt"",
@@ -148,6 +151,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
 
             Assert.That(data.Change, Is.EqualTo(VersionChange.Minor));
             Assert.That(data.ForkMode, Is.EqualTo(ForkMode.PreferFork));
+            Assert.That(data.UsePrerelease, Is.EqualTo(UsePrerelease.Never));
 
             Assert.That(data.Verbosity, Is.EqualTo(LogLevel.Detailed));
             Assert.That(data.LogDestination, Is.EqualTo(LogDestination.File));

--- a/NuKeeper.Abstractions/Configuration/UsePrerelease.cs
+++ b/NuKeeper.Abstractions/Configuration/UsePrerelease.cs
@@ -2,9 +2,8 @@ namespace NuKeeper.Abstractions.Configuration
 {
     public enum UsePrerelease
     {
-        None = 0,
-        Always = 1,
-        Never = 2,
-        FromPrerelease = 3
+        Always,
+        Never,
+        FromPrerelease
     }
 }

--- a/NuKeeper.Inspection.Tests/NuGetApi/UsePrereleaseLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/UsePrereleaseLookupTests.cs
@@ -193,66 +193,6 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             Assert.That(updates.Major.Identity.Version, Is.EqualTo(HighestVersion(resultPackages)));
         }
 
-        [TestCase(false, VersionChange.Major, 2, 3, 4, "")]
-        [TestCase(false, VersionChange.Minor, 1, 3, 1, "")]
-        [TestCase(false, VersionChange.Patch, 1, 2, 5, "")]
-        [TestCase(false, VersionChange.None, 1, 2, 3, "")]
-        [TestCase(true, VersionChange.Major, 2, 3, 4, PackageVersionTestData.PrereleaseLabel)]
-        [TestCase(true, VersionChange.Minor, 1, 3, 1, PackageVersionTestData.PrereleaseLabel)]
-        [TestCase(true, VersionChange.Patch, 1, 2, 5, PackageVersionTestData.PrereleaseLabel)]
-        [TestCase(true, VersionChange.None, 1, 2, 3, PackageVersionTestData.PrereleaseLabel)]
-        public async Task WhenFromPrereleaseIsNoneAndCurrentVersionIsPrerelease(
-            bool latestPackageIsPrerelease,
-            VersionChange dataRange,
-            int expectedMajor, int expectedMinor, int expectedPatch, string expectedReleaseLabel)
-        {
-            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedReleaseLabel);
-            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
-            if (latestPackageIsPrerelease)
-            {
-                // Only grab updated prerelease packages for this test - otherwise we'll upgrade to 2.3.4 instead of 2.3.4-prerelease
-                resultPackages = resultPackages.Where(x => x.Identity.Version.IsPrerelease).ToList();
-            }
-            var allVersionsLookup = MockVersionLookup(resultPackages);
-
-            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
-
-            var updates = await lookup.FindVersionUpdate(
-                CurrentVersion123Prerelease("TestPackage"),
-                NuGetSources.GlobalFeed,
-                VersionChange.Major,
-                UsePrerelease.None);
-
-            AssertPackagesIdentityIs(updates, "TestPackage");
-            Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
-            Assert.That(updates.Major.Identity.Version, Is.EqualTo(HighestVersion(resultPackages)));
-        }
-
-        [TestCase(VersionChange.Major, 2, 3, 4, "")]
-        [TestCase(VersionChange.Minor, 1, 3, 1, "")]
-        [TestCase(VersionChange.Patch, 1, 2, 5, "")]
-        [TestCase(VersionChange.None, 1, 2, 3, "")]
-        public async Task WhenFromPrereleaseIsNoneAndCurrentVersionIsStable(VersionChange dataRange,
-            int expectedMajor, int expectedMinor, int expectedPatch, string expectedReleaseLabel)
-        {
-            var expectedUpdate = new NuGetVersion(expectedMajor, expectedMinor, expectedPatch, expectedReleaseLabel);
-            var resultPackages = PackageVersionTestData.VersionsFor(dataRange);
-            var allVersionsLookup = MockVersionLookup(resultPackages);
-
-            IApiPackageLookup lookup = new ApiPackageLookup(allVersionsLookup);
-
-            var updates = await lookup.FindVersionUpdate(
-                CurrentVersion123("TestPackage"),
-                NuGetSources.GlobalFeed,
-                VersionChange.Major,
-                UsePrerelease.None);
-
-            AssertPackagesIdentityIs(updates, "TestPackage");
-            Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
-            Assert.That(updates.Major.Identity.Version, Is.EqualTo(HighestVersion(resultPackages)));
-        }
-
-
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMedatadata> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();


### PR DESCRIPTION
Review the `IsPrerelease` enum
The `None = 0` option is best practice in some contexts where values could be uninitialised, but here it is a command line param, and that is not value that we want users to be able to set. 
Add in standard tests on settings file.

Case over enum should default to throwing, for an unknown value.