### PR TITLE
Package version ranges

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuGet/VersionRangesTests.cs
+++ b/NuKeeper.Abstractions.Tests/NuGet/VersionRangesTests.cs
@@ -1,0 +1,73 @@
+using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
+using NUnit.Framework;
+
+namespace NuKeeper.Abstractions.Tests.NuGet
+{
+    public class VersionRangesTests
+    {
+        [TestCase("1.2.3")]
+        [TestCase("1.2.3.4")]
+        [TestCase("1.2.3-beta04")]
+        [TestCase("1.2.3.4-beta05")]
+        public void ParseableToSingleVersion(string rangeString)
+        {
+            var canParseAsRange = VersionRange.TryParse(rangeString, out VersionRange versionRange);
+            Assert.That(canParseAsRange, Is.True);
+
+            var singleVersion = VersionRanges.SingleVersion(versionRange);
+
+            Assert.That(versionRange, Is.Not.Null);
+            Assert.That(singleVersion, Is.Not.Null);
+        }
+
+        [TestCase("1.*")]
+        [TestCase("1.2.*")]
+        [TestCase("1.2.3.*")]
+        [TestCase("[1.*, 2.0.0)")]
+        public void ParseableButNotSingleVersion(string rangeString)
+        {
+            var canParseAsRange = VersionRange.TryParse(rangeString, out VersionRange versionRange);
+            Assert.That(canParseAsRange, Is.True);
+
+            var singleVersion = VersionRanges.SingleVersion(versionRange);
+
+            Assert.That(versionRange, Is.Not.Null);
+            Assert.That(singleVersion, Is.Null);
+        }
+
+        [TestCase("1.2.3")]
+        [TestCase("1.2.3.4")]
+        [TestCase("1.2.3-beta04")]
+        [TestCase("1.2.3.4-beta05")]
+        public void ParseableToPackageIdentity(string rangeString)
+        {
+            var rangeIdentity = PackageVersionRange.Read("testPackage", rangeString);
+            var singleVersion = rangeIdentity.SingleVersionIdentity();
+
+            Assert.That(rangeIdentity, Is.Not.Null);
+            Assert.That(rangeIdentity.Id, Is.EqualTo("testPackage"));
+            Assert.That(rangeIdentity.Version, Is.Not.Null);
+
+            Assert.That(singleVersion, Is.Not.Null);
+            Assert.That(singleVersion.Id, Is.EqualTo("testPackage"));
+            Assert.That(singleVersion.Version, Is.Not.Null);
+        }
+
+        [TestCase("1.*")]
+        [TestCase("1.2.*")]
+        [TestCase("1.2.3.*")]
+        [TestCase("[1.*, 2.0.0)")]
+        public void ParseableButNotToPackageIdentity(string rangeString)
+        {
+            var rangeIdentity = PackageVersionRange.Read("testPackage", rangeString);
+            var singleVersion = rangeIdentity.SingleVersionIdentity();
+
+            Assert.That(rangeIdentity, Is.Not.Null);
+            Assert.That(rangeIdentity.Id, Is.EqualTo("testPackage"));
+            Assert.That(rangeIdentity.Version, Is.Not.Null);
+
+            Assert.That(singleVersion, Is.Null);
+        }
+    }
+}

--- a/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
+++ b/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
@@ -1,0 +1,55 @@
+using System;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuKeeper.Abstractions.NuGet
+{
+    public class PackageVersionRange
+    {
+        public PackageVersionRange(string id, VersionRange version)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Should not be null or empty", nameof(id));
+            }
+
+            if (Version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            Id = id;
+            Version = version;
+        }
+
+        public string Id { get; }
+        public VersionRange Version { get; }
+
+        public static PackageVersionRange Read(string id, string version)
+        {
+            var success = VersionRange.TryParse(version, out VersionRange versionRange);
+            if (!success)
+            {
+                throw new ArgumentException($"Could not parse {version} as a version range", nameof(version));
+            }
+
+            return new PackageVersionRange(id, versionRange);
+        }
+
+        public NuGetVersion SingleVersion()
+        {
+            return VersionRanges.SingleVersion(Version);
+        }
+
+        public PackageIdentity Identity()
+        {
+            var version = SingleVersion();
+            if (version == null)
+            {
+                return null;
+            }
+
+            return new PackageIdentity(Id, version);
+        }
+    }
+}

--- a/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
+++ b/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
@@ -13,13 +13,8 @@ namespace NuKeeper.Abstractions.NuGet
                 throw new ArgumentException("Should not be null or empty", nameof(id));
             }
 
-            if (Version == null)
-            {
-                throw new ArgumentNullException(nameof(version));
-            }
-
             Id = id;
-            Version = version;
+            Version = version ?? throw new ArgumentNullException(nameof(version));
         }
 
         public string Id { get; }
@@ -36,14 +31,9 @@ namespace NuKeeper.Abstractions.NuGet
             return new PackageVersionRange(id, versionRange);
         }
 
-        public NuGetVersion SingleVersion()
+        public PackageIdentity SingleVersionIdentity()
         {
-            return VersionRanges.SingleVersion(Version);
-        }
-
-        public PackageIdentity Identity()
-        {
-            var version = SingleVersion();
+            var version = VersionRanges.SingleVersion(Version);
             if (version == null)
             {
                 return null;

--- a/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
+++ b/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Abstractions.NuGet
             var success = VersionRange.TryParse(version, out VersionRange versionRange);
             if (!success)
             {
-                throw new ArgumentException($"Could not parse {version} as a version range", nameof(version));
+                return null;
             }
 
             return new PackageVersionRange(id, versionRange);

--- a/NuKeeper.Abstractions/NuGet/VersionRanges.cs
+++ b/NuKeeper.Abstractions/NuGet/VersionRanges.cs
@@ -1,0 +1,17 @@
+using NuGet.Versioning;
+
+namespace NuKeeper.Abstractions.NuGet
+{
+    public static class VersionRanges
+    {
+        public static NuGetVersion SingleVersion(VersionRange range)
+        {
+            if (range.IsFloating || range.HasLowerAndUpperBounds)
+            {
+                return null;
+            }
+
+            return range.MinVersion;
+        }
+    }
+}

--- a/NuKeeper.Inspection.Tests/Report/PackageUpdates.cs
+++ b/NuKeeper.Inspection.Tests/Report/PackageUpdates.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.Inspection.Tests.Report
                 OsSpecifics.GenerateBaseDirectory(),
                 Path.Combine("folder", "src", "project1", "packages.config"),
                 PackageReferenceType.PackagesConfig);
-            return new PackageInProject(package.Id, package.Version.ToString(), path);
+            return new PackageInProject(package, path);
         }
 
         internal static List<PackageUpdateSet> PackageUpdateSets(int count)

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -9,13 +9,14 @@ using NuKeeper.Abstractions.Logging;
 namespace NuKeeper.Inspection.RepositoryInspection
 {
     public class DirectoryBuildTargetsReader : IPackageReferenceFinder
-
     {
         private readonly INuKeeperLogger _logger;
+        private readonly PackageInProjectReader _packageInProjectReader;
 
         public DirectoryBuildTargetsReader(INuKeeperLogger logger)
         {
             _logger = logger;
+            _packageInProjectReader = new PackageInProjectReader(logger);
         }
 
         public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
@@ -69,7 +70,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 }
                 var version = el.Attribute("Version")?.Value;
 
-                return new PackageInProject(id, version, path);
+                return _packageInProjectReader.Read(id, version, path, null);
             }
             catch (Exception ex)
             {

--- a/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
@@ -11,10 +11,12 @@ namespace NuKeeper.Inspection.RepositoryInspection
     public class NuspecFileReader : IPackageReferenceFinder
     {
         private readonly INuKeeperLogger _logger;
+        private readonly PackageInProjectReader _packageInProjectReader;
 
         public NuspecFileReader(INuKeeperLogger logger)
         {
             _logger = logger;
+            _packageInProjectReader = new PackageInProjectReader(logger);
         }
 
         public IReadOnlyCollection<PackageInProject> ReadFile(string baseDirectory, string relativePath)
@@ -64,7 +66,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 var id = el.Attribute("id")?.Value;
                 var version = el.Attribute("version")?.Value;
 
-                return new PackageInProject(id, version, path);
+                return _packageInProjectReader.Read(id, version, path, null);
 
             }
             catch (Exception ex)

--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
     {
         public PackageInProject(PackageIdentity identity,
             PackagePath path,
-            IEnumerable<string> projectReferences)
+            IEnumerable<string> projectReferences = null)
         {
             Identity = identity;
             Path = path;

--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public class PackageInProjectReader
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public PackageInProjectReader(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public PackageInProject Read(
+            string id, string version,
+            PackagePath path,
+            IEnumerable<string> projectReferences)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                _logger.Normal($"Skipping package with no id specified in file '{path.FullName}'.");
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                _logger.Normal($"Skipping package '{id}' with no version specified in file '{path.FullName}'.");
+                return null;
+            }
+
+            var packageVersionRange = PackageVersionRange.Read(id, version);
+
+            if (packageVersionRange == null)
+            {
+                _logger.Normal($"Skipping package '{id}' with version '{version}' that could not be parsed in file '{path.FullName}'.");
+                return null;
+            }
+
+            var singleVersion = packageVersionRange.SingleVersionIdentity();
+
+            if (singleVersion == null)
+            {
+                _logger.Normal($"Skipping package '{id}' with version range '{version}' that is not a single version in file '{path.FullName}'.");
+                return null;
+            }
+
+            return new PackageInProject(singleVersion, path, projectReferences);
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return null;
                 }
 
-                var singleVersion = packageVersionRange?.SingleVersionIdentity();
+                var singleVersion = packageVersionRange.SingleVersionIdentity();
 
                 if (singleVersion == null)
                 {


### PR DESCRIPTION
I would like the code to work better with version ranges. This is a start.

The package version in a  `.csproj` or `packages.config` file is actually a version range. The single version (e.g. `1.2.3` ) is actually a very common special case. But there are others, e.g. e.g.  `AWSSDK.Core` version `3.3.*`.

We use the library class `NuGet.Versioning.VersionRange` for a range. 

Where the library class `PackageIdentity` has a package Id and a package version, there is no library class to store an Id and Package version range, so I made `PackageVersionRange` .

This is currently converted to a `PackageIdentity` immediately, and drop the items where it can't be converted.  All this gives us is more specific messages about why we can't update that package.

Next steps would be to keep it for longer and convert at the last possible time.

#466
