### PR TITLE
Use the NetCore 2.2 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk
+FROM microsoft/dotnet:2.2-sdk
 RUN dotnet tool install --global NuKeeper --version 0.17.0
 ENV PATH="${PATH}:/root/.dotnet/tools"
 ENTRYPOINT ["nukeeper"]


### PR DESCRIPTION
The docker image should have SDK version 2.2, because that will give a version of `dotnet` that works for `netcoreapp2.2` and `2.1` projects (and lower versions). Whereas SDK 2.1 might not work for projects that target `netcoreapp2.2`.
