### PR TITLE
Changed size property of AzureRepository from int to long.

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -103,7 +103,7 @@ namespace NuKeeper.AzureDevOps
         public string url { get; set; }
         public Project project { get; set; }
         public string defaultBranch { get; set; }
-        public int size { get; set; }
+        public long size { get; set; }
         public string remoteUrl { get; set; }
         public string sshUrl { get; set; }
     }

--- a/Nukeeper.AzureDevOps.Tests/AzureDevopsRestTypesTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevopsRestTypesTests.cs
@@ -1,0 +1,47 @@
+using Newtonsoft.Json;
+using NuKeeper.AzureDevOps;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nukeeper.AzureDevOps.Tests
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class AzureDevopsRestTypesTests
+    {
+        [TestCase((long)0)]
+        [TestCase((long)2147483647)] //int.MaxValue
+        [TestCase((long)4294967295)] //uint.MaxValue
+        [TestCase((long)9223372036854775807)] //long.MaxValue
+        public void AzureRepository_CanBeDeserializedWithSize(long size)
+        {
+            var json = AzureRepositoryJsonWithSize(size);
+            Assert.DoesNotThrow(() => JsonConvert.DeserializeObject<AzureRepository>(json));
+        }
+
+        private static string AzureRepositoryJsonWithSize(long size)
+        {
+            return "" +
+            "{" +
+                "\"id\": \"a949c96a-9e6b-486f-a41c-90d5e15db277\"," +
+                "\"name\": \"Repo.Name\"," +
+                "\"url\": \"https://organization.visualstudio.com/a949c96a-9e6b-486f-a41c-90d5e15db277/_apis/git/repositories/a949c96a-9e6b-486f-a41c-90d5e15db277\"," +
+                "\"project\": {" +
+                    "\"id\": \"a949c96a-9e6b-486f-a41c-90d5e15db277\"," +
+                    "\"name\": \"Project\"," +
+                    "\"description\": \"A project\"," +
+                    "\"url\": \"https://organization.visualstudio.com/_apis/projects/a949c96a-9e6b-486f-a41c-90d5e15db277\"," +
+                    "\"state\": \"wellFormed\"," +
+                    "\"revision\": 202846384," +
+                    "\"visibility\": \"private\"" +
+                "}," +
+                "\"defaultBranch\": \"refs/heads/master\"," +
+                $"\"size\": {size}," +
+                "\"remoteUrl\": \"https://organization.visualstudio.com/Project/_git/Repo.Name\"," +
+                "\"sshUrl\": \"organization@vs-ssh.visualstudio.com:v3/organization/Project/Repo.Name\"" +
+            "}";
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes issue #661

# TL;DR
When you have a repository in your Azure DevOps project with a size greater than `int.MaxValue` you will get this error:
![image](https://user-images.githubusercontent.com/6184673/51660746-08452d80-1faf-11e9-993a-12a719f31e21.png)

Updating from `int` to `long` fixes this issue. I tried to update to `ulong` but NewtonSoft JSON (de)serializes this as a long. Apparently, javascript does not support `ulong` values so JSON doesn't as a result of that. (https://stackoverflow.com/questions/29911786/json-net-prevent-ulong-from-getting-serialized-in-scientific-notation)