### PR TITLE
Include and exclude regex are used early on

### DIFF
--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -36,11 +36,11 @@ namespace NuKeeper.Git
             _gitCredentials = gitCredentials;
             _identity = userIdentity;
         }
-        
+
         public void Clone(Uri pullEndpoint)
         {
             _logger.Normal($"Git clone {pullEndpoint} to {WorkingFolder.FullPath}");
-          
+
             Repository.Clone(pullEndpoint.AbsoluteUri, WorkingFolder.FullPath,
                 new CloneOptions
                 {
@@ -84,7 +84,8 @@ namespace NuKeeper.Git
             var qualifiedBranchName = "origin/" + branchName;
             if (BranchExists(qualifiedBranchName))
             {
-                throw new NuKeeperException($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+                _logger.Normal($"Git Cannot checkout new branch: a branch named '{qualifiedBranchName}' already exists");
+                return;
             }
 
             _logger.Detailed($"Git checkout new branch '{branchName}'");

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Inspections.Files;
@@ -9,10 +10,22 @@ namespace NuKeeper.Inspection
 {
     public interface IUpdateFinder
     {
+        /// <summary>
+        /// Finds the package update sets that are used
+        /// </summary>
+        /// <param name="workingFolder"></param>
+        /// <param name="sources"></param>
+        /// <param name="allowedChange"></param>
+        /// <param name="usePrerelease"></param>
+        /// <param name="include">Optional, for no include pass null</param>
+        /// <param name="exclude">Optional, for no exclude pass null</param>
+        /// <returns></returns>
         Task<IReadOnlyCollection<PackageUpdateSet>> FindPackageUpdateSets(
             IFolder workingFolder,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease);
+            UsePrerelease usePrerelease,
+            Regex include = null,
+            Regex exclude = null);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -50,11 +51,7 @@ namespace NuKeeper.Inspection.NuGetApi
             }
             catch (Exception ex)
             {
-                if(ex is UnauthorizedAccessException)
-                    _nuKeeperLogger.Minimal(ex.Message);
-                else
-                    _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
-                
+                _nuKeeperLogger.Normal($"Getting {packageName} from {source} returned exception: {ex.Message}");
                 return Enumerable.Empty<PackageSearchMedatadata>();
             }
         }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -50,7 +50,11 @@ namespace NuKeeper.Inspection.NuGetApi
             }
             catch (Exception ex)
             {
-                _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
+                if(ex is UnauthorizedAccessException)
+                    _nuKeeperLogger.Minimal(ex.Message);
+                else
+                    _nuKeeperLogger.Error($"Error getting {packageName} from {source}", ex);
+                
                 return Enumerable.Empty<PackageSearchMedatadata>();
             }
         }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/NuKeeper.Update.Tests/UpdateSelectionTests.cs
+++ b/NuKeeper.Update.Tests/UpdateSelectionTests.cs
@@ -8,7 +8,10 @@ using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Inspection;
 using NuKeeper.Inspection.NuGetApi;
 using NuKeeper.Inspection.RepositoryInspection;
 using NuKeeper.Update.Selection;
@@ -57,77 +60,6 @@ namespace NuKeeper.Update.Tests
             var target = CreateUpdateSelection();
 
             var results = await target.Filter(updateSets, OneTargetSelection(), Pass);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
-        }
-
-        [Test]
-        public async Task WhenThereAreIncludes_OnlyConsiderMatches()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new FilterSettings
-            {
-                MaxPackageUpdates = 10,
-                Includes = new Regex("bar")
-            };
-
-            var target = CreateUpdateSelection();
-
-            var results = await target.Filter(updateSets, settings, Pass);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("bar"));
-        }
-
-        [Test]
-        public async Task WhenThereAreExcludes_OnlyConsiderNonMatching()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new FilterSettings
-            {
-                MaxPackageUpdates = 10,
-                Excludes = new Regex("bar")
-            };
-
-            var target = CreateUpdateSelection();
-
-            var results = await target.Filter(updateSets, settings, Pass);
-
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.First().SelectedId, Is.EqualTo("foo"));
-        }
-
-        [Test]
-        public async Task WhenThereAreIncludesAndExcludes_OnlyConsiderMatchesButRemoveNonMatching()
-        {
-            var updateSets = new List<PackageUpdateSet>
-            {
-                UpdateFoobarFromOneVersion(),
-                UpdateFooFromOneVersion(),
-                UpdateBarFromTwoVersions()
-            };
-
-            var settings = new FilterSettings 
-            {
-                MaxPackageUpdates = 10,
-                Excludes = new Regex("bar"),
-                Includes = new Regex("foo")
-            };
-
-            var target = CreateUpdateSelection();
-
-            var results = await target.Filter(updateSets, settings, Pass);
 
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results.First().SelectedId, Is.EqualTo("foo"));

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -1,8 +1,8 @@
 using System.Text;
+using SimpleInjector;
 using NuGet.Common;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
-using SimpleInjector;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -54,7 +54,7 @@ namespace NuKeeper.Engine
             var sources = _nugetSourcesReader.Read(settings.WorkingFolder ?? git.WorkingFolder, userSettings.NuGetSources);
 
             var updates = await _updateFinder.FindPackageUpdateSets(
-                settings.WorkingFolder ?? git.WorkingFolder, sources, userSettings.AllowedChange, userSettings.UsePrerelease);
+                settings.WorkingFolder ?? git.WorkingFolder, sources, userSettings.AllowedChange, userSettings.UsePrerelease, settings.PackageFilters?.Includes, settings.PackageFilters?.Excludes);
 
             _reporter.Report(
                 userSettings.OutputDestination,

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Inspections.Files;
@@ -50,7 +51,9 @@ namespace NuKeeper.Local
                 folder,
                 sources,
                 settings.UserSettings.AllowedChange,
-                settings.UserSettings.UsePrerelease);
+                settings.UserSettings.UsePrerelease,
+                settings.PackageFilters?.Includes,
+                settings.PackageFilters?.Excludes);
 
             Report(settings.UserSettings, sortedUpdates);
 
@@ -64,10 +67,12 @@ namespace NuKeeper.Local
             IFolder folder,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease)
+            UsePrerelease usePrerelease,
+            Regex includes,
+            Regex excludes)
         {
             var updates = await _updateFinder.FindPackageUpdateSets(
-                folder, sources, allowedChange, usePrerelease);
+                folder, sources, allowedChange, usePrerelease, includes, excludes);
 
             return _sorter.Sort(updates)
                 .ToList();


### PR DESCRIPTION
This PR adds the `include` and `exclude` regex early on in the proces. This is a performance boost, what now happens is that the regex filtered the packages all the way at the end of the proces. With this PR it is done in the beginning, this means that packages are not relevant will not check for updates from potentialy multiple remotes.

Log now reads:
```
Found 44 packages
Filtered by Include '^EventSourcing.' from 44 to 9
Found 9 packages in use, 5 distinct, in 3 projects.
EventSourcing.Extensions, EventSourcing.LeaderElection, EventSourcing.PubSub, EventSourcing.Shared, EventSourcing.Store
```