### PR TITLE
Github uri formats can vary

### DIFF
--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using NuGet.Common;
 using NuKeeper.Abstractions.Git;
 
 namespace NuKeeper.Abstractions.Formats

--- a/NuKeeper.GitHub.Tests/GitHubForkFinderTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubForkFinderTests.cs
@@ -98,6 +98,47 @@ namespace NuKeeper.GitHub.Tests
         }
 
         [Test]
+        public async Task WhenSuitableUserForkIsFound_ThatMatchesCloneHtmlUrl_WithRepoUrlVariation()
+        {
+            var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentCloneBareUrl), "testOrg", "someRepo");
+
+            var userRepo = RepositoryBuilder.MakeRepository();
+
+            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
+            collaborationPlatform.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(userRepo);
+
+            var forkFinder = new GitHubForkFinder(collaborationPlatform, Substitute.For<INuKeeperLogger>(), ForkMode.PreferFork);
+
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+
+            Assert.That(fork, Is.Not.EqualTo(fallbackFork));
+            AssertForkMatchesRepo(fork, userRepo);
+        }
+
+        [Test]
+        public async Task WhenSuitableUserForkIsFound_ThatMatchesCloneHtmlUrl_WithParentRepoUrlVariation()
+        {
+            var fallbackFork = new ForkData(new Uri(RepositoryBuilder.ParentCloneUrl), "testOrg", "someRepo");
+
+            var userRepo = RepositoryBuilder.MakeRepository(
+                RepositoryBuilder.ForkCloneUrl,
+                true, true, "userRepo",
+                RepositoryBuilder.MakeParentRepo(RepositoryBuilder.ParentCloneBareUrl));
+
+            var collaborationPlatform = Substitute.For<ICollaborationPlatform>();
+            collaborationPlatform.GetUserRepository(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(userRepo);
+
+            var forkFinder = new GitHubForkFinder(collaborationPlatform, Substitute.For<INuKeeperLogger>(), ForkMode.PreferFork);
+
+            var fork = await forkFinder.FindPushFork("testUser", fallbackFork);
+
+            Assert.That(fork, Is.Not.EqualTo(fallbackFork));
+            AssertForkMatchesRepo(fork, userRepo);
+        }
+
+        [Test]
         public async Task WhenUnsuitableUserForkIsFoundItIsNotUsed()
         {
             var fallbackFork = NoMatchFork();

--- a/NuKeeper.GitHub.Tests/RepositoryBuilder.cs
+++ b/NuKeeper.GitHub.Tests/RepositoryBuilder.cs
@@ -8,8 +8,10 @@ namespace NuKeeper.GitHub.Tests
     public static class RepositoryBuilder
     {
         public const string ParentCloneUrl = "http://repos.com/org/parent.git";
+        public const string ParentCloneBareUrl = "http://repos.com/org/parent/";
 
         public const string ForkCloneUrl = "http://repos.com/org/repo.git";
+        public const string ForkCloneBareUrl = "http://repos.com/org/repo/";
         public const string NoMatchUrl = "http://repos.com/org/nomatch";
 
         public static Repository MakeRepository(bool canPull, bool canPush)
@@ -21,7 +23,8 @@ namespace NuKeeper.GitHub.Tests
             string forkCloneUrl = ForkCloneUrl,
             bool canPull = true,
             bool canPush = true,
-            string name = "repoName")
+            string name = "repoName",
+            Repository parent = null)
         {
             return new Repository(
                 name,
@@ -30,16 +33,17 @@ namespace NuKeeper.GitHub.Tests
                 new Uri(forkCloneUrl),
                 MakeUser(),
                 true,
-                MakeParentRepo());
+                parent ?? MakeParentRepo());
         }
 
-        private static Repository MakeParentRepo()
+        public static Repository MakeParentRepo(
+            string cloneUrl = ParentCloneUrl)
         {
             return new Repository(
                 "repoName",
                 false,
                 new UserPermissions(false, true, true),
-                new Uri(ParentCloneUrl),
+                new Uri(cloneUrl),
                 MakeUser(),
                 true,
                 null

--- a/NuKeeper.GitHub/GitHubForkFinder.cs
+++ b/NuKeeper.GitHub/GitHubForkFinder.cs
@@ -112,9 +112,9 @@ namespace NuKeeper.GitHub
             var userFork = await _collaborationPlatform.GetUserRepository(userName, originFork.Name);
             if (userFork != null)
             {
-                var isFork = RepoIsForkOf(userFork, originFork.Uri);
-                var canPush = userFork.UserPermissions.Push;
-                if (isFork && canPush)
+                var isMatchingFork = RepoIsForkOf(userFork, originFork.Uri);
+                var forkIsPushable = userFork.UserPermissions.Push;
+                if (isMatchingFork && forkIsPushable)
                 {
                     // the user has a pushable fork
                     return RepositoryToForkData(userFork);
@@ -122,7 +122,7 @@ namespace NuKeeper.GitHub
 
                 // the user has a repo of that name, but it can't be used. 
                 // Don't try to create it
-                _logger.Normal($"User '{userName}' fork of '{originFork.Name}' exists but is unsuitable. Match: {isFork}. Pushable: {canPush}");
+                _logger.Normal($"User '{userName}' fork of '{originFork.Name}' exists but is unsuitable. Matching: {isMatchingFork}. Pushable: {forkIsPushable}");
                 return null;
             }
 
@@ -145,7 +145,7 @@ namespace NuKeeper.GitHub
 
             return UrlIsMatch(
                 userRepo.Parent?.CloneUrl,
-                GithubHelpers.GithubUri(originRepo));
+                GithubUriHelpers.Normalise(originRepo));
         }
 
         private static bool UrlIsMatch(Uri test, Uri expected)

--- a/NuKeeper.GitHub/GitHubForkFinder.cs
+++ b/NuKeeper.GitHub/GitHubForkFinder.cs
@@ -143,14 +143,20 @@ namespace NuKeeper.GitHub
                 return false;
             }
 
-            return UrlIsMatch(
-                userRepo.Parent?.CloneUrl,
-                GithubUriHelpers.Normalise(originRepo));
-        }
+            if (userRepo.Parent?.CloneUrl == null)
+            {
+                return false;
+            }
 
-        private static bool UrlIsMatch(Uri test, Uri expected)
-        {
-            return (test != null) && (test == expected);
+            if (originRepo == null)
+            {
+                return false;
+            }
+
+            var userParentUrl = GithubUriHelpers.Normalise(userRepo.Parent.CloneUrl);
+            var originUrl = GithubUriHelpers.Normalise(originRepo);
+
+            return userParentUrl.Equals(originUrl);
         }
 
         private static ForkData RepositoryToForkData(Repository repo)

--- a/NuKeeper.GitHub/GitHubRepository.cs
+++ b/NuKeeper.GitHub/GitHubRepository.cs
@@ -10,7 +10,7 @@ namespace NuKeeper.GitHub
             repository.Archived,
             repository.Permissions != null ?
                 new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull) : null,
-            GithubHelpers.GithubUri(repository.CloneUrl),
+            GithubUriHelpers.Normalise(repository.CloneUrl),
             new User(repository.Owner.Login, repository.Owner.Name, repository.Owner.Email),
             repository.Fork,
             repository.Parent != null ?

--- a/NuKeeper.GitHub/GitHubRepository.cs
+++ b/NuKeeper.GitHub/GitHubRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using NuKeeper.Abstractions.CollaborationModels;
 
 namespace NuKeeper.GitHub
@@ -11,28 +10,13 @@ namespace NuKeeper.GitHub
             repository.Archived,
             repository.Permissions != null ?
                 new UserPermissions(repository.Permissions.Admin, repository.Permissions.Push, repository.Permissions.Pull) : null,
-            GithubUri(repository.CloneUrl),
+            GithubHelpers.GithubUri(repository.CloneUrl),
             new User(repository.Owner.Login, repository.Owner.Name, repository.Owner.Email),
             repository.Fork,
             repository.Parent != null ?
                 new GitHubRepository(repository.Parent) : null
             )
         {
-        }
-
-        private static Uri GithubUri(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return null;
-            }
-
-            if (value.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-            {
-                value = value.Substring(0, value.Length - 4);
-            }
-
-            return new Uri(value, UriKind.Absolute);
         }
     }
 }

--- a/NuKeeper.GitHub/GithubHelpers.cs
+++ b/NuKeeper.GitHub/GithubHelpers.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace NuKeeper.GitHub
+{
+    public static class GithubHelpers
+    {
+        public static Uri GithubUri(Uri value)
+        {
+            return GithubUri(value.ToString());
+        }
+
+        public static Uri GithubUri(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            if (value.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 4);
+            }
+
+            if (value.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 1);
+            }
+
+            return new Uri(value, UriKind.Absolute);
+        }
+    }
+}

--- a/NuKeeper.GitHub/GithubUriHelpers.cs
+++ b/NuKeeper.GitHub/GithubUriHelpers.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace NuKeeper.GitHub
 {
-    public static class GithubHelpers
+    public static class GithubUriHelpers
     {
-        public static Uri GithubUri(Uri value)
+        public static Uri Normalise(Uri value)
         {
-            return GithubUri(value.ToString());
+            return Normalise(value.ToString());
         }
 
-        public static Uri GithubUri(string value)
+        public static Uri Normalise(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {


### PR DESCRIPTION
Github uri formats can vary. not just `.git` on the end but also trailing slash.
This issue that prevented a fork being used due to presence/absence of trailing slash and therefor string mismatch.

Extracted the code that normalises them into `GithubHelpers`.  Call it in 1 more place where the format can vary.
Use `Uri` not `string` a bit more. 
More details in the message when it does not match. The original message doesn't say which of the 2 possible reasons it failed for, not pushable, or not matching. it just said
`User 'anthony-steele' fork of 'helper-lib' exists but is unsuitable.`