### PR TITLE
BeforePullRequestCommand

### DIFF
--- a/NuKeeper.Abstractions/Configuration/UserSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/UserSettings.cs
@@ -21,5 +21,6 @@ namespace NuKeeper.Abstractions.Configuration
         public string OutputFileName { get; set; }
 
         public string Directory { get; set; }
+        public string BeforePullRequestCommand { get; set; }
     }
 }


### PR DESCRIPTION
Hacking around with a "BeforePullRequestCommand"
for #568 

- To generalise this, there could be different places to run commands, that can be hooked into, e.g. "after checkout", "after branch", but not try to cover all the cases, I'll go with YAGNI until someone has a use for that.

- The command is run in the checkout folder, meaning that if the script is in the source repo it will be there with the rest of the repo files. Since the script won't necessarily know what this path is, it is possible to give the command a variable substitution, e.g. replace `{{CheckoutFolder}}` with this path, `{{GitOrigin}}` with that, etc. Unclear if anything like this is needed.