### PR TITLE
Implemented pull after checking out.

### DIFF
--- a/NuKeeper.Abstractions/Git/IGitDriver.cs
+++ b/NuKeeper.Abstractions/Git/IGitDriver.cs
@@ -19,6 +19,8 @@ namespace NuKeeper.Abstractions.Git
 
         void Push(string remoteName, string branchName);
 
+        void Pull();
+
         string GetCurrentHead();
 
     }

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -154,6 +154,16 @@ namespace NuKeeper.Git
             }
         }
 
+        public void Pull()
+        {
+            using (var repo = MakeRepo())
+            {
+                var pullOptions = new PullOptions();
+
+                GitCommands.Pull(repo, GetSignature(repo), pullOptions);
+            }
+        }
+
         public string GetCurrentHead()
         {
             using (var repo = MakeRepo())

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -67,6 +67,8 @@ namespace NuKeeper.Engine.Packages
 
             git.Checkout(repository.DefaultBranch);
 
+            git.Pull();
+
             // branch
             var branchWithChanges = BranchNamer.MakeName(updates);
             _logger.Detailed($"Using branch name: '{branchWithChanges}'");
@@ -98,7 +100,6 @@ namespace NuKeeper.Engine.Packages
             var pullRequestRequest = new PullRequestRequest(qualifiedBranch, title, repository.DefaultBranch) { Body = body };
 
             await _collaborationFactory.CollaborationPlatform.OpenPullRequest(repository.Pull, pullRequestRequest, settings.SourceControlServerSettings.Labels);
-
 
             git.Checkout(repository.DefaultBranch);
             return updates.Count;


### PR DESCRIPTION
Fix for: https://github.com/NuKeeperDotNet/NuKeeper/issues/620

This pull request implements `git pull` in `LibGit2SharpDriver`. Calling `Pull` after `Checkout` to make sure the default branch is locally up-to-date.