### PR TITLE
Add Paket support

### DIFF
--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -6,7 +6,9 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="NuGet.Protocol" Version="4.9.1" />
+    <PackageReference Include="Paket.Core" Version="5.195.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/NuKeeper.Inspection/RepositoryInspection/NugetRepositoryScanner.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NugetRepositoryScanner.cs
@@ -7,11 +7,11 @@ using NuKeeper.Abstractions.Inspections.Files;
 
 namespace NuKeeper.Inspection.RepositoryInspection
 {
-    public class RepositoryScanner: IRepositoryScanner
+    public class NugetRepositoryScanner: IRepositoryScanner
     {
         private readonly IReadOnlyCollection<IPackageReferenceFinder> _finders;
 
-        public RepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader,
+        public NugetRepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader,
             NuspecFileReader nuspecFileReader, DirectoryBuildTargetsReader directoryBuildTargetsReader)
         {
             _finders = new IPackageReferenceFinder[]
@@ -32,13 +32,14 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 .GetFilePatterns()
                 .SelectMany(workingFolder.Find)
                 .Where(f => !DirectoryExclusions.PathIsExcluded(f.FullName));
-
-            return files.SelectMany(f =>
+            var packages =  files.SelectMany(f =>
                 packageReferenceFinder.ReadFile(
                     workingFolder.FullPath,
                     GetRelativeFileName(
                         workingFolder.FullPath,
                         f.FullName)));
+
+            return packages;
         }
 
         private static string GetRelativeFileName(string rootDir, string fileName)

--- a/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageReferenceType.cs
@@ -6,6 +6,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
         ProjectFile,
         ProjectFileOldStyle,
         Nuspec,
-        DirectoryBuildTargets
+        DirectoryBuildTargets,
+        PaketDependencyFile
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/PaketRepositoryScanner.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PaketRepositoryScanner.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.FSharp.Core;
+using NuKeeper.Abstractions.Inspections.Files;
+using Paket;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public class PaketRepositoryScanner : IRepositoryScanner
+    {
+        private readonly IReadOnlyCollection<IPackageReferenceFinder> _finders;
+
+        public PaketRepositoryScanner(ProjectFileReader projectFileReader, PackagesFileReader packagesFileReader,
+            NuspecFileReader nuspecFileReader, DirectoryBuildTargetsReader directoryBuildTargetsReader)
+        {
+            _finders = new IPackageReferenceFinder[]
+                {projectFileReader, packagesFileReader, nuspecFileReader, directoryBuildTargetsReader};
+        }
+
+        public IReadOnlyCollection<PackageInProject> FindAllNuGetPackages(IFolder workingFolder)
+        {
+            var deps = new Dependencies($"{workingFolder.FullPath}/paket.dependencies");
+            try
+            {
+                var outdated = deps.FindOutdated(false, false, false, FSharpOption<string>.None); //todo see if we can get the current version list immeditaily
+                var packages = new List<PackageInProject>();
+
+                foreach (var package in outdated)
+                {
+
+                    var path = new PackagePath(workingFolder.FullPath, "paket.dependencies",
+                        PackageReferenceType.PaketDependencyFile);
+
+                    var installedVersion = deps.GetInstalledVersion(FSharpOption<string>.None, package.Item2);
+                    var packageInfo = new PackageInProject(package.Item2, installedVersion.Value, path);
+
+                    packages.Add(packageInfo);
+                }
+
+                return packages;
+            }
+            catch (Exception e)
+            {
+                var ex = e.Message;
+                return null;
+            }
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -164,7 +164,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             // then the app root directory to scan is "C:\Code\NuKeeper\"
             // So go up four dir levels to the root
             // Self is a convenient source of a valid project to scan
-            var fullPath = new Uri(typeof(RepositoryScanner).GetTypeInfo().Assembly.CodeBase).LocalPath;
+            var fullPath = new Uri(typeof(NugetRepositoryScanner).GetTypeInfo().Assembly.CodeBase).LocalPath;
             var runDir = Path.GetDirectoryName(fullPath);
 
             var projectRootDir = Directory.GetParent(runDir).Parent.Parent.Parent;
@@ -180,7 +180,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
         private static IRepositoryScanner MakeScanner()
         {
             var logger = Substitute.For<INuKeeperLogger>();
-            return new RepositoryScanner(
+            return new NugetRepositoryScanner(
                 new ProjectFileReader(logger),
                 new PackagesFileReader(logger),
                 new NuspecFileReader(logger),

--- a/NuKeeper.Update/IUpdateRunner.cs
+++ b/NuKeeper.Update/IUpdateRunner.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.RepositoryInspection;
 
@@ -6,6 +7,6 @@ namespace NuKeeper.Update
 {
     public interface IUpdateRunner
     {
-        Task Update(PackageUpdateSet updateSet, NuGetSources sources);
+        Task Update(PackageUpdateSet updateSet, NuGetSources sources, IFolder folder);
     }
 }

--- a/NuKeeper.Update/NuKeeper.Update.csproj
+++ b/NuKeeper.Update/NuKeeper.Update.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/NuKeeper.Update/NugetUpdateRunner.cs
+++ b/NuKeeper.Update/NugetUpdateRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.RepositoryInspection;
@@ -38,7 +39,7 @@ namespace NuKeeper.Update
             _updateDirectoryBuildTargetsCommand = updateDirectoryBuildTargetsCommand;
         }
 
-        public async Task Update(PackageUpdateSet updateSet, NuGetSources sources)
+        public async Task Update(PackageUpdateSet updateSet, NuGetSources sources, IFolder folder)
         {
             var sortedUpdates = Sort(updateSet.CurrentPackages);
 

--- a/NuKeeper.Update/PaketUpdateRunner.cs
+++ b/NuKeeper.Update/PaketUpdateRunner.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.FSharp.Core;
+using NuKeeper.Abstractions.Inspections.Files;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Inspection.RepositoryInspection;
+using NuKeeper.Inspection.Sort;
+using Paket;
+
+namespace NuKeeper.Update
+{
+    public class PaketUpdateRunner : IUpdateRunner
+    {
+        private INuKeeperLogger _logger;
+
+        public PaketUpdateRunner(INuKeeperLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Update(PackageUpdateSet updateSet, NuGetSources sources, IFolder folder)
+        {
+            var sortedUpdates = Sort(updateSet.CurrentPackages);
+            var dependencies = new Dependencies($"{folder.FullPath}/paket.dependencies");
+            _logger.Detailed($"Updating '{updateSet.SelectedId}' to {updateSet.SelectedVersion} in {sortedUpdates.Count} projects");
+
+            foreach (var current in sortedUpdates)
+            {
+                dependencies.UpdatePackage(FSharpOption<string>.None, current.Id, FSharpOption<string>.Some(updateSet.SelectedVersion.Version.ToString()), false, SemVerUpdateMode.NoRestriction,false);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private IReadOnlyCollection<PackageInProject> Sort(IReadOnlyCollection<PackageInProject> packages)
+        {
+            var sorter = new PackageInProjectTopologicalSort(_logger);
+            return sorter.Sort(packages)
+                .ToList();
+        }
+    }
+}

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -30,7 +30,7 @@ namespace NuKeeper
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
             container.Register<IPackageVersionsLookup, PackageVersionsLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();
-            container.Register<IRepositoryScanner, RepositoryScanner>();
+            container.Register<IRepositoryScanner, PaketRepositoryScanner>();
 
             container.Register<IUpdateFinder, UpdateFinder>();
             container.Register<INuGetSourcesReader, NuGetSourcesReader>();

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -1,8 +1,8 @@
 using System.Text;
+using SimpleInjector;
 using NuGet.Common;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
-using SimpleInjector;
 using NuKeeper.Inspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -16,7 +16,7 @@ namespace NuKeeper
             container.Register<IUpdateNuspecCommand, UpdateNuspecCommand>();
             container.Register<IUpdateDirectoryBuildTargetsCommand, UpdateDirectoryBuildTargetsCommand>();
             container.Register<IExternalProcess, ExternalProcess>();
-            container.Register<IUpdateRunner, UpdateRunner>();
+            container.Register<IUpdateRunner, PaketUpdateRunner>();
             container.Register<INuGetPath, NuGetPath>();
         }
     }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -74,7 +74,7 @@ namespace NuKeeper.Engine.Packages
 
             foreach (var updateSet in updates)
             {
-                await _updateRunner.Update(updateSet, sources);
+                await _updateRunner.Update(updateSet, sources, null);
 
                 var commitMessage = CommitWording.MakeCommitMessage(updateSet);
                 git.Commit(commitMessage);

--- a/NuKeeper/Local/LocalUpdater.cs
+++ b/NuKeeper/Local/LocalUpdater.cs
@@ -64,7 +64,7 @@ namespace NuKeeper.Local
             {
                 _logger.Minimal("Updating " + Description.ForUpdateSet(update));
 
-                await _updateRunner.Update(update, sources);
+                await _updateRunner.Update(update, sources, workingFolder);
             }
         }
     }

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
This PR adds paket support. It not complete yet and there a still issues.

The flow for a local `update` is as follows:

- [x] Read packages from `paket.dependencies` file in the `PaketRepositoryScanner`. This impl should be improved.
- [x] Do sorting, excluding, etc NuKeeper way
- [ ] Check for new version that satisfy the `paket.lock` file. Requires a Paket impl of `IPackageLookup` 
- [ ] Take those version and apply updates in the `PaketUpdateRunner`

For a remote repo there i still work to be done to read the `paket.dependecies` file.