### PR TITLE
Use NugetVersion in build

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -3,6 +3,13 @@ queue:
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 steps:
+  - bash: echo Set $NugetVersion
+    env:
+      NugetVersion: $(NugetVersion)
+  - powershell: Write-Host Set $NugetVersion
+    env:
+      NugetVersion : $(NugetVersion)
+
 - task: DotNetCoreInstaller@0
   displayName: 'Use .NET Core sdk 2.1.500'
   inputs:

--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -8,7 +8,7 @@ steps:
   inputs:
     version: 2.1.500
 
-- bash: NugetVersion=$(NugetVersion)
+- bash: export NugetVersion=$(NugetVersion)
   displayName: 'set NugetVersion into env vars'
   env:
     NugetVersion: $(NugetVersion)

--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -3,17 +3,15 @@ queue:
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 steps:
-  - bash: echo Set $NugetVersion
-    env:
-      NugetVersion: $(NugetVersion)
-  - powershell: Write-Host Set $NugetVersion
-    env:
-      NugetVersion : $(NugetVersion)
-
 - task: DotNetCoreInstaller@0
   displayName: 'Use .NET Core sdk 2.1.500'
   inputs:
     version: 2.1.500
+
+- bash: NugetVersion=$(NugetVersion)
+  displayName: 'set NugetVersion into env vars'
+  env:
+    NugetVersion: $(NugetVersion)
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'

--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -8,7 +8,7 @@ steps:
   inputs:
     version: 2.1.500
 
-- bash: export NugetVersion=$(NugetVersion)
+- bash: export NugetVersion
   displayName: 'set NugetVersion into env vars'
   env:
     NugetVersion: $(NugetVersion)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>0.10.2</VersionPrefix>
-    <PackageVersion>$(VersionPrefix)</PackageVersion>
+    <PackageVersion>$(NugetVersion)</PackageVersion>
     <Copyright>Copyright (c) NuKeeper 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
I'm not quite sure that this will work, but in the Azure DevOps build there is a variable called `NugetVersion` which will contain the correct version metadata and we want it to show up here, and not the `VersionPrefix` which is no longer correct.
