### PR TITLE
We only need one url for a repo

### DIFF
--- a/NuKeeper.Abstractions/CollaborationModels/Repository.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/Repository.cs
@@ -4,12 +4,11 @@ namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class Repository
     {
-        public Repository(string name, bool archived, UserPermissions userPermissions, Uri htmlUrl, Uri cloneUrl, User owner, bool fork, Repository parent)
+        public Repository(string name, bool archived, UserPermissions userPermissions, Uri cloneUrl, User owner, bool fork, Repository parent)
         {
             Name = name;
             Archived = archived;
             UserPermissions = userPermissions;
-            HtmlUrl = htmlUrl;
             CloneUrl = cloneUrl;
             Owner = owner;
             Fork = fork;
@@ -19,7 +18,6 @@ namespace NuKeeper.Abstractions.CollaborationModels
         public string Name { get; }
         public bool Archived { get; }
         public UserPermissions UserPermissions { get; }
-        public Uri HtmlUrl { get; }
         public User Owner { get; }
         public bool Fork { get; }
         public Repository Parent { get; }

--- a/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
+++ b/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
@@ -11,7 +11,7 @@ namespace NuKeeper.Abstractions.Configuration
 
         public RepositorySettings(Repository repository)
         {
-            RepositoryUri = repository.HtmlUrl;
+            RepositoryUri = repository.CloneUrl;
             RepositoryOwner = repository.Owner.Login;
             RepositoryName = repository.Name;
         }

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -68,7 +68,7 @@ namespace NuKeeper.AzureDevOps
             return repos.Select(x =>
                     new Repository(x.name, false,
                         new UserPermissions(true, true, true),
-                        new Uri(x.url), new Uri(x.remoteUrl),
+                        new Uri(x.remoteUrl),
                         null, false, null))
                 .ToList();
         }

--- a/NuKeeper.BitBucket/BitbucketPlatform.cs
+++ b/NuKeeper.BitBucket/BitbucketPlatform.cs
@@ -116,7 +116,6 @@ namespace NuKeeper.BitBucket
         {
             return new Repository(repo.name, false,
                     new UserPermissions(true, true, true),
-                    new Uri(repo.links.clone.First(x => x.name == "https").href),
                     new Uri(repo.links.html.href),
                     null, false, null);
         }

--- a/NuKeeper.GitHub.Tests/GitHubForkFinderTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubForkFinderTests.cs
@@ -79,9 +79,9 @@ namespace NuKeeper.GitHub.Tests
         }
 
         [Test]
-        public async Task WhenSuitableUserForkIsFound_ThatMatchesParentHtmlUrl_ItIsUsedOverFallback()
+        public async Task WhenSuitableUserForkIsFound_ThatMatchesCloneHtmlUrl_ItIsUsedOverFallback()
         {
-            var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentHtmlUrl), "testOrg", "someRepo");
+            var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentCloneUrl), "testOrg", "someRepo");
 
             var userRepo = RepositoryBuilder.MakeRepository();
 

--- a/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubRepositoryDiscoveryTests.cs
@@ -87,7 +87,7 @@ namespace NuKeeper.GitHub.Tests
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[0].Name));
-            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[0].HtmlUrl));
+            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[0].CloneUrl));
         }
 
         [Test]
@@ -95,8 +95,8 @@ namespace NuKeeper.GitHub.Tests
         {
             var inputRepos = new List<Repository>
             {
-                RepositoryBuilder.MakeRepository("http://a.com/repo1", "http://a.com/repo1.git", false),
-                RepositoryBuilder.MakeRepository("http://b.com/repob", "http://b.com/repob.git", true)
+                RepositoryBuilder.MakeRepository("http://a.com/repo1.git", false),
+                RepositoryBuilder.MakeRepository("http://b.com/repob.git", true)
             };
 
             var githubRepositoryDiscovery = MakeGithubRepositoryDiscovery(inputRepos.AsReadOnly());
@@ -109,7 +109,7 @@ namespace NuKeeper.GitHub.Tests
 
             var firstRepo = repos.First();
             Assert.That(firstRepo.RepositoryName, Is.EqualTo(inputRepos[1].Name));
-            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[1].HtmlUrl));
+            Assert.That(firstRepo.RepositoryUri.ToString(), Is.EqualTo(inputRepos[1].CloneUrl));
         }
 
         [Test]

--- a/NuKeeper.GitHub.Tests/RepositoryBuilder.cs
+++ b/NuKeeper.GitHub.Tests/RepositoryBuilder.cs
@@ -7,20 +7,17 @@ namespace NuKeeper.GitHub.Tests
 {
     public static class RepositoryBuilder
     {
-        public const string ParentHtmlUrl = "http://repos.com/org/parent";
         public const string ParentCloneUrl = "http://repos.com/org/parent.git";
 
-        public const string ForkHtmlUrl = "http://repos.com/org/repo";
         public const string ForkCloneUrl = "http://repos.com/org/repo.git";
         public const string NoMatchUrl = "http://repos.com/org/nomatch";
 
         public static Repository MakeRepository(bool canPull, bool canPush)
         {
-            return MakeRepository(ForkHtmlUrl, ForkCloneUrl, canPull, canPush);
+            return MakeRepository(ForkCloneUrl, canPull, canPush);
         }
 
         public static Repository MakeRepository(
-            string forkHtmlUrl = ForkHtmlUrl,
             string forkCloneUrl = ForkCloneUrl,
             bool canPull = true,
             bool canPush = true,
@@ -30,7 +27,6 @@ namespace NuKeeper.GitHub.Tests
                 name,
                 false,
                 new UserPermissions(false, canPush, canPull),
-                new Uri(forkHtmlUrl),
                 new Uri(forkCloneUrl),
                 MakeUser(),
                 true,
@@ -44,7 +40,6 @@ namespace NuKeeper.GitHub.Tests
                 false,
                 new UserPermissions(false, true, true),
                 new Uri(ParentCloneUrl),
-                new Uri(ParentHtmlUrl),
                 MakeUser(),
                 true,
                 null

--- a/NuKeeper.GitHub/GitHubForkFinder.cs
+++ b/NuKeeper.GitHub/GitHubForkFinder.cs
@@ -141,8 +141,7 @@ namespace NuKeeper.GitHub
                 return false;
             }
 
-            return UrlIsMatch(userRepo.Parent?.CloneUrl.ToString(), parentUrl)
-                   || UrlIsMatch(userRepo.Parent?.HtmlUrl.ToString(), parentUrl);
+            return UrlIsMatch(userRepo.Parent?.CloneUrl.ToString(), parentUrl);
         }
 
         private static bool UrlIsMatch(string test, string expected)

--- a/NuKeeper.GitHub/GitHubRepository.cs
+++ b/NuKeeper.GitHub/GitHubRepository.cs
@@ -3,7 +3,7 @@ using NuKeeper.Abstractions.CollaborationModels;
 
 namespace NuKeeper.GitHub
 {
-    public class GitHubRepository : Abstractions.CollaborationModels.Repository
+    public class GitHubRepository : Repository
     {
         public GitHubRepository(Octokit.Repository repository)
         : base(
@@ -11,13 +11,28 @@ namespace NuKeeper.GitHub
             repository.Archived,
             repository.Permissions != null ?
                 new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull) : null,
-            new Uri(repository.CloneUrl),
+            GithubUri(repository.CloneUrl),
             new User(repository.Owner.Login, repository.Owner.Name, repository.Owner.Email),
             repository.Fork,
             repository.Parent != null ?
                 new GitHubRepository(repository.Parent) : null
             )
         {
+        }
+
+        private static Uri GithubUri(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            if (value.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 4);
+            }
+
+            return new Uri(value, UriKind.Absolute);
         }
     }
 }

--- a/NuKeeper.GitHub/GitHubRepository.cs
+++ b/NuKeeper.GitHub/GitHubRepository.cs
@@ -11,7 +11,6 @@ namespace NuKeeper.GitHub
             repository.Archived,
             repository.Permissions != null ?
                 new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull) : null,
-            new Uri(repository.HtmlUrl),
             new Uri(repository.CloneUrl),
             new User(repository.Owner.Login, repository.Owner.Name, repository.Owner.Email),
             repository.Fork,

--- a/Nukeeper.AzureDevOps.Tests/RepositoryBuilder.cs
+++ b/Nukeeper.AzureDevOps.Tests/RepositoryBuilder.cs
@@ -18,11 +18,10 @@ namespace Nukeeper.AzureDevOps.Tests
 
         public static Repository MakeRepository(bool canPull, bool canPush)
         {
-            return MakeRepository(ForkHtmlUrl, ForkCloneUrl, canPull, canPush);
+            return MakeRepository(ForkCloneUrl, canPull, canPush);
         }
 
         public static Repository MakeRepository(
-            Uri forkHtmlUrl = null,
             Uri forkCloneUrl = null,
             bool canPull = true,
             bool canPush = true,
@@ -32,7 +31,6 @@ namespace Nukeeper.AzureDevOps.Tests
                 name,
                 false,
                 new UserPermissions(false, canPush, canPull),
-                forkHtmlUrl ?? ForkHtmlUrl,
                 forkCloneUrl ?? ForkCloneUrl,
                 MakeUser(),
                 true,
@@ -46,7 +44,6 @@ namespace Nukeeper.AzureDevOps.Tests
                 false,
                 new UserPermissions(false, true, true),
                 ParentCloneUrl,
-                ParentHtmlUrl,
                 MakeUser(),
                 true,
                 null

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -77,7 +77,6 @@ namespace NuKeeper.BitBucketLocal
                     new Repository(repo.Name, false,
                         new UserPermissions(true, true, true),
                         new Uri(repo.Links.Clone.First(x => x.Name.StartsWith("http", StringComparison.InvariantCultureIgnoreCase)).Href),
-                        new Uri(repo.Links.Clone.First(x => x.Name.StartsWith("http", StringComparison.InvariantCultureIgnoreCase)).Href),
                         null, false, null))
                 .ToList();
         }

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRepositoryDiscovery.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRepositoryDiscovery.cs
@@ -60,10 +60,10 @@ namespace NuKeeper.BitBucketLocal
             }
 
             return usableRepos
-                .Select(r => new RepositorySettings()
+                .Select(r => new RepositorySettings
                 {
                     ApiUri = _setting.BaseApiUrl, 
-                    RepositoryUri = r.HtmlUrl,
+                    RepositoryUri = r.CloneUrl,
                     RepositoryName = r.Name,
                     RepositoryOwner = organisationName
                 }).ToList();


### PR DESCRIPTION
We only need one url for a repo. The difference between `HtmlUrl` and `CloneUrl` is not clear, I think it's duplication. #633


Needs testing with github