### PR TITLE
Try a larger "unit" of testing

### DIFF
--- a/NuKeeper.EndToEndTests/Data/NewStyleCsProj/TestCase.csproj
+++ b/NuKeeper.EndToEndTests/Data/NewStyleCsProj/TestCase.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  </ItemGroup>
+</Project>

--- a/NuKeeper.EndToEndTests/FinderTests.cs
+++ b/NuKeeper.EndToEndTests/FinderTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Inspection;
+using NuKeeper.Inspection.Files;
+using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.EndToEndTests
+{
+    public class FinderTests
+    {
+        [Test]
+        public async Task TestMissingFolder()
+        {
+            var logger = new TestLogger();
+            var finder = BuildUpdateFinder(logger);
+
+            Assert.That(finder, Is.Not.Null);
+
+            var updates = await finder.FindPackageUpdateSets(
+                FolderForPath(".{sep}NoSuchPath"),
+                NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.Never);
+
+            Assert.That(updates, Is.Not.Null);
+            Assert.That(updates, Is.Empty);
+
+            Assert.That(logger.ReceivedMessage("Found 0 possible updates"));
+        }
+
+        [Test]
+        public async Task TestSimpleFolder()
+        {
+            var logger = new TestLogger();
+            var finder = BuildUpdateFinder(logger);
+
+            Assert.That(finder, Is.Not.Null);
+
+            var updates = await finder.FindPackageUpdateSets(
+                FolderForPath(".{sep}Data{sep}newStyleCsProj"),
+                NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.Never);
+
+            Assert.That(updates, Is.Not.Null);
+            Assert.That(updates, Is.Not.Empty);
+            Assert.That(logger.ReceivedMessage("Found 1 possible updates"));
+            Assert.That(logger.ReceivedMessage("Newtonsoft.Json"));
+        }
+
+        private Folder FolderForPath(string path)
+        {
+            path = path.Replace("{sep}", "" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+
+            var logger = new TestLogger();
+            return new Folder(logger, new DirectoryInfo(path));
+        }
+
+        private static UpdateFinder BuildUpdateFinder(INuKeeperLogger logger)
+        {
+            var nugetLogger = new NuGetLogger(logger);
+
+            var scanner = new RepositoryScanner(
+                new ProjectFileReader(logger),
+                new PackagesFileReader(logger),
+                new NuspecFileReader(logger),
+                new DirectoryBuildTargetsReader(logger),
+                new NullExclusions());
+
+            var lookup =
+                new PackageUpdatesLookup(
+                    new BulkPackageLookup(new ApiPackageLookup(new PackageVersionsLookup(nugetLogger, logger)),
+                        new PackageLookupResultReporter(logger)));
+
+            var finder = new UpdateFinder(scanner, lookup, logger);
+            return finder;
+        }
+    }
+}

--- a/NuKeeper.EndToEndTests/FinderTests.cs
+++ b/NuKeeper.EndToEndTests/FinderTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.EndToEndTests
             Assert.That(finder, Is.Not.Null);
 
             var updates = await finder.FindPackageUpdateSets(
-                FolderForPath(".{sep}Data{sep}newStyleCsProj"),
+                FolderForPath(".{sep}Data{sep}NewStyleCsProj"),
                 NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.Never);
 
             Assert.That(updates, Is.Not.Null);

--- a/NuKeeper.EndToEndTests/NuKeeper.EndToEndTests.csproj
+++ b/NuKeeper.EndToEndTests/NuKeeper.EndToEndTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Data\NewStyleCsProj\TestCase.csproj">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Common" Version="4.9.4" />
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
+    <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NuKeeper.EndToEndTests/NullExclusions.cs
+++ b/NuKeeper.EndToEndTests/NullExclusions.cs
@@ -1,0 +1,12 @@
+using NuKeeper.Inspection.RepositoryInspection;
+
+namespace NuKeeper.EndToEndTests
+{
+    public class NullExclusions : IDirectoryExclusions
+    {
+        public bool PathIsExcluded(string path)
+        {
+            return false;
+        }
+    }
+}

--- a/NuKeeper.EndToEndTests/TestLogger.cs
+++ b/NuKeeper.EndToEndTests/TestLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.EndToEndTests
+{
+    public class TestLogger : INuKeeperLogger
+    {
+        private readonly List<string> _messages = new List<string>();
+
+        public void Error(string message, Exception ex = null)
+        {
+            _messages.Add(message);
+        }
+
+        public void Minimal(string message)
+        {
+            _messages.Add(message);
+        }
+
+        public void Normal(string message)
+        {
+            _messages.Add(message);
+        }
+
+        public void Detailed(string message)
+        {
+            _messages.Add(message);
+        }
+
+        public IReadOnlyCollection<string> Messages => _messages;
+
+        public bool ReceivedMessage(string match)
+        {
+            return Messages.Any(m => m.Equals(match, StringComparison.Ordinal));
+        }
+    }
+}

--- a/NuKeeper.sln
+++ b/NuKeeper.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Abstractions.Tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.BitBucketLocal", "Nukeeper.BitBucketLocal\NuKeeper.BitBucketLocal.csproj", "{37444E91-3675-4FC7-9EB1-37B091115BAE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.EndToEndTests", "NuKeeper.EndToEndTests\NuKeeper.EndToEndTests.csproj", "{83C8093C-8A5D-4A55-8417-D8E959DC64F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83C8093C-8A5D-4A55-8417-D8E959DC64F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83C8093C-8A5D-4A55-8417-D8E959DC64F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83C8093C-8A5D-4A55-8417-D8E959DC64F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83C8093C-8A5D-4A55-8417-D8E959DC64F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A proposed approach to tests, so supplement or partly replace current unit tests that focus on 1 class at a time ( As per [Mr Cooper's advice to avoid these highly coupled tests with lots of mocks](https://www.youtube.com/watch?v=EZ05e7EMOLM) ) and so make refactoring easier and tests simpler, and generally increase test coverage and therefor reliability.

Try an "end to end" find updates tests, with a sample `.csproj`  file as data, and a "find updates run against this test data. This exercises `UpdateFinder` and all code underneath it.  `UpdateFinder` is essentialy the entry point to `NuKeeper.Inspection`.

Anything under `NuKeeper.EndToEndTests/Data/` is not part of NuKeeper code, it is test data input to NuKeeper.

The idea is to extend this to a suite of sample projects, e.g. .NET core and .NET full framework, `.vbproj`, `.fsproj`, simple and quirky, and run similar "inspect" or even update tests against each of them.


The choice of  the package `"Newtonsoft.Json" Version="10.0.1" ` as starting point is deliberate - it's well known, and has a patch update to `10.03` as well as major updates.

Since these tests use a bare minimum of mocks, and real file and the real public nuget feed, you might call them "integration" tests, I don't really mind. It tests the behaviour of `NuKeeper.Inspection` via the entry point, not the implementation.


Related, some test coverage tracking would be good.