### PR TITLE
Added BitBucket "default reviewers" to Pull Requests

### DIFF
--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -74,7 +74,7 @@ namespace NuKeeper.Collaboration
 
                 if (reader != null)
                 {
-                    _nuKeeperLogger.Normal($"Collaboration platform specified as '{_platform}'");
+                    _nuKeeperLogger.Normal($"Collaboration platform specified as '{reader.Platform}'");
                 }
 
                 return reader;
@@ -86,7 +86,7 @@ namespace NuKeeper.Collaboration
 
                 if (reader != null)
                 {
-                    _nuKeeperLogger.Normal($"Matched uri '{apiEndpoint}' to collaboration platform '{_platform}'");
+                    _nuKeeperLogger.Normal($"Matched uri '{apiEndpoint}' to collaboration platform '{reader.Platform}'");
                 }
 
                 return reader;

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
@@ -10,7 +9,7 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.BitBucketLocal.Models;
 using Repository = NuKeeper.Abstractions.CollaborationModels.Repository;
-using User = NuKeeper.Abstractions.CollaborationModels.User;
+
 
 namespace NuKeeper.BitBucketLocal
 {

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -10,6 +10,7 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.BitBucketLocal.Models;
 using Repository = NuKeeper.Abstractions.CollaborationModels.Repository;
+using User = NuKeeper.Abstractions.CollaborationModels.User;
 
 namespace NuKeeper.BitBucketLocal
 {
@@ -29,8 +30,9 @@ namespace NuKeeper.BitBucketLocal
             _settings = settings;
             var httpClient = new HttpClient
             {
-                BaseAddress = settings.ApiBase
-            };
+                BaseAddress = new Uri($"{settings.ApiBase.Scheme}://{settings.ApiBase.Authority}")
+             };
+
             _client = new BitbucketLocalRestClient(httpClient, _logger, settings.Username, settings.Token);
         }
 
@@ -44,6 +46,8 @@ namespace NuKeeper.BitBucketLocal
             var repositories = await _client.GetGitRepositories(target.Owner);
             var targetRepository = repositories.FirstOrDefault(x => x.Name.Equals(target.Name, StringComparison.InvariantCultureIgnoreCase));
 
+            var reviewers = await _client.GetBitBucketReviewers(target.Owner, targetRepository.Name);
+
             var pullReq = new PullRequest
             {
                 Title = request.Title,
@@ -55,7 +59,8 @@ namespace NuKeeper.BitBucketLocal
                 ToRef = new Ref
                 {
                     Id = request.BaseRef
-                }
+                },
+                Reviewers = reviewers.ToList()
             };
 
             await _client.CreatePullRequest(pullReq, target.Owner, targetRepository.Name);

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.BitBucketLocal
 
             return new RepositorySettings
             {
-                ApiUri = new Uri($"{repositoryUri.Scheme}://{repositoryUri.Authority}/rest/api/1.0"),
+                ApiUri = new Uri($"{repositoryUri.Scheme}://{repositoryUri.Authority}"),
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
                 RepositoryOwner = project
@@ -65,3 +65,5 @@ namespace NuKeeper.BitBucketLocal
         }
     }
 }
+
+

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -83,26 +84,26 @@ namespace NuKeeper.BitBucketLocal
 
         public async Task<IEnumerable<Repository>> GetProjects([CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>("projects?limit=999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>("rest/api/1.0/projects?limit=999", caller);
             return response.Values;
         }
 
 
         public async Task<IEnumerable<Repository>> GetGitRepositories(string projectName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($"projects/{projectName}/repos?limit=999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($"rest/api/1.0/projects/{projectName}/repos?limit=999", caller);
             return response.Values;
         }
 
         public async Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string repositoryName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<string>>($"projects/{projectName}/repos/{repositoryName}/files?limit=9999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<string>>($"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/files?limit=9999", caller);
             return response.Values;
         }
 
         public async Task<IEnumerable<Branch>> GetGitRepositoryBranches(string projectName, string repositoryName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Branch>>($"projects/{projectName}/repos/{repositoryName}/branches", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Branch>>($"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/branches", caller);
             return  response.Values;
         }
 
@@ -111,9 +112,15 @@ namespace NuKeeper.BitBucketLocal
             var requestJson = JsonConvert.SerializeObject(pullReq, Formatting.None, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore});
             var requestBody = new StringContent(requestJson, Encoding.UTF8, "application/json");
             
-            var response = await _client.PostAsync($@"projects/{projectName}/repos/{repositoryName}/pull-requests", requestBody);
+            var response = await _client.PostAsync($@"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/pull-requests", requestBody);
 
             return await HandleResponse<PullRequest>(response, caller);
+        }
+
+        public async Task<IEnumerable<AddReviewer>> GetBitBucketReviewers(string projectName, string repositoryName, [CallerMemberName] string caller = null)
+        {
+            var response = await GetResourceOrEmpty<List<Conditions>>($"rest/default-reviewers/1.0/projects/{projectName}/repos/{repositoryName}/conditions", caller);
+            return response.SelectMany(c => c.Reviewers).Select(usr => new AddReviewer() {User = usr} );
         }
     }
 }

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -18,6 +18,8 @@ namespace NuKeeper.BitBucketLocal
     {
         private readonly HttpClient _client;
         private readonly INuKeeperLogger _logger;
+        private const string ApiPath = @"rest/api/1.0";
+        private const string ApiReviewersPath = @"rest/default-reviewers/1.0";
 
         public BitbucketLocalRestClient(HttpClient client, INuKeeperLogger logger, string username, string appPassword)
         {
@@ -84,26 +86,26 @@ namespace NuKeeper.BitBucketLocal
 
         public async Task<IEnumerable<Repository>> GetProjects([CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>("rest/api/1.0/projects?limit=999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($@"{ApiPath}/projects?limit=999", caller);
             return response.Values;
         }
 
 
         public async Task<IEnumerable<Repository>> GetGitRepositories(string projectName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($"rest/api/1.0/projects/{projectName}/repos?limit=999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($@"{ApiPath}/projects/{projectName}/repos?limit=999", caller);
             return response.Values;
         }
 
         public async Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string repositoryName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<string>>($"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/files?limit=9999", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<string>>($@"{ApiPath}/projects/{projectName}/repos/{repositoryName}/files?limit=9999", caller);
             return response.Values;
         }
 
         public async Task<IEnumerable<Branch>> GetGitRepositoryBranches(string projectName, string repositoryName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<IteratorBasedPage<Branch>>($"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/branches", caller);
+            var response = await GetResourceOrEmpty<IteratorBasedPage<Branch>>($@"{ApiPath}/projects/{projectName}/repos/{repositoryName}/branches", caller);
             return  response.Values;
         }
 
@@ -112,15 +114,15 @@ namespace NuKeeper.BitBucketLocal
             var requestJson = JsonConvert.SerializeObject(pullReq, Formatting.None, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore});
             var requestBody = new StringContent(requestJson, Encoding.UTF8, "application/json");
             
-            var response = await _client.PostAsync($@"rest/api/1.0/projects/{projectName}/repos/{repositoryName}/pull-requests", requestBody);
+            var response = await _client.PostAsync($@"{ApiPath}/projects/{projectName}/repos/{repositoryName}/pull-requests", requestBody);
 
             return await HandleResponse<PullRequest>(response, caller);
         }
 
-        public async Task<IEnumerable<AddReviewer>> GetBitBucketReviewers(string projectName, string repositoryName, [CallerMemberName] string caller = null)
+        public async Task<IEnumerable<PullRequestReviewer>> GetBitBucketReviewers(string projectName, string repositoryName, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<List<Conditions>>($"rest/default-reviewers/1.0/projects/{projectName}/repos/{repositoryName}/conditions", caller);
-            return response.SelectMany(c => c.Reviewers).Select(usr => new AddReviewer() {User = usr} );
+            var response = await GetResourceOrEmpty<List<Conditions>>($@"{ApiReviewersPath}/projects/{projectName}/repos/{repositoryName}/conditions", caller);
+            return response.SelectMany(c => c.Reviewers).Select(usr => new PullRequestReviewer() {User = usr} );
         }
     }
 }

--- a/Nukeeper.BitBucketLocal/Models/AddReviewer.cs
+++ b/Nukeeper.BitBucketLocal/Models/AddReviewer.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.BitBucketLocal.Models
+{
+    public class AddReviewer
+    {
+        [JsonProperty("user")]
+        public Reviewer User { get; set; }
+    }
+}

--- a/Nukeeper.BitBucketLocal/Models/Conditions.cs
+++ b/Nukeeper.BitBucketLocal/Models/Conditions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NuKeeper.BitBucketLocal.Models
+{
+    public class Conditions
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("reviewers")]
+        public List<Reviewer> Reviewers { get; set; }
+    }
+}

--- a/Nukeeper.BitBucketLocal/Models/PullRequest.cs
+++ b/Nukeeper.BitBucketLocal/Models/PullRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace NuKeeper.BitBucketLocal.Models
@@ -27,5 +28,10 @@ namespace NuKeeper.BitBucketLocal.Models
 
         [JsonProperty("locked")]
         public bool Locked { get; set; } = false;
+
+        [JsonProperty("reviewers")]
+        public List<AddReviewer> Reviewers { get; set; }
     }
 }
+
+

--- a/Nukeeper.BitBucketLocal/Models/PullRequest.cs
+++ b/Nukeeper.BitBucketLocal/Models/PullRequest.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.BitBucketLocal.Models
         public bool Locked { get; set; } = false;
 
         [JsonProperty("reviewers")]
-        public List<AddReviewer> Reviewers { get; set; }
+        public List<PullRequestReviewer> Reviewers { get; set; }
     }
 }
 

--- a/Nukeeper.BitBucketLocal/Models/PullRequestReviewer.cs
+++ b/Nukeeper.BitBucketLocal/Models/PullRequestReviewer.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace NuKeeper.BitBucketLocal.Models
 {
-    public class AddReviewer
+    public class PullRequestReviewer
     {
         [JsonProperty("user")]
         public Reviewer User { get; set; }

--- a/Nukeeper.BitBucketLocal/Models/Reviewer.cs
+++ b/Nukeeper.BitBucketLocal/Models/Reviewer.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.BitBucketLocal.Models
+{
+    public class Reviewer
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
I've added the possibility to add "default reviewers" to Pull Requests. 
Default Reviewers are set for each repo in BitBucket.
We really missed this feature as nobody was noticed when new PR was made.

