### PR TITLE
fix(AzD): branch name comparison didn't work with AzD naming

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -89,7 +89,7 @@ namespace NuKeeper.AzureDevOps
             var repos = await _client.GetGitRepositories(projectName);
             var repo = repos.Single(x => x.name == repositoryName);
             var refs = await _client.GetRepositoryRefs(projectName, repo.id);
-            var count = refs.Count(x => x.name == branchName);
+            var count = refs.Count(x => x.name.EndsWith(branchName, StringComparison.OrdinalIgnoreCase));
             if (count > 0)
             {
                 _logger.Detailed($"Branch found for {projectName} / {repositoryName} / {branchName}");

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -146,9 +146,9 @@ namespace NuKeeper.Git
             {
                 
                 var localBranch = repo.Branches
-                    .FirstOrDefault(b => b.CanonicalName.EndsWith(branchName, StringComparison.OrdinalIgnoreCase));
+                    .Single(b => b.CanonicalName.EndsWith(branchName, StringComparison.OrdinalIgnoreCase));
                 var remote = repo.Network.Remotes
-                    .FirstOrDefault(b => b.Name.EndsWith(remoteName, StringComparison.OrdinalIgnoreCase));
+                    .Single(b => b.Name.EndsWith(remoteName, StringComparison.OrdinalIgnoreCase));
 
                 repo.Branches.Update(localBranch,
                     b => b.Remote = remote.Name,

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -144,8 +144,11 @@ namespace NuKeeper.Git
 
             using (var repo = MakeRepo())
             {
-                var localBranch = repo.Branches[branchName];
-                var remote = repo.Network.Remotes[remoteName];
+                
+                var localBranch = repo.Branches
+                    .FirstOrDefault(b => b.CanonicalName.EndsWith(branchName, StringComparison.OrdinalIgnoreCase));
+                var remote = repo.Network.Remotes
+                    .FirstOrDefault(b => b.Name.EndsWith(remoteName, StringComparison.OrdinalIgnoreCase));
 
                 repo.Branches.Update(localBranch,
                     b => b.Remote = remote.Name,


### PR DESCRIPTION
fixes #677 