### PR TITLE
 Target NetCoreApp2.2 not 2.1

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -4,9 +4,9 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 steps:
 - task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.1.500'
+  displayName: 'Use .NET Core sdk 2.2.100'
   inputs:
-    version: 2.1.500
+    version: 2.2.100
 
 - bash: echo NugetVersion is $NugetVersion; export NugetVersion
   displayName: 'export NugetVersion into env vars'

--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -4,9 +4,9 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 steps:
 - task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.100'
+  displayName: 'Use .NET Core sdk 2.2.101'
   inputs:
-    version: 2.2.100
+    version: 2.2.101
 
 - bash: echo NugetVersion is $NugetVersion; export NugetVersion
   displayName: 'export NugetVersion into env vars'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: trusty
-dotnet: 2.2.100
+dotnet: 2.2.101
 script:
   - dotnet build -c Release NuKeeper.sln /m:1
   - dotnet test -c Release NuKeeper.sln --filter "TestCategory!=WindowsOnly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dist: trusty
+dist: bionic
 dotnet: 2.2.101
 script:
   - dotnet build -c Release NuKeeper.sln /m:1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dist: bionic
+dist: xenial
 dotnet: 2.2.101
 script:
   - dotnet build -c Release NuKeeper.sln /m:1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: trusty
-dotnet: 2.1.500
+dotnet: 2.2.100
 script:
   - dotnet build -c Release NuKeeper.sln /m:1
   - dotnet test -c Release NuKeeper.sln --filter "TestCategory!=WindowsOnly"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <VersionPrefix>$(NugetVersion)</VersionPrefix>

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+ 	</PropertyGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Content Include="$(NuGetPackageRoot)\nuget.commandline\4.7.1\tools\NuGet.exe">
       <Pack>true</Pack>
-      <PackagePath>tools\netcoreapp2.1\any\NuGet.exe</PackagePath>
+      <PackagePath>tools\netcoreapp2.2\any\NuGet.exe</PackagePath>
     </Content>
   </ItemGroup>
 </Project>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.500"
+    "version": "2.2.101"
   },
   "projects": []
 }


### PR DESCRIPTION
Update to the December SDK release
- Target `netcoreapp2.2` not `2.1`
- SDK Version `2.2.101`
- `TreatWarningsAsErrors` and `LangVersion` settings are not needed in `.csproj` files as these are set globally in `Directory.Build.props`