### PR TITLE
Two dockerfiles

### DIFF
--- a/Docker/SDK21_Dockerfile
+++ b/Docker/SDK21_Dockerfile
@@ -1,0 +1,4 @@
+FROM microsoft/dotnet:2.1-sdk
+RUN dotnet tool install --global NuKeeper --version 0.19.0
+ENV PATH="${PATH}:/root/.dotnet/tools"
+ENTRYPOINT ["nukeeper"]

--- a/Docker/SDK22_Dockerfile
+++ b/Docker/SDK22_Dockerfile
@@ -1,4 +1,4 @@
 FROM microsoft/dotnet:2.2-sdk
-RUN dotnet tool install --global NuKeeper --version 0.17.0
+RUN dotnet tool install --global NuKeeper --version 0.19.0
 ENV PATH="${PATH}:/root/.dotnet/tools"
 ENTRYPOINT ["nukeeper"]


### PR DESCRIPTION
Two dockerfiles, one for each of the .NET Core SDK 2.1 and SDK 2.2

A fix /workaround for https://github.com/NuKeeperDotNet/NuKeeper/issues/682
This will require matching changes to builds on dockehub at https://cloud.docker.com/u/nukeeper/repository/docker/nukeeper/nukeeper/build
to build them both