### PR TITLE
No errors when package is not found

### DIFF
--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -36,11 +36,11 @@ namespace NuKeeper.Git
             _gitCredentials = gitCredentials;
             _identity = userIdentity;
         }
-        
+
         public void Clone(Uri pullEndpoint)
         {
             _logger.Normal($"Git clone {pullEndpoint} to {WorkingFolder.FullPath}");
-          
+
             Repository.Clone(pullEndpoint.AbsoluteUri, WorkingFolder.FullPath,
                 new CloneOptions
                 {
@@ -84,7 +84,8 @@ namespace NuKeeper.Git
             var qualifiedBranchName = "origin/" + branchName;
             if (BranchExists(qualifiedBranchName))
             {
-                throw new NuKeeperException($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+                _logger.Normal($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+                return;
             }
 
             _logger.Detailed($"Git checkout new branch '{branchName}'");

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -50,11 +51,7 @@ namespace NuKeeper.Inspection.NuGetApi
             }
             catch (Exception ex)
             {
-                if(ex is UnauthorizedAccessException)
-                    _nuKeeperLogger.Minimal(ex.Message);
-                else
-                    _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
-                
+                _nuKeeperLogger.Normal($"Getting {packageName} from {source} returned exception: {ex.Message}");
                 return Enumerable.Empty<PackageSearchMedatadata>();
             }
         }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -50,7 +50,11 @@ namespace NuKeeper.Inspection.NuGetApi
             }
             catch (Exception ex)
             {
-                _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
+                if(ex is UnauthorizedAccessException)
+                    _nuKeeperLogger.Minimal(ex.Message);
+                else
+                    _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
+                
                 return Enumerable.Empty<PackageSearchMedatadata>();
             }
         }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -1,8 +1,8 @@
 using System.Text;
+using SimpleInjector;
 using NuGet.Common;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
-using SimpleInjector;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;


### PR DESCRIPTION
This PR includes 2 fixes.

1. NuKeeper throws if the branch already exists. This shouldn't happen in my opinion. If you are to lazy to "accept" the PR's then that should be fine. It is also optional in Azure DevOps to delete the branch after a merge. If you keep the branch then NuKeeper will stop working because it detect a stale old branch(shouldn't happen that much because it's bound to a specific upgrade but still).

The `RunFinderForSource` gets called for every nuget source that you have. If it can't authenticate for a specific source that shouldn't be a problem because it can still succeeded, the error create the perception that it fails. 

2. For the project i'm working on right now we don't want any secrets in our code. That means that for some project in our solution we include a `nuget.config` that has credentials that looks like this:


```
  <packageSourceCredentials>
    <VSTS>
      <add key="Username" value="dontcare@dontcare.com" />      
      <add key="ClearTextPassword" value="__System.AccessToken__" />
    </VSTS>
  </packageSourceCredentials>

```
The `System.AccessToken` is injected by our CI. However NuKeeper will use this for it's command. The tool will still work fine because on our machine we have a system wide `nuget.config` which contains a PAT. The downside is that any command generates a hell of a lot `Errors` and our whole screen is almost red. 
