### PR TITLE
Short names must be one char. Pick new ones.

### DIFF
--- a/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Include, Is.Null);
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
-            Assert.That(data.MaxPr, Is.Null);
+            Assert.That(data.MaxPackageUpdates, Is.Null);
             Assert.That(data.MaxRepo, Is.Null);
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
@@ -57,7 +57,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Include, Is.Null);
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
-            Assert.That(data.MaxPr, Is.Null);
+            Assert.That(data.MaxPackageUpdates, Is.Null);
             Assert.That(data.MaxRepo, Is.Null);
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
@@ -80,7 +80,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
                ""excludeRepos"":""repoOut"",
                ""label"": [ ""foo"", ""bar"" ],
                ""logFile"":""somefile.log"",
-               ""maxpr"": 42,
+               ""maxPackageUpdates"": 42,
                ""maxRepo"": 12,
                ""verbosity"": ""Detailed"",
                ""Change"": ""Minor"",
@@ -139,7 +139,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
 
             var data = fsr.Read(path);
 
-            Assert.That(data.MaxPr, Is.EqualTo(42));
+            Assert.That(data.MaxPackageUpdates, Is.EqualTo(42));
             Assert.That(data.MaxRepo, Is.EqualTo(12));
         }
 

--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -27,7 +27,7 @@ namespace NuKeeper.Abstractions.Configuration
 
         public string LogFile { get; set; }
 
-        public int? MaxPr { get; set; }
+        public int? MaxPackageUpdates { get; set; }
         public int? MaxRepo { get; set; }
 
         public bool? Consolidate { get; set; }

--- a/NuKeeper.Tests/Commands/GlobalCommandTests.cs
+++ b/NuKeeper.Tests/Commands/GlobalCommandTests.cs
@@ -186,7 +186,7 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                MaxPr = 42
+                MaxPackageUpdates = 42
             };
 
             var (settings, _) = await CaptureSettings(fileSettings);

--- a/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
+++ b/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
@@ -168,7 +168,7 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                MaxPr = 42
+                MaxPackageUpdates = 42
             };
 
             var (settings, _) = await CaptureSettings(fileSettings);

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -247,7 +247,7 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                MaxPr = 42
+                MaxPackageUpdates = 42
             };
 
             var (settings, _) = await CaptureSettings(fileSettings);
@@ -291,7 +291,7 @@ namespace NuKeeper.Tests.Commands
         {
             var fileSettings = new FileSettings
             {
-                MaxPr = 42
+                MaxPackageUpdates = 42
             };
 
             var (settings, _) = await CaptureSettings(fileSettings, false, 101);
@@ -323,7 +323,7 @@ namespace NuKeeper.Tests.Commands
         public static async Task<(SettingsContainer settingsContainer, CollaborationPlatformSettings platformSettings)> CaptureSettings(
             FileSettings settingsIn,
             bool addLabels = false,
-            int? maxPr = null)
+            int? maxPackageUpdates = null)
         {
             var logger = Substitute.For<IConfigureLogger>();
             var fileSettings = Substitute.For<IFileSettingsCache>();
@@ -346,7 +346,7 @@ namespace NuKeeper.Tests.Commands
                 command.Label = new List<string> {"runLabel1", "runLabel2"};
             }
 
-            command.MaxPullRequestsPerRepository = maxPr;
+            command.MaxPackageUpdates = maxPackageUpdates;
 
             await command.OnExecute();
 

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -24,9 +24,9 @@ namespace NuKeeper.Commands
                 "Prefer to make branches on a fork of the writer repository, or on that repository itself. Allowed values are PreferFork, PreferSingleRepository, SingleRepositoryOnly.")]
         public ForkMode? ForkMode { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "p", LongName = "maxpr",
-            Description = "The maximum number of pull requests to raise on any repository. Defaults to 3.")]
-        public int? MaxPullRequestsPerRepository { get; set; }
+        [Option(CommandOptionType.SingleValue, ShortName = "p", LongName = "maxpackageupdates",
+            Description = "The maximum number of package updates to apply on any repository. Defaults to 3.")]
+        public int? MaxPackageUpdates { get; set; }
 
         [Option(CommandOptionType.NoValue, ShortName = "n", LongName = "consolidate",
             Description = "Consolidate updates into a single pull request. Defaults to false.")]
@@ -97,9 +97,9 @@ namespace NuKeeper.Commands
             settings.UserSettings.ConsolidateUpdatesInSinglePullRequest =
                 Concat.FirstValue(Consolidate, fileSettings.Consolidate, false);
 
-            const int defaultMaxPullRequests = 3;
+            const int defaultMaxPackageUpdates = 3;
             settings.PackageFilters.MaxPackageUpdates =
-                Concat.FirstValue(MaxPullRequestsPerRepository, fileSettings.MaxPr, defaultMaxPullRequests);
+                Concat.FirstValue(MaxPackageUpdates, fileSettings.MaxPackageUpdates, defaultMaxPackageUpdates);
 
             var defaultLabels = new List<string> {"nukeeper"};
 

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.Commands
             Description = "The maximum number of pull requests to raise on any repository. Defaults to 3.")]
         public int? MaxPullRequestsPerRepository { get; set; }
 
-        [Option(CommandOptionType.NoValue, ShortName = "co", LongName = "consolidate",
+        [Option(CommandOptionType.NoValue, ShortName = "n", LongName = "consolidate",
             Description = "Consolidate updates into a single pull request. Defaults to false.")]
         public bool? Consolidate { get; set; }
 

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -42,7 +42,7 @@ namespace NuKeeper.Commands
                 "Api Base Url. If you are using an internal server and not a public one, you must set it to the api url of your server.")]
         public string ApiEndpoint { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "t", LongName = "platform",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "platform",
             Description = "Sets the collaboration platform type. By default this is inferred from the Url.")]
         public Platform? Platform { get; set; }
 

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Commands
         public ForkMode? ForkMode { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "p", LongName = "maxpackageupdates",
-            Description = "The maximum number of package updates to apply on any repository. Defaults to 3.")]
+            Description = "The maximum number of package updates to apply on one repository. Defaults to 3.")]
         public int? MaxPackageUpdates { get; set; }
 
         [Option(CommandOptionType.NoValue, ShortName = "n", LongName = "consolidate",

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Commands
             Description = "Allowed version change: Patch, Minor, Major. Defaults to Major.")]
         public VersionChange? AllowedChange { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "r", LongName = "useprerelease",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "useprerelease",
             Description = "Allowed prerelease: Always, Never, FromPrerelease. Defaults to FromPrerelease.")]
         public UsePrerelease? UsePrerelease { get; set; }
 

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Commands
             Description = "Allowed version change: Patch, Minor, Major. Defaults to Major.")]
         public VersionChange? AllowedChange { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "up", LongName = "useprerelease",
+        [Option(CommandOptionType.SingleValue, ShortName = "r", LongName = "useprerelease",
             Description = "Allowed prerelease: Always, Never, FromPrerelease. Defaults to FromPrerelease.")]
         public UsePrerelease? UsePrerelease { get; set; }
 
@@ -53,23 +53,23 @@ namespace NuKeeper.Commands
             Description = "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed].")]
         public LogLevel? Verbosity { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "ld", LongName = "logdestination",
+        [Option(CommandOptionType.SingleValue, ShortName = "b", LongName = "logdestination",
             Description = "Destination for logging.")]
         public LogDestination? LogDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "lf", LongName = "logfile",
+        [Option(CommandOptionType.SingleValue, ShortName = "j", LongName = "logfile",
             Description = "Log to the named file.")]
         public string LogFile { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "om", LongName = "outputformat",
+        [Option(CommandOptionType.SingleValue, ShortName = "h", LongName = "outputformat",
             Description = "Format for output.")]
         public OutputFormat? OutputFormat { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "od", LongName = "outputdestination",
+        [Option(CommandOptionType.SingleValue, ShortName = "d", LongName = "outputdestination",
             Description = "Destination for output.")]
         public OutputDestination? OutputDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "of", LongName = "outputfile",
+        [Option(CommandOptionType.SingleValue, ShortName = "o", LongName = "outputfile",
             Description = "File name for output.")]
         public string OutputFileName { get; set; }
 

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -53,23 +53,23 @@ namespace NuKeeper.Commands
             Description = "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed].")]
         public LogLevel? Verbosity { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "b", LongName = "logdestination",
+        [Option(CommandOptionType.SingleValue, LongName = "logdestination",
             Description = "Destination for logging.")]
         public LogDestination? LogDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "j", LongName = "logfile",
+        [Option(CommandOptionType.SingleValue, LongName = "logfile",
             Description = "Log to the named file.")]
         public string LogFile { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "h", LongName = "outputformat",
+        [Option(CommandOptionType.SingleValue, LongName = "outputformat",
             Description = "Format for output.")]
         public OutputFormat? OutputFormat { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "d", LongName = "outputdestination",
+        [Option(CommandOptionType.SingleValue, LongName = "outputdestination",
             Description = "Destination for output.")]
         public OutputDestination? OutputDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "o", LongName = "outputfile",
+        [Option(CommandOptionType.SingleValue, LongName = "outputfile",
             Description = "File name for output.")]
         public string OutputFileName { get; set; }
 

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -53,23 +53,23 @@ namespace NuKeeper.Commands
             Description = "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed].")]
         public LogLevel? Verbosity { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "logdestination",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "logdestination",
             Description = "Destination for logging.")]
         public LogDestination? LogDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "logfile",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "logfile",
             Description = "Log to the named file.")]
         public string LogFile { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "outputformat",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "outputformat",
             Description = "Format for output.")]
         public OutputFormat? OutputFormat { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "outputdestination",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "outputdestination",
             Description = "Destination for output.")]
         public OutputDestination? OutputDestination { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "outputfile",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "outputfile",
             Description = "File name for output.")]
         public string OutputFileName { get; set; }
 

--- a/NuKeeper/Commands/InspectCommand.cs
+++ b/NuKeeper/Commands/InspectCommand.cs
@@ -6,7 +6,7 @@ using NuKeeper.Local;
 
 namespace NuKeeper.Commands
 {
-    [Command("inspect", Description = "Checks projects existing locally for possible updates.")]
+    [Command("inspect", "i", Description = "Checks projects existing locally for possible updates.")]
     internal class InspectCommand : LocalNuKeeperCommand
     {
         private readonly ILocalEngine _engine;

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -11,10 +11,10 @@ namespace NuKeeper.Commands
 {
     internal abstract class MultipleRepositoryCommand : CollaborationPlatformCommand
     {
-        [Option(CommandOptionType.SingleValue, ShortName = "ir", LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, ShortName = "k", LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
         public string IncludeRepos { get; set;  }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "er", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, ShortName = "u", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
         public string ExcludeRepos { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "x", LongName = "maxrepo",

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -11,13 +11,13 @@ namespace NuKeeper.Commands
 {
     internal abstract class MultipleRepositoryCommand : CollaborationPlatformCommand
     {
-        [Option(CommandOptionType.SingleValue, ShortName = "k", LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
         public string IncludeRepos { get; set;  }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "u", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
         public string ExcludeRepos { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "x", LongName = "maxrepo",
+        [Option(CommandOptionType.SingleValue, LongName = "maxrepo",
             Description = "The maximum number of repositories to change. Defaults to 10.")]
         public int? AllowedMaxRepositoriesChangedChange { get; set; }
 

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -11,16 +11,15 @@ namespace NuKeeper.Commands
 {
     internal abstract class MultipleRepositoryCommand : CollaborationPlatformCommand
     {
-        [Option(CommandOptionType.SingleValue, LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "includerepos", Description = "Only consider repositories matching this regex pattern.")]
         public string IncludeRepos { get; set;  }
 
-        [Option(CommandOptionType.SingleValue, LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "excluderepos", Description = "Do not consider repositories matching this regex pattern.")]
         public string ExcludeRepos { get; set; }
 
-        [Option(CommandOptionType.SingleValue, LongName = "maxrepo",
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "maxrepo",
             Description = "The maximum number of repositories to change. Defaults to 10.")]
         public int? AllowedMaxRepositoriesChangedChange { get; set; }
-
 
         protected MultipleRepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
             : base(engine, logger, fileSettingsCache, collaborationFactory)

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -7,7 +7,7 @@ using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Commands
 {
-    [Command("org", Description = "Performs version checks and generates pull requests for all repositories in a github organisation.")]
+    [Command("org", "o", "organization", "organisation", Description = "Performs version checks and generates pull requests for all repositories in a github organisation.")]
     internal class OrganisationCommand : MultipleRepositoryCommand
     {
         [Argument(0, Name = "GitHub organisation name", Description = "The organisation to scan.")]

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -9,7 +9,7 @@ using NuKeeper.Collaboration;
 
 namespace NuKeeper.Commands
 {
-    [Command("repo", Description = "Performs version checks and generates pull requests for a single repository.")]
+    [Command("repo", "r","repository", Description = "Performs version checks and generates pull requests for a single repository.")]
     internal class RepositoryCommand : CollaborationPlatformCommand
     {
         [Argument(0, Name = "Repository URI", Description = "The URI of the repository to scan.")]


### PR DESCRIPTION
With the latest `CommandlineUtils`, option short names must be one char (as intended). The 2-char short 
names don't work any more. 

This is a breaking change, but it is already broken.

In this PR, each option has a unique short name. Since there are 22 of them,  many are unrelated to the command text.
And we are running out of letters. Some future options won't have short names.

In this new scheme, some of the options don't have short names at all where they are 1) not frequently used and 2) no obvious letter is available. 



