### PR TITLE
Maxupdate has 0 option to allow all

### DIFF
--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -104,7 +104,7 @@ namespace NuKeeper.Update.Tests
             var results = await target.Filter(updateSets, settings, Pass);
 
             Assert.That(results.Count, Is.EqualTo(2));
-            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
+            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
         }
 
         [Test]

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -84,6 +84,28 @@ namespace NuKeeper.Update.Tests
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
         }
+        
+        [Test]
+        public async Task WhenThereMaxPackagesUpdateIsZero_DontCap()
+        {
+            var updateSets = new List<PackageUpdateSet>
+            {
+                UpdateFooFromOneVersion(),
+                UpdateBarFromTwoVersions()
+            };
+
+            var settings = new FilterSettings
+            {
+                MaxPackageUpdates = 0,
+            };
+
+            var target = CreateUpdateSelection();
+
+            var results = await target.Filter(updateSets, settings, Pass);
+
+            Assert.That(results.Count, Is.EqualTo(2));
+            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
+        }
 
         [Test]
         public async Task WhenThereAreExcludes_OnlyConsiderNonMatching()

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -36,8 +36,12 @@ namespace NuKeeper.Update.Selection
             var filtered = await ApplyFilters(candidates, remoteCheck);
 
             var capped = filtered
-                .Take(settings.MaxPackageUpdates)
                 .ToList();
+
+            if (settings.MaxPackageUpdates > 0)
+            {
+                capped = capped.Take(settings.MaxPackageUpdates).ToList();
+            }
 
             LogPackageCounts(candidates.Count, filtered.Count, capped.Count);
 

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -1,8 +1,8 @@
 using System.Text;
+using SimpleInjector;
 using NuGet.Common;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
-using SimpleInjector;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;


### PR DESCRIPTION
For a project that i've been working on i use the following command:

`nukeeper update --include ^EventSourcing. --age 0 --maxupdate 50`

This yields about 50 packages update in total. 7 project with about 7 `EventSourcing.*` packages. It would be nice to just say `--maxupdate 0` and allow it to update as many as it wants.
