### PR TITLE
Make DirectoryExclusions an instance with interface

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryExclusionsTests.cs
@@ -16,7 +16,10 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         public void ShouldBeIncluded(string pathTemplate)
         {
             var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
-            var actual = DirectoryExclusions.PathIsExcluded(path);
+
+            var exclusions = new DirectoryExclusions();
+            var actual = exclusions.PathIsExcluded(path);
+
             Assert.That(actual, Is.False);
         }
 
@@ -28,7 +31,9 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             var path = pathTemplate.Replace("{sep}", $"{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
 
-            var actual = DirectoryExclusions.PathIsExcluded(path);
+            var exclusions = new DirectoryExclusions();
+            var actual = exclusions.PathIsExcluded(path);
+
             Assert.That(actual, Is.True);
         }
     }

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryExclusions.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryExclusions.cs
@@ -5,11 +5,10 @@ using System.Linq;
 
 namespace NuKeeper.Inspection.RepositoryInspection
 {
-    public static class DirectoryExclusions
+    public class DirectoryExclusions : IDirectoryExclusions
     {
-        public static bool PathIsExcluded(string path)
+        public bool PathIsExcluded(string path)
         {
-            // subDir is a full path, check all parts
             return ExcludedDirNames.Any(s => PathContains(path, s));
         }
 

--- a/NuKeeper.Inspection/RepositoryInspection/IDirectoryExclusions.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/IDirectoryExclusions.cs
@@ -1,0 +1,7 @@
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    public interface IDirectoryExclusions
+    {
+        bool PathIsExcluded(string path);
+    }
+}

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -184,7 +184,8 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
                 new ProjectFileReader(logger),
                 new PackagesFileReader(logger),
                 new NuspecFileReader(logger),
-                new DirectoryBuildTargetsReader(logger));
+                new DirectoryBuildTargetsReader(logger),
+                new DirectoryExclusions());
         }
 
         private static void WriteFile(IFolder path, string fileName, string contents)

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -23,6 +23,7 @@ namespace NuKeeper
             container.RegisterInstance<IConfigureLogger>(logger);
             container.Register<ILogger, NuGetLogger>();
 
+            container.Register<IDirectoryExclusions, DirectoryExclusions>();
             container.Register<IFolder, Folder>();
             container.Register<IFolderFactory, FolderFactory>();
 


### PR DESCRIPTION
Make `DirectoryExclusions` an instance with interface.
I ran into the need for this while planning new tests that test `UpdateFinder` and everything under it.
Test data files underneath the `\bin\` folder are automatically excluded unless you can control this behaviour by supplying a different `IDirectoryExclusions` instance for those tests.