### PR TITLE
Flow the version range further

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuGet/VersionRangesTests.cs
+++ b/NuKeeper.Abstractions.Tests/NuGet/VersionRangesTests.cs
@@ -42,7 +42,7 @@ namespace NuKeeper.Abstractions.Tests.NuGet
         [TestCase("1.2.3.4-beta05")]
         public void ParseableToPackageIdentity(string rangeString)
         {
-            var rangeIdentity = PackageVersionRange.Read("testPackage", rangeString);
+            var rangeIdentity = PackageVersionRange.Parse("testPackage", rangeString);
             var singleVersion = rangeIdentity.SingleVersionIdentity();
 
             Assert.That(rangeIdentity, Is.Not.Null);
@@ -60,7 +60,7 @@ namespace NuKeeper.Abstractions.Tests.NuGet
         [TestCase("[1.*, 2.0.0)")]
         public void ParseableButNotToPackageIdentity(string rangeString)
         {
-            var rangeIdentity = PackageVersionRange.Read("testPackage", rangeString);
+            var rangeIdentity = PackageVersionRange.Parse("testPackage", rangeString);
             var singleVersion = rangeIdentity.SingleVersionIdentity();
 
             Assert.That(rangeIdentity, Is.Not.Null);

--- a/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
+++ b/NuKeeper.Abstractions/NuGet/PackageVersionRange.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Abstractions.NuGet
         public string Id { get; }
         public VersionRange Version { get; }
 
-        public static PackageVersionRange Read(string id, string version)
+        public static PackageVersionRange Parse(string id, string version)
         {
             var success = VersionRange.TryParse(version, out VersionRange versionRange);
             if (!success)

--- a/NuKeeper.Inspection.Tests/Report/Formats/CsvReportFormatTests.cs
+++ b/NuKeeper.Inspection.Tests/Report/Formats/CsvReportFormatTests.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.Report.Formats;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
@@ -58,8 +57,8 @@ namespace NuKeeper.Inspection.Tests.Report.Formats
         [Test]
         public void TwoRowsHaveOutput()
         {
-            var package1 = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
-            var package2 = new PackageIdentity("fish", new NuGetVersion("2.3.4"));
+            var package1 = PackageVersionRange.Parse("foo.bar", "1.2.3");
+            var package2 = PackageVersionRange.Parse("fish", "2.3.4");
 
             var rows = new List<PackageUpdateSet>
             {

--- a/NuKeeper.Inspection.Tests/Report/PackageUpdates.cs
+++ b/NuKeeper.Inspection.Tests/Report/PackageUpdates.cs
@@ -8,21 +8,22 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.NuGet;
 
 namespace NuKeeper.Inspection.Tests.Report
 {
     public static class PackageUpdates
     {
-        public static PackageUpdateSet UpdateSetFor(PackageIdentity package, params PackageInProject[] packages)
+        public static PackageUpdateSet UpdateSetFor(PackageVersionRange package, params PackageInProject[] packages)
         {
             var publishedDate = new DateTimeOffset(2018, 2, 19, 11, 12, 7, TimeSpan.Zero);
-            var latest = new PackageSearchMedatadata(package, new PackageSource("http://none"), publishedDate, null);
+            var latest = new PackageSearchMedatadata(package.SingleVersionIdentity(), new PackageSource("http://none"), publishedDate, null);
 
             var updates = new PackageLookupResult(VersionChange.Major, latest, null, null);
             return new PackageUpdateSet(updates, packages);
         }
 
-        public static PackageInProject MakePackageForV110(PackageIdentity package)
+        public static PackageInProject MakePackageForV110(PackageVersionRange package)
         {
             var path = new PackagePath(
                 OsSpecifics.GenerateBaseDirectory(),
@@ -36,8 +37,8 @@ namespace NuKeeper.Inspection.Tests.Report
             var result = new List<PackageUpdateSet>();
             foreach (var index in Enumerable.Range(1, count))
             {
-                var package = new PackageIdentity($"test.package{index}",
-                    new NuGetVersion($"1.2.{index}"));
+                var package = PackageVersionRange.Parse(
+                    $"test.package{index}", $"1.2.{index}");
 
                 var updateSet = UpdateSetFor(package, MakePackageForV110(package));
                 result.Add(updateSet);
@@ -48,7 +49,7 @@ namespace NuKeeper.Inspection.Tests.Report
 
         public static List<PackageUpdateSet> OnePackageUpdateSet()
         {
-            var package = new PackageIdentity("foo.bar", new NuGetVersion("1.2.3"));
+            var package = PackageVersionRange.Parse("foo.bar", "1.2.3");
 
             return new List<PackageUpdateSet>
             {

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/PackageAssert.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/PackageAssert.cs
@@ -8,6 +8,8 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         public static void IsPopulated(PackageInProject package)
         {
             Assert.That(package, Is.Not.Null);
+            Assert.That(package.PackageVersionRange, Is.Not.Null);
+            Assert.That(package.Version, Is.Not.Null);
             Assert.That(package.Identity, Is.Not.Null);
             Assert.That(package.Path, Is.Not.Null);
 

--- a/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
+++ b/NuKeeper.Inspection.Tests/Sort/PackageInProjectTopologicalSortTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Inspection.Sort;
 using NUnit.Framework;
@@ -167,8 +168,9 @@ namespace NuKeeper.Inspection.Tests.Sort
                 refs.Add(refProject.Path.FullName);
             }
 
-            return new PackageInProject(
-                new PackageIdentity(packageId, new NuGetVersion(packageVersion)),
+            var packageVersionRange = PackageVersionRange.Parse(packageId, packageVersion);
+
+            return new PackageInProject(packageVersionRange,
                 new PackagePath(basePath, relativePath, PackageReferenceType.ProjectFile),
                 refs);
         }

--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProject.cs
@@ -2,29 +2,35 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
 
 namespace NuKeeper.Inspection.RepositoryInspection
 {
     public class PackageInProject
     {
-        public PackageInProject(PackageIdentity identity,
+        public PackageInProject(PackageVersionRange packageVersionRange,
             PackagePath path,
             IEnumerable<string> projectReferences = null)
         {
-            Identity = identity;
+            PackageVersionRange = packageVersionRange;
             Path = path;
             ProjectReferences = projectReferences?.ToList() ?? new List<string>();
         }
 
-        public PackageInProject(string id, string version, PackagePath path) :
-            this(new PackageIdentity(id, new NuGetVersion(version)), path, null)
+        public PackageInProject(string id, string versionRange, PackagePath path) :
+            this(new PackageVersionRange(id, VersionRange.Parse(versionRange)), path, null)
         {
         }
 
-        public PackageIdentity Identity { get; }
+        public PackageIdentity Identity => PackageVersionRange.SingleVersionIdentity();
+
+        public PackageVersionRange PackageVersionRange { get; }
+
         public PackagePath Path { get; }
 
-        public string Id => Identity.Id;
+        public string Id => PackageVersionRange.Id;
+        public VersionRange Range => PackageVersionRange.Version;
+
         public NuGetVersion Version => Identity.Version;
 
         public bool IsPrerelease => Identity.Version.IsPrerelease;

--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
@@ -30,7 +30,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return null;
             }
 
-            var packageVersionRange = PackageVersionRange.Read(id, version);
+            var packageVersionRange = PackageVersionRange.Parse(id, version);
 
             if (packageVersionRange == null)
             {
@@ -38,7 +38,9 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return null;
             }
 
-            var singleVersion = packageVersionRange.SingleVersionIdentity();
+            var pip = new PackageInProject(packageVersionRange, path, projectReferences);
+
+            var singleVersion = pip.Identity;
 
             if (singleVersion == null)
             {
@@ -46,7 +48,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return null;
             }
 
-            return new PackageInProject(singleVersion, path, projectReferences);
+            return pip;
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var subject = new UpdateProjectImportsCommand();
 
-            var package = new PackageInProject("acme", "1",
+            var package = new PackageInProject("acme", "1.0.0",
                 new PackagePath(workDirectory, projectName, PackageReferenceType.ProjectFileOldStyle));
 
             await subject.Invoke(package, null, null, NuGetSources.GlobalFeed);
@@ -76,7 +76,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var subject = new UpdateProjectImportsCommand();
 
-            var package = new PackageInProject("acme", "1",
+            var package = new PackageInProject("acme", "1.0.0",
                 new PackagePath(workDirectory, "RootProject.csproj", PackageReferenceType.ProjectFileOldStyle));
 
             await subject.Invoke(package, null, null, NuGetSources.GlobalFeed);

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -69,8 +69,8 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             var item = results.FirstOrDefault();
 
             Assert.That(item, Is.Not.Null);
-            Assert.That(item.Identity.Id, Is.EqualTo("foo"));
-            Assert.That(item.Identity.Version, Is.EqualTo(new NuGetVersion(1,2,3)));
+            Assert.That(item.Id, Is.EqualTo("foo"));
+            Assert.That(item.Version, Is.EqualTo(new NuGetVersion(1,2,3)));
             Assert.That(item.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.PackagesConfig));
         }
 
@@ -139,8 +139,8 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             var item = results.FirstOrDefault();
 
             Assert.That(item, Is.Not.Null);
-            Assert.That(item.Identity.Id, Is.EqualTo("foo"));
-            Assert.That(item.Identity.Version, Is.EqualTo(new NuGetVersion(1, 2, 3)));
+            Assert.That(item.Id, Is.EqualTo("foo"));
+            Assert.That(item.Version, Is.EqualTo(new NuGetVersion(1, 2, 3)));
             Assert.That(item.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.ProjectFile));
         }
 

--- a/NuKeeper.Tests/PackageUpdates.cs
+++ b/NuKeeper.Tests/PackageUpdates.cs
@@ -6,6 +6,7 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 
@@ -24,9 +25,10 @@ namespace NuKeeper.Tests
             string version = "1.2.3",
             PackageReferenceType packageRefType = PackageReferenceType.ProjectFile)
         {
-            var packageId = new PackageIdentity(packageName, new NuGetVersion(version));
+            var packageId = PackageVersionRange.Parse(packageName, version);
+
             var latest = new PackageSearchMedatadata(
-                packageId, OfficialPackageSource(),
+                packageId.SingleVersionIdentity(), OfficialPackageSource(),
                 null,
                 Enumerable.Empty<PackageDependency>());
 


### PR DESCRIPTION
`PackageInProject` now contains a `PackageVersionRange`
Although the `PackageInProjectReader` still discards it upfront if it's not a single version.