### PR TITLE
Do not expose LibGit2Sharp usage outside of the NuKeeper.Git project

### DIFF
--- a/NuKeeper.Abstractions/Git/GitUsernamePasswordCredentials.cs
+++ b/NuKeeper.Abstractions/Git/GitUsernamePasswordCredentials.cs
@@ -1,0 +1,9 @@
+namespace NuKeeper.Abstractions.Git
+{
+    public class GitUsernamePasswordCredentials
+    {
+        public string Username { get; set; }
+
+        public string Password { get; set; }
+    }
+}

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -3,7 +3,6 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0080" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -1,10 +1,10 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Git;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Git;
@@ -35,13 +35,12 @@ namespace NuKeeper.Engine
         }
 
         public async Task<int> Run(RepositorySettings repository,
-            UsernamePasswordCredentials gitCreds,
-            Identity userIdentity,
-            SettingsContainer settings)
+            GitUsernamePasswordCredentials credentials,
+            SettingsContainer settings, User user)
         {
             try
             {
-                var repo = await BuildGitRepositorySpec(repository, gitCreds.Username);
+                var repo = await BuildGitRepositorySpec(repository, credentials.Username);
                 if (repo == null)
                 {
                     return 0;
@@ -74,7 +73,7 @@ namespace NuKeeper.Engine
                     settings.WorkingFolder = folder;
                 }
 
-                var git = new LibGit2SharpDriver(_logger, folder, gitCreds, userIdentity);
+                var git = new LibGit2SharpDriver(_logger, folder, credentials, user);
 
                 var updatesDone = await _repositoryUpdater.Run(git, repo, settings);
 

--- a/NuKeeper/Engine/IGitRepositoryEngine.cs
+++ b/NuKeeper/Engine/IGitRepositoryEngine.cs
@@ -1,13 +1,14 @@
-using LibGit2Sharp;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Git;
 
 namespace NuKeeper.Engine
 {
     public interface IGitRepositoryEngine
     {
         Task<int> Run(RepositorySettings repository,
-            UsernamePasswordCredentials gitCreds, Identity userIdentity,
-            SettingsContainer settings);
+            GitUsernamePasswordCredentials credentials,
+            SettingsContainer settings, User user);
     }
 }


### PR DESCRIPTION
Minor cleanup, might be useful if some replacement git driver is considered in order to support shallow checkout.