### PR TITLE
Nuget update commandline is NonInteractive

### DIFF
--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.Update.Process
             }
 
             var sources = allSources.CommandLine("-Source");
-            var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources}";
+            var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources} -NonInteractive";
             await _externalProcess.Run(projectPath, nuget, updateCommand, true);
         }
     }


### PR DESCRIPTION
Use the `-NonInteractive` flag on update
docs https://docs.microsoft.com/en-gb/nuget/tools/cli-ref-update

For #627