### PR TITLE
GitLab support

### DIFF
--- a/NuKeeper.Abstractions/CollaborationPlatform/Platform.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/Platform.cs
@@ -5,6 +5,7 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
         GitHub,
         AzureDevOps,
         Bitbucket,
-        BitbucketLocal
+        BitbucketLocal,
+        GitLab
     }
 }

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -9,13 +9,11 @@ namespace NuKeeper.Gitlab.Tests
     {
         private GitlabSettingsReader _gitlabSettingsReader;
 
-
         [SetUp]
         public void Setup()
         {
             _gitlabSettingsReader = new GitlabSettingsReader();
         }
-
 
         [Test]
         public void ReturnsCorrectPlatform()
@@ -24,7 +22,6 @@ namespace NuKeeper.Gitlab.Tests
 
             Assert.AreEqual(Platform.GitLab, platform);
         }
-
 
         [Test]
         public void AssumesItCanReadGitLabUrls()

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Gitlab.Tests
             var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, "master");
 
             Assert.IsNotNull(repositorySettings);
-            Assert.AreEqual(new Uri("https://gitlab.com/api/v4"), repositorySettings.ApiUri);
+            Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
             Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
             Assert.AreEqual("user", repositorySettings.RepositoryOwner);
             Assert.AreEqual("projectname", repositorySettings.RepositoryName);

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Gitlab.Tests
             var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, "master");
 
             Assert.IsNotNull(repositorySettings);
-            Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
+            Assert.AreEqual(new Uri("https://gitlab.com/api/v4"), repositorySettings.ApiUri);
             Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
             Assert.AreEqual("user", repositorySettings.RepositoryOwner);
             Assert.AreEqual("projectname", repositorySettings.RepositoryName);

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -31,18 +31,19 @@ namespace NuKeeper.Gitlab.Tests
             Assert.AreEqual(true, canRead);
         }
 
-        [Test]
-        public void GetsCorrectSettingsFromTheUrl()
+        [TestCase(null)]
+        [TestCase("master")]
+        public void GetsCorrectSettingsFromTheUrl(string targetBranch)
         {
             var repositoryUri = new Uri("https://gitlab.com/user/projectname.git");
-            var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, "master");
+            var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, targetBranch);
 
             Assert.IsNotNull(repositorySettings);
             Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
             Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
             Assert.AreEqual("user", repositorySettings.RepositoryOwner);
             Assert.AreEqual("projectname", repositorySettings.RepositoryName);
-            Assert.AreEqual("master", repositorySettings.TargetBranch);
+            Assert.AreEqual(targetBranch, repositorySettings.RemoteInfo?.BranchName);
         }
     }
 }

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -1,0 +1,51 @@
+using System;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NUnit.Framework;
+
+namespace NuKeeper.Gitlab.Tests
+{
+    [TestFixture]
+    public class GitlabSettingsReaderTests
+    {
+        private GitlabSettingsReader _gitlabSettingsReader;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _gitlabSettingsReader = new GitlabSettingsReader();
+        }
+
+
+        [Test]
+        public void ReturnsCorrectPlatform()
+        {
+            var platform = _gitlabSettingsReader.Platform;
+
+            Assert.AreEqual(Platform.GitLab, platform);
+        }
+
+
+        [Test]
+        public void ReturnsTrueForGitLabUrl()
+        {
+            var canRead = _gitlabSettingsReader.CanRead(new Uri("https://gitlab.com/user/projectname.git"));
+
+            Assert.AreEqual(true, canRead);
+        }
+
+        [Test]
+        public void RepositorySettingsGetsCorrectSettings()
+        {
+            var repositoryUri = new Uri("https://gitlab.com/user/projectname.git");
+            var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, "master");
+
+            Assert.IsNotNull(repositorySettings);
+            Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
+            Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
+            Assert.AreEqual("user", repositorySettings.RepositoryOwner);
+            Assert.AreEqual("projectname", repositorySettings.RepositoryName);
+            Assert.AreEqual("master", repositorySettings.TargetBranch);
+        }
+    }
+}

--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -27,7 +27,7 @@ namespace NuKeeper.Gitlab.Tests
 
 
         [Test]
-        public void ReturnsTrueForGitLabUrl()
+        public void AssumesItCanReadGitLabUrls()
         {
             var canRead = _gitlabSettingsReader.CanRead(new Uri("https://gitlab.com/user/projectname.git"));
 
@@ -35,7 +35,7 @@ namespace NuKeeper.Gitlab.Tests
         }
 
         [Test]
-        public void RepositorySettingsGetsCorrectSettings()
+        public void GetsCorrectSettingsFromTheUrl()
         {
             var repositoryUri = new Uri("https://gitlab.com/user/projectname.git");
             var repositorySettings = _gitlabSettingsReader.RepositorySettings(repositoryUri, "master");

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
+    <ProjectReference Include="..\NuKeeper.Gitlab\NuKeeper.Gitlab.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.Gitlab/GitlabForkFinder.cs
+++ b/NuKeeper.Gitlab/GitlabForkFinder.cs
@@ -14,8 +14,6 @@ namespace NuKeeper.Gitlab
         {
             _collaborationPlatform = collaborationPlatform;
             _nuKeeperLogger = nuKeeperLogger;
-
-            throw new System.NotImplementedException();
         }
 
         public Task<ForkData> FindPushFork(string userName, ForkData fallbackFork)

--- a/NuKeeper.Gitlab/GitlabForkFinder.cs
+++ b/NuKeeper.Gitlab/GitlabForkFinder.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Gitlab
@@ -8,17 +10,51 @@ namespace NuKeeper.Gitlab
     public class GitlabForkFinder : IForkFinder
     {
         private readonly ICollaborationPlatform _collaborationPlatform;
-        private readonly INuKeeperLogger _nuKeeperLogger;
+        private readonly INuKeeperLogger _logger;
+        private readonly ForkMode _forkMode;
 
-        public GitlabForkFinder(ICollaborationPlatform collaborationPlatform, INuKeeperLogger nuKeeperLogger)
+        public GitlabForkFinder(ICollaborationPlatform collaborationPlatform, INuKeeperLogger logger, ForkMode forkMode)
         {
+            if (forkMode != ForkMode.SingleRepositoryOnly)
+            {
+                throw new ArgumentOutOfRangeException(nameof(forkMode), $"{_forkMode} has not yet been implemented");
+            }
+
             _collaborationPlatform = collaborationPlatform;
-            _nuKeeperLogger = nuKeeperLogger;
+            _logger = logger;
+            _forkMode = forkMode;
+
+            _logger.Detailed($"FindPushFork. Fork Mode is {_forkMode}");
         }
 
-        public Task<ForkData> FindPushFork(string userName, ForkData fallbackFork)
+        public async Task<ForkData> FindPushFork(string userName, ForkData fallbackFork)
         {
-            throw new System.NotImplementedException();
+            return await FindUpstreamRepoOnly(fallbackFork);
+        }
+
+        private async Task<ForkData> FindUpstreamRepoOnly(ForkData pullFork)
+        {
+            // Only want to pull and push from the same origin repo.
+            var canUseOriginRepo = await IsPushableRepo(pullFork);
+            if (canUseOriginRepo)
+            {
+                _logger.Normal($"Using upstream fork as push, for project {pullFork.Owner} at {pullFork.Uri}");
+                return pullFork;
+            }
+
+            NoPushableForkFound(pullFork.Name);
+            return null;
+        }
+
+        private void NoPushableForkFound(string name)
+        {
+            _logger.Error($"No pushable fork found for {name} in mode {_forkMode}");
+        }
+
+        private async Task<bool> IsPushableRepo(ForkData originFork)
+        {
+            var originRepo = await _collaborationPlatform.GetUserRepository(originFork.Owner, originFork.Name);
+            return originRepo?.UserPermissions.Push == true;
         }
     }
 }

--- a/NuKeeper.Gitlab/GitlabForkFinder.cs
+++ b/NuKeeper.Gitlab/GitlabForkFinder.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.CollaborationModels;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.Gitlab
+{
+    public class GitlabForkFinder : IForkFinder
+    {
+        private readonly ICollaborationPlatform _collaborationPlatform;
+        private readonly INuKeeperLogger _nuKeeperLogger;
+
+        public GitlabForkFinder(ICollaborationPlatform collaborationPlatform, INuKeeperLogger nuKeeperLogger)
+        {
+            _collaborationPlatform = collaborationPlatform;
+            _nuKeeperLogger = nuKeeperLogger;
+
+            throw new System.NotImplementedException();
+        }
+
+        public Task<ForkData> FindPushFork(string userName, ForkData fallbackFork)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -12,21 +12,28 @@ namespace NuKeeper.Gitlab
     public class GitlabPlatform: ICollaborationPlatform
     {
         private readonly INuKeeperLogger _logger;
+        private GitlabRestClient _client;
 
         public GitlabPlatform(INuKeeperLogger logger)
         {
             _logger = logger;
-
         }
 
         public void Initialise(AuthSettings settings)
         {
-            throw new NotImplementedException();
+            var httpClient = new HttpClient
+            {
+                BaseAddress = settings.ApiBase
+            };
+
+            _client = new GitlabRestClient(httpClient, settings.Token, _logger);
         }
 
-        public Task<User> GetCurrentUser()
+        public async Task<User> GetCurrentUser()
         {
-            throw new NotImplementedException();
+            var user = await _client.GetCurrentUser().ConfigureAwait(false);
+
+            return new User(user.UserName, user.Name, user.Email);
         }
 
         public Task OpenPullRequest(ForkData target, PullRequestRequest request, IEnumerable<string> labels)

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -59,11 +59,13 @@ namespace NuKeeper.Gitlab
 
         public Task<IReadOnlyList<Organization>> GetOrganizations()
         {
+            _logger.Error("GitLab organizations have not yet been implemented.");
             throw new NotImplementedException();
         }
 
         public Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string projectName)
         {
+            _logger.Error("GitLab organizations have not yet been implemented.");
             throw new NotImplementedException();
         }
 
@@ -79,6 +81,7 @@ namespace NuKeeper.Gitlab
 
         public Task<Repository> MakeUserFork(string owner, string repositoryName)
         {
+            _logger.Error($"{ForkMode.PreferFork} has not yet been implemented for GitLab.");
             throw new NotImplementedException();
         }
 
@@ -91,6 +94,7 @@ namespace NuKeeper.Gitlab
 
         public Task<SearchCodeResult> Search(SearchCodeRequest search)
         {
+            _logger.Error($"Search has not yet been implemented for GitLab.");
             throw new NotImplementedException();
         }
     }

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.CollaborationModels;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.Gitlab
+{
+    public class GitlabPlatform: ICollaborationPlatform
+    {
+        private readonly INuKeeperLogger _logger;
+
+        public GitlabPlatform(INuKeeperLogger logger)
+        {
+            _logger = logger;
+
+        }
+
+        public void Initialise(AuthSettings settings)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<User> GetCurrentUser()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task OpenPullRequest(ForkData target, PullRequestRequest request, IEnumerable<string> labels)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<Organization>> GetOrganizations()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<Repository>> GetRepositoriesForOrganisation(string organisationName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Repository> GetUserRepository(string userName, string repositoryName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Repository> MakeUserFork(string owner, string repositoryName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> RepositoryBranchExists(string userName, string repositoryName, string branchName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<SearchCodeResult> Search(SearchCodeRequest search)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -15,7 +15,6 @@ namespace NuKeeper.Gitlab
     {
         private readonly INuKeeperLogger _logger;
         private GitlabRestClient _client;
-        private AuthSettings _settings;
 
         public GitlabPlatform(INuKeeperLogger logger)
         {
@@ -24,8 +23,6 @@ namespace NuKeeper.Gitlab
 
         public void Initialise(AuthSettings settings)
         {
-            _settings = settings;
-
             var httpClient = new HttpClient
             {
                 BaseAddress = settings.ApiBase
@@ -35,7 +32,7 @@ namespace NuKeeper.Gitlab
 
         public async Task<User> GetCurrentUser()
         {
-            var user = await _client.GetCurrentUser().ConfigureAwait(false);
+            var user = await _client.GetCurrentUser();
 
             return new User(user.UserName, user.Name, user.Email);
         }
@@ -54,7 +51,7 @@ namespace NuKeeper.Gitlab
                 Id = $"{projectName}/{repositoryName}"
             };
 
-            await _client.OpenMergeRequest(projectName, repositoryName, mergeRequest).ConfigureAwait(false);
+            await _client.OpenMergeRequest(projectName, repositoryName, mergeRequest);
         }
 
         public Task<IReadOnlyList<Organization>> GetOrganizations()
@@ -71,7 +68,7 @@ namespace NuKeeper.Gitlab
 
         public async Task<Repository> GetUserRepository(string userName, string repositoryName)
         {
-            var project = await _client.GetProject(userName, repositoryName).ConfigureAwait(false);
+            var project = await _client.GetProject(userName, repositoryName);
 
             return new Repository(project.Name, project.Archived,
                 new UserPermissions(true, true, true),
@@ -87,7 +84,7 @@ namespace NuKeeper.Gitlab
 
         public async Task<bool> RepositoryBranchExists(string userName, string repositoryName, string branchName)
         {
-            var result = await _client.CheckExistingBranch(userName, repositoryName, branchName).ConfigureAwait(false);
+            var result = await _client.CheckExistingBranch(userName, repositoryName, branchName);
 
             return result != null;
         }

--- a/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
+++ b/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -8,20 +10,33 @@ namespace NuKeeper.Gitlab
 {
     public class GitlabRepositoryDiscovery : IRepositoryDiscovery
     {
-        private readonly INuKeeperLogger _nuKeeperLogger;
+        private readonly INuKeeperLogger _logger;
         private readonly ICollaborationPlatform _collaborationPlatform;
 
-        public GitlabRepositoryDiscovery(INuKeeperLogger nuKeeperLogger, ICollaborationPlatform collaborationPlatform)
+        public GitlabRepositoryDiscovery(INuKeeperLogger logger, ICollaborationPlatform collaborationPlatform)
         {
-            _nuKeeperLogger = nuKeeperLogger;
+            _logger = logger;
             _collaborationPlatform = collaborationPlatform;
-
-            throw new System.NotImplementedException();
         }
 
         public Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings)
         {
-            throw new System.NotImplementedException();
+            switch (settings.Scope)
+            {
+                case ServerScope.Global:
+                    throw new NotImplementedException();
+
+                case ServerScope.Organisation:
+                    throw new NotImplementedException();
+
+                case ServerScope.Repository:
+                    IEnumerable<RepositorySettings> repositorySettings = new[] { settings.Repository };
+                    return Task.FromResult(repositorySettings);
+
+                default:
+                    _logger.Error($"Unknown Server Scope {settings.Scope}");
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
+++ b/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.Gitlab
+{
+    public class GitlabRepositoryDiscovery : IRepositoryDiscovery
+    {
+        private readonly INuKeeperLogger _nuKeeperLogger;
+        private readonly ICollaborationPlatform _collaborationPlatform;
+
+        public GitlabRepositoryDiscovery(INuKeeperLogger nuKeeperLogger, ICollaborationPlatform collaborationPlatform)
+        {
+            _nuKeeperLogger = nuKeeperLogger;
+            _collaborationPlatform = collaborationPlatform;
+
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
+++ b/NuKeeper.Gitlab/GitlabRepositoryDiscovery.cs
@@ -24,9 +24,8 @@ namespace NuKeeper.Gitlab
             switch (settings.Scope)
             {
                 case ServerScope.Global:
-                    throw new NotImplementedException();
-
                 case ServerScope.Organisation:
+                    _logger.Error($"{settings.Scope} not yet implemented");
                     throw new NotImplementedException();
 
                 case ServerScope.Repository:

--- a/NuKeeper.Gitlab/GitlabRestClient.cs
+++ b/NuKeeper.Gitlab/GitlabRestClient.cs
@@ -9,7 +9,6 @@ using System.Web;
 using Newtonsoft.Json;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Logging;
-using Model = NuKeeper.Gitlab.Model;
 
 namespace NuKeeper.Gitlab
 {
@@ -31,7 +30,7 @@ namespace NuKeeper.Gitlab
         // GET /user
         public async Task<Model.User> GetCurrentUser()
         {
-            return await GetResource<Model.User>("user").ConfigureAwait(false);
+            return await GetResource<Model.User>("user");
         }
 
         // https://docs.gitlab.com/ee/api/projects.html#get-single-project
@@ -39,7 +38,7 @@ namespace NuKeeper.Gitlab
         public async Task<Model.Project> GetProject(string projectName, string repositoryName)
         {
             var encodedProjectName = HttpUtility.UrlEncode($"{projectName}/{repositoryName}");
-            return await GetResource<Model.Project>($"projects/{encodedProjectName}").ConfigureAwait(false);
+            return await GetResource<Model.Project>($"projects/{encodedProjectName}");
         }
 
         // https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
@@ -50,11 +49,11 @@ namespace NuKeeper.Gitlab
             var encodedProjectName = HttpUtility.UrlEncode($"{projectName}/{repositoryName}");
             var encodedBranchName = HttpUtility.UrlEncode(branchName);
 
-            return await GetResource<Model.Branch>(
+            return await GetResource(
                 $"projects/{encodedProjectName}/repository/branches/{encodedBranchName}",
                 statusCode => statusCode == HttpStatusCode.NotFound
                     ? Result<Model.Branch>.Success(null)
-                    : Result<Model.Branch>.Failure()).ConfigureAwait(false);
+                    : Result<Model.Branch>.Failure());
         }
 
         // https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
@@ -73,17 +72,17 @@ namespace NuKeeper.Gitlab
             var fullUrl = new Uri(url, UriKind.Relative);
             _logger.Detailed($"{caller}: Requesting {fullUrl}");
 
-            var response = await _client.GetAsync(fullUrl).ConfigureAwait(false);
-            return await HandleResponse<T>(response, customErrorHandling, caller).ConfigureAwait(false);
+            var response = await _client.GetAsync(fullUrl);
+            return await HandleResponse(response, customErrorHandling, caller);
         }
 
         private async Task<T> PostResource<T>(string url, HttpContent content, Func<HttpStatusCode, Result<T>> customErrorHandling = null, [CallerMemberName] string caller = null)
         {
             _logger.Detailed($"{caller}: Requesting {url}");
 
-            var response = await _client.PostAsync(url, content).ConfigureAwait(false);
+            var response = await _client.PostAsync(url, content);
 
-            return await HandleResponse<T>(response, customErrorHandling, caller).ConfigureAwait(false);
+            return await HandleResponse(response, customErrorHandling, caller);
         }
 
         private async Task<T> HandleResponse<T>(HttpResponseMessage response,
@@ -92,7 +91,7 @@ namespace NuKeeper.Gitlab
         {
             string msg;
 
-            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
             {

--- a/NuKeeper.Gitlab/GitlabRestClient.cs
+++ b/NuKeeper.Gitlab/GitlabRestClient.cs
@@ -3,10 +3,13 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using Newtonsoft.Json;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.Logging;
+using Model = NuKeeper.Gitlab.Model;
 
 namespace NuKeeper.Gitlab
 {
@@ -21,12 +24,45 @@ namespace NuKeeper.Gitlab
             _logger = logger;
 
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _client.DefaultRequestHeaders.Add("PRIVATE-TOKEN", token);
+            _client.DefaultRequestHeaders.Add("Private-Token", token);
         }
 
+        // https://docs.gitlab.com/ee/api/users.html#for-normal-users-1
+        // GET /user
         public async Task<Model.User> GetCurrentUser()
         {
-            return await GetResource<Model.User>("/user").ConfigureAwait(false);
+            return await GetResource<Model.User>("user").ConfigureAwait(false);
+        }
+
+        // https://docs.gitlab.com/ee/api/projects.html#get-single-project
+        // GET /projects/:id
+        public async Task<Model.Project> GetProject(string projectName, string repositoryName)
+        {
+            var encodedProjectName = HttpUtility.UrlEncode($"{projectName}/{repositoryName}");
+            return await GetResource<Model.Project>($"projects/{encodedProjectName}").ConfigureAwait(false);
+        }
+
+        // https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
+        // GET /projects/:id/repository/branches/:branch
+        public async Task<Model.Branch> CheckExistingBranch(string projectName, string repositoryName,
+            string branchName)
+        {
+            var encodedProjectName = HttpUtility.UrlEncode($"{projectName}/{repositoryName}");
+            var encodedBranchName = HttpUtility.UrlEncode(branchName);
+
+            return await GetResource<Model.Branch>(
+                $"projects/{encodedProjectName}/repository/branches/{encodedBranchName}").ConfigureAwait(false);
+        }
+
+        // POST /projects/:id/merge_requests
+        // https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
+        public Task<Model.MergeRequest> OpenMergeRequest(string projectName, string repositoryName, Model.MergeRequest mergeRequest)
+        {
+            var encodedProjectName = HttpUtility.UrlEncode($"{projectName}/{repositoryName}");
+
+            var content = new StringContent(JsonConvert.SerializeObject(mergeRequest), Encoding.UTF8,
+                "application/json");
+            return PostResource<Model.MergeRequest>($"projects/{encodedProjectName}/merge_requests", content);
         }
 
         private async Task<T> GetResource<T>(string url, [CallerMemberName] string caller = null)
@@ -35,6 +71,15 @@ namespace NuKeeper.Gitlab
             _logger.Detailed($"{caller}: Requesting {fullUrl}");
 
             var response = await _client.GetAsync(fullUrl).ConfigureAwait(false);
+            return await HandleResponse<T>(response, caller).ConfigureAwait(false);
+        }
+
+        private async Task<T> PostResource<T>(string url, HttpContent content, [CallerMemberName] string caller = null)
+        {
+            _logger.Detailed($"{caller}: Requesting {url}");
+
+            var response = await _client.PostAsync(url, content).ConfigureAwait(false);
+
             return await HandleResponse<T>(response, caller).ConfigureAwait(false);
         }
 
@@ -60,6 +105,8 @@ namespace NuKeeper.Gitlab
                         _logger.Error(msg);
                         throw new NuKeeperException(msg);
 
+                    case HttpStatusCode.NotFound:
+                        return default;
                     default:
                         msg = $"{caller}: Error {response.StatusCode}";
                         _logger.Error($"{caller}: Error {response.StatusCode}");

--- a/NuKeeper.Gitlab/GitlabRestClient.cs
+++ b/NuKeeper.Gitlab/GitlabRestClient.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.Logging;
+
+namespace NuKeeper.Gitlab
+{
+    public class GitlabRestClient
+    {
+        private readonly HttpClient _client;
+        private readonly INuKeeperLogger _logger;
+
+        public GitlabRestClient(HttpClient client, string token, INuKeeperLogger logger)
+        {
+            _client = client;
+            _logger = logger;
+
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _client.DefaultRequestHeaders.Add("PRIVATE-TOKEN", token);
+        }
+
+        public async Task<Model.User> GetCurrentUser()
+        {
+            return await GetResource<Model.User>("/user").ConfigureAwait(false);
+        }
+
+        private async Task<T> GetResource<T>(string url, [CallerMemberName] string caller = null)
+        {
+            var fullUrl = new Uri(url, UriKind.Relative);
+            _logger.Detailed($"{caller}: Requesting {fullUrl}");
+
+            var response = await _client.GetAsync(fullUrl).ConfigureAwait(false);
+            return await HandleResponse<T>(response, caller).ConfigureAwait(false);
+        }
+
+        private async Task<T> HandleResponse<T>(HttpResponseMessage response, [CallerMemberName] string caller = null)
+        {
+            string msg;
+
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.Detailed($"Response {response.StatusCode} is not success, body:\n{responseBody}");
+
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.Unauthorized:
+                        msg = $"{caller}: Unauthorised, ensure PAT has appropriate permissions";
+                        _logger.Error(msg);
+                        throw new NuKeeperException(msg);
+
+                    case HttpStatusCode.Forbidden:
+                        msg = $"{caller}: Forbidden, ensure PAT has appropriate permissions";
+                        _logger.Error(msg);
+                        throw new NuKeeperException(msg);
+
+                    default:
+                        msg = $"{caller}: Error {response.StatusCode}";
+                        _logger.Error($"{caller}: Error {response.StatusCode}");
+                        throw new NuKeeperException(msg);
+                }
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(responseBody);
+            }
+            catch (Exception ex)
+            {
+                msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
+                _logger.Error(msg);
+                throw new NuKeeperException($"Failed to parse json to {typeof(T)}", ex);
+            }
+        }
+    }
+}

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -16,7 +16,10 @@ namespace NuKeeper.Gitlab
 
         public bool CanRead(Uri repositoryUri)
         {
-            return repositoryUri?.Host.Contains("gitlab", StringComparison.OrdinalIgnoreCase) == true;
+            if (repositoryUri == null)
+                return false;
+
+            return repositoryUri.Host.Contains("gitlab", StringComparison.OrdinalIgnoreCase);
         }
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
@@ -39,7 +42,7 @@ namespace NuKeeper.Gitlab
                     $"The provided uri was is not in the correct format. Provided null and format should be {UrlPattern}");
             }
 
-            // Assumption - url should look https://gitlab.com/{username}/{projectname}.git";
+            // Assumption - url should look like https://gitlab.com/{username}/{projectname}.git";
             var path = repositoryUri.AbsolutePath;
             var pathParts = path.Split('/')
                 .Where(s => !string.IsNullOrWhiteSpace(s))
@@ -48,13 +51,13 @@ namespace NuKeeper.Gitlab
             if (pathParts.Count != 2)
             {
                 throw new NuKeeperException(
-                    $"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
+                    $"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be {UrlPattern}");
             }
 
             var repoOwner = pathParts[0];
             var repoName = pathParts[1].Replace(".git", string.Empty);
 
-            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4/"};
+            var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 
             return new RepositorySettings
             {

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -1,0 +1,26 @@
+using System;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+
+namespace NuKeeper.Gitlab
+{
+    public class GitlabSettingsReader: ISettingsReader
+    {
+        public Platform Platform => Platform.GitLab;
+        
+        public bool CanRead(Uri repositoryUri)
+        {
+            throw new NotImplementedException();
+        }
+
+        public RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -65,7 +65,9 @@ namespace NuKeeper.Gitlab
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner,
-                TargetBranch = targetBranch
+                RemoteInfo = targetBranch == null
+                    ? null
+                    : new RemoteInfo { BranchName = targetBranch }
             };
         }
     }

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -1,26 +1,69 @@
 using System;
+using System.Linq;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Formats;
 
 namespace NuKeeper.Gitlab
 {
-    public class GitlabSettingsReader: ISettingsReader
+    public class GitlabSettingsReader : ISettingsReader
     {
+        private const string GitLabTokenEnvironmentVariableName = "NuKeeper_gitlab_token";
+        private const string UrlPattern = "https://gitlab.com/{username}/{projectname}.git";
+
         public Platform Platform => Platform.GitLab;
-        
+
         public bool CanRead(Uri repositoryUri)
         {
-            throw new NotImplementedException();
-        }
-
-        public RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch = null)
-        {
-            throw new NotImplementedException();
+            return repositoryUri?.Host.Contains("gitlab", StringComparison.OrdinalIgnoreCase) == true;
         }
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
-            throw new NotImplementedException();
+            UpdateTokenSettings(settings);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
+        }
+
+        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
+        {
+            var envToken = Environment.GetEnvironmentVariable(GitLabTokenEnvironmentVariableName);
+            settings.Token = Concat.FirstValue(envToken, settings.Token);
+        }
+
+        public RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch = null)
+        {
+            if (repositoryUri == null)
+            {
+                throw new NuKeeperException(
+                    $"The provided uri was is not in the correct format. Provided null and format should be {UrlPattern}");
+            }
+
+            // Assumption - url should look https://gitlab.com/{username}/{projectname}.git";
+            var path = repositoryUri.AbsolutePath;
+            var pathParts = path.Split('/')
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+
+            if (pathParts.Count != 2)
+            {
+                throw new NuKeeperException(
+                    $"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
+            }
+
+            var repoOwner = pathParts[0];
+            var repoName = pathParts[1].Replace(".git", string.Empty);
+
+            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4/"};
+
+            return new RepositorySettings
+            {
+                ApiUri = uriBuilder.Uri,
+                RepositoryUri = repositoryUri,
+                RepositoryName = repoName,
+                RepositoryOwner = repoOwner,
+                TargetBranch = targetBranch
+            };
         }
     }
 }

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -54,7 +54,7 @@ namespace NuKeeper.Gitlab
             var repoOwner = pathParts[0];
             var repoName = pathParts[1].Replace(".git", string.Empty);
 
-            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4/"};
+            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4"};
 
             return new RepositorySettings
             {

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -54,7 +54,7 @@ namespace NuKeeper.Gitlab
             var repoOwner = pathParts[0];
             var repoName = pathParts[1].Replace(".git", string.Empty);
 
-            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4"};
+            var uriBuilder = new UriBuilder(repositoryUri) {Path = "/api/v4/"};
 
             return new RepositorySettings
             {

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -9,8 +9,14 @@ namespace NuKeeper.Gitlab
 {
     public class GitlabSettingsReader : ISettingsReader
     {
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
         private const string GitLabTokenEnvironmentVariableName = "NuKeeper_gitlab_token";
         private const string UrlPattern = "https://gitlab.com/{username}/{projectname}.git";
+
+        public GitlabSettingsReader(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
 
         public Platform Platform => Platform.GitLab;
 
@@ -24,13 +30,8 @@ namespace NuKeeper.Gitlab
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
-            UpdateTokenSettings(settings);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
-        }
+            var envToken = _environmentVariablesProvider.GetEnvironmentVariable(GitLabTokenEnvironmentVariableName);
 
-        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
-        {
-            var envToken = Environment.GetEnvironmentVariable(GitLabTokenEnvironmentVariableName);
             settings.Token = Concat.FirstValue(envToken, settings.Token);
         }
 

--- a/NuKeeper.Gitlab/Model/Access.cs
+++ b/NuKeeper.Gitlab/Model/Access.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Access
+    {
+        [JsonProperty("access_level")]
+        public long AccessLevel { get; set; }
+
+        [JsonProperty("notification_level")]
+        public long NotificationLevel { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Branch.cs
+++ b/NuKeeper.Gitlab/Model/Branch.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Branch
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("merged")]
+        public bool Merged { get; set; }
+
+        [JsonProperty("protected")]
+        public bool Protected { get; set; }
+
+        [JsonProperty("default")]
+        public bool Default { get; set; }
+
+        [JsonProperty("developers_can_push")]
+        public bool DevelopersCanPush { get; set; }
+
+        [JsonProperty("developers_can_merge")]
+        public bool DevelopersCanMerge { get; set; }
+
+        [JsonProperty("can_push")]
+        public bool CanPush { get; set; }
+
+        [JsonProperty("commit")]
+        public Commit Commit { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Commit.cs
+++ b/NuKeeper.Gitlab/Model/Commit.cs
@@ -1,0 +1,38 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Commit
+    {
+        [JsonProperty("author_email")]
+        public string AuthorEmail { get; set; }
+
+        [JsonProperty("author_name")]
+        public string AuthorName { get; set; }
+
+        [JsonProperty("authored_date")]
+        public DateTimeOffset AuthoredDate { get; set; }
+
+        [JsonProperty("committed_date")]
+        public DateTimeOffset CommittedDate { get; set; }
+
+        [JsonProperty("committer_email")]
+        public string CommitterEmail { get; set; }
+
+        [JsonProperty("committer_name")]
+        public string CommitterName { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("short_id")]
+        public string ShortId { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/ForkedFromProject.cs
+++ b/NuKeeper.Gitlab/Model/ForkedFromProject.cs
@@ -1,0 +1,56 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class ForkedFromProject
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("name_with_namespace")]
+        public string NameWithNamespace { get; set; }
+
+        [JsonProperty("path")]
+        public string Path { get; set; }
+
+        [JsonProperty("path_with_namespace")]
+        public string PathWithNamespace { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("default_branch")]
+        public string DefaultBranch { get; set; }
+
+        [JsonProperty("ssh_url_to_repo")]
+        public string SshUrlToRepo { get; set; }
+
+        [JsonProperty("http_url_to_repo")]
+        public Uri HttpUrlToRepo { get; set; }
+
+        [JsonProperty("web_url")]
+        public Uri WebUrl { get; set; }
+
+        [JsonProperty("avatar_url")]
+        public Uri AvatarUrl { get; set; }
+
+        [JsonProperty("license_url")]
+        public Uri LicenseUrl { get; set; }
+
+        [JsonProperty("star_count")]
+        public long StarCount { get; set; }
+
+        [JsonProperty("forks_count")]
+        public long ForksCount { get; set; }
+
+        [JsonProperty("last_activity_at")]
+        public DateTimeOffset LastActivityAt { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Links.cs
+++ b/NuKeeper.Gitlab/Model/Links.cs
@@ -1,0 +1,29 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Links
+    {
+        [JsonProperty("self")]
+        public Uri Self { get; set; }
+
+        [JsonProperty("issues")]
+        public Uri Issues { get; set; }
+
+        [JsonProperty("merge_requests")]
+        public Uri MergeRequests { get; set; }
+
+        [JsonProperty("repo_branches")]
+        public Uri RepoBranches { get; set; }
+
+        [JsonProperty("labels")]
+        public Uri Labels { get; set; }
+
+        [JsonProperty("events")]
+        public Uri Events { get; set; }
+
+        [JsonProperty("members")]
+        public Uri Members { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/MergeRequest.cs
+++ b/NuKeeper.Gitlab/Model/MergeRequest.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class MergeRequest
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("target_branch")]
+        public string TargetBranch { get; set; }
+
+        [JsonProperty("source_branch")]
+        public string SourceBranch { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Owner.cs
+++ b/NuKeeper.Gitlab/Model/Owner.cs
@@ -1,0 +1,17 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Owner
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Permissions.cs
+++ b/NuKeeper.Gitlab/Model/Permissions.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Permissions
+    {
+        [JsonProperty("project_access")]
+        public Access ProjectAccess { get; set; }
+
+        [JsonProperty("group_access")]
+        public Access GroupAccess { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Project.cs
+++ b/NuKeeper.Gitlab/Model/Project.cs
@@ -1,0 +1,131 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Project
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("description")]
+        public object Description { get; set; }
+
+        [JsonProperty("default_branch")]
+        public string DefaultBranch { get; set; }
+
+        [JsonProperty("visibility")]
+        public string Visibility { get; set; }
+
+        [JsonProperty("ssh_url_to_repo")]
+        public string SshUrlToRepo { get; set; }
+
+        [JsonProperty("http_url_to_repo")]
+        public Uri HttpUrlToRepo { get; set; }
+
+        [JsonProperty("web_url")]
+        public Uri WebUrl { get; set; }
+
+        [JsonProperty("readme_url")]
+        public Uri ReadmeUrl { get; set; }
+
+        [JsonProperty("owner")]
+        public Owner Owner { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("name_with_namespace")]
+        public string NameWithNamespace { get; set; }
+
+        [JsonProperty("path")]
+        public string Path { get; set; }
+
+        [JsonProperty("path_with_namespace")]
+        public string PathWithNamespace { get; set; }
+
+        [JsonProperty("issues_enabled")]
+        public bool IssuesEnabled { get; set; }
+
+        [JsonProperty("open_issues_count")]
+        public long OpenIssuesCount { get; set; }
+
+        [JsonProperty("merge_requests_enabled")]
+        public bool MergeRequestsEnabled { get; set; }
+
+        [JsonProperty("jobs_enabled")]
+        public bool JobsEnabled { get; set; }
+
+        [JsonProperty("wiki_enabled")]
+        public bool WikiEnabled { get; set; }
+
+        [JsonProperty("snippets_enabled")]
+        public bool SnippetsEnabled { get; set; }
+
+        [JsonProperty("resolve_outdated_diff_discussions")]
+        public bool ResolveOutdatedDiffDiscussions { get; set; }
+
+        [JsonProperty("container_registry_enabled")]
+        public bool ContainerRegistryEnabled { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("last_activity_at")]
+        public DateTimeOffset LastActivityAt { get; set; }
+
+        [JsonProperty("creator_id")]
+        public long CreatorId { get; set; }
+
+        [JsonProperty("import_status")]
+        public string ImportStatus { get; set; }
+
+        [JsonProperty("archived")]
+        public bool Archived { get; set; }
+
+        [JsonProperty("avatar_url")]
+        public Uri AvatarUrl { get; set; }
+
+        [JsonProperty("shared_runners_enabled")]
+        public bool SharedRunnersEnabled { get; set; }
+
+        [JsonProperty("forks_count")]
+        public long ForksCount { get; set; }
+
+        [JsonProperty("star_count")]
+        public long StarCount { get; set; }
+
+        [JsonProperty("runners_token")]
+        public string RunnersToken { get; set; }
+
+        [JsonProperty("public_jobs")]
+        public bool PublicJobs { get; set; }
+
+        [JsonProperty("only_allow_merge_if_pipeline_succeeds")]
+        public bool OnlyAllowMergeIfPipelineSucceeds { get; set; }
+
+        [JsonProperty("only_allow_merge_if_all_discussions_are_resolved")]
+        public bool OnlyAllowMergeIfAllDiscussionsAreResolved { get; set; }
+
+        [JsonProperty("request_access_enabled")]
+        public bool RequestAccessEnabled { get; set; }
+
+        [JsonProperty("merge_method")]
+        public string MergeMethod { get; set; }
+
+        [JsonProperty("statistics")]
+        public Statistics Statistics { get; set; }
+
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        [JsonProperty("import_error")]
+        public object ImportError { get; set; }
+
+        [JsonProperty("permissions", NullValueHandling = NullValueHandling.Ignore)]
+        public Permissions Permissions { get; set; }
+
+        [JsonProperty("forked_from_project", NullValueHandling = NullValueHandling.Ignore)]
+        public ForkedFromProject ForkedFromProject { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/Statistics.cs
+++ b/NuKeeper.Gitlab/Model/Statistics.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class Statistics
+    {
+        [JsonProperty("commit_count")]
+        public long CommitCount { get; set; }
+
+        [JsonProperty("storage_size")]
+        public long StorageSize { get; set; }
+
+        [JsonProperty("repository_size")]
+        public long RepositorySize { get; set; }
+
+        [JsonProperty("lfs_objects_size")]
+        public long LfsObjectsSize { get; set; }
+
+        [JsonProperty("job_artifacts_size")]
+        public long JobArtifactsSize { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/Model/User.cs
+++ b/NuKeeper.Gitlab/Model/User.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.Gitlab.Model
+{
+    public class User
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("username")]
+        public string UserName { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+    }
+}

--- a/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
+++ b/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <NoWarn>1701;1702;CA1051;CA1707;CA1724,CA2227;CA1056;</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
   </ItemGroup>

--- a/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
+++ b/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
+++ b/NuKeeper.Gitlab/NuKeeper.Gitlab.csproj
@@ -7,9 +7,9 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
+
   <PropertyGroup>
-    <NoWarn>1701;1702;CA1051;CA1707;CA1724,CA2227;CA1056;</NoWarn>
+    <NoWarn>1701;1702;CA1051;CA1707;CA1724,CA2227;CA1056;CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NuKeeper.Gitlab/Result.cs
+++ b/NuKeeper.Gitlab/Result.cs
@@ -1,0 +1,27 @@
+using System;
+
+class Result<T>
+{
+    private readonly T _value;
+    public bool IsSuccessful { get; }
+
+    public T Value => IsSuccessful
+        ? _value
+        : throw new InvalidOperationException("Trying to request a value of a failed result.");
+
+    private Result(T value, bool isSuccessful)
+    {
+        _value = value;
+        IsSuccessful = isSuccessful;
+    }
+
+    public static Result<T> Success(T value)
+    {
+        return new Result<T>(value, true);
+    }
+
+    public static Result<T> Failure()
+    {
+        return new Result<T>(default(T), false);
+    }
+}

--- a/NuKeeper.sln
+++ b/NuKeeper.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.Abstractions.Tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.BitBucketLocal", "Nukeeper.BitBucketLocal\NuKeeper.BitBucketLocal.csproj", "{37444E91-3675-4FC7-9EB1-37B091115BAE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Gitlab", "NuKeeper.Gitlab\NuKeeper.Gitlab.csproj", "{10DCD86D-66D4-43A8-AAC7-86777DC7166D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37444E91-3675-4FC7-9EB1-37B091115BAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NuKeeper.sln
+++ b/NuKeeper.sln
@@ -43,6 +43,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuKeeper.BitBucketLocal", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Gitlab", "NuKeeper.Gitlab\NuKeeper.Gitlab.csproj", "{10DCD86D-66D4-43A8-AAC7-86777DC7166D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuKeeper.Gitlab.Tests", "NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj", "{14B60A31-F10D-4599-8E63-27D471D94D4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10DCD86D-66D4-43A8-AAC7-86777DC7166D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14B60A31-F10D-4599-8E63-27D471D94D4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14B60A31-F10D-4599-8E63-27D471D94D4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14B60A31-F10D-4599-8E63-27D471D94D4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14B60A31-F10D-4599-8E63-27D471D94D4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -154,7 +154,7 @@ namespace NuKeeper.Collaboration
                 case Platform.GitLab:
                     CollaborationPlatform = new GitlabPlatform(_nuKeeperLogger);
                     RepositoryDiscovery = new GitlabRepositoryDiscovery(_nuKeeperLogger, CollaborationPlatform);
-                    ForkFinder = new GitlabForkFinder(CollaborationPlatform, _nuKeeperLogger);
+                    ForkFinder = new GitlabForkFinder(CollaborationPlatform, _nuKeeperLogger, forkMode);
                     break;
 
                 default:

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -10,6 +10,7 @@ using NuKeeper.AzureDevOps;
 using NuKeeper.BitBucket;
 using NuKeeper.BitBucketLocal;
 using NuKeeper.GitHub;
+using NuKeeper.Gitlab;
 
 namespace NuKeeper.Collaboration
 {
@@ -148,6 +149,12 @@ namespace NuKeeper.Collaboration
                     CollaborationPlatform = new BitBucketLocalPlatform(_nuKeeperLogger);
                     RepositoryDiscovery = new BitbucketLocalRepositoryDiscovery(_nuKeeperLogger, CollaborationPlatform, Settings);
                     ForkFinder = new BitbucketForkFinder(CollaborationPlatform, _nuKeeperLogger, forkMode);
+                    break;
+
+                case Platform.GitLab:
+                    CollaborationPlatform = new GitlabPlatform(_nuKeeperLogger);
+                    RepositoryDiscovery = new GitlabRepositoryDiscovery(_nuKeeperLogger, CollaborationPlatform);
+                    ForkFinder = new GitlabForkFinder(CollaborationPlatform, _nuKeeperLogger);
                     break;
 
                 default:

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -11,6 +11,7 @@ using NuKeeper.Engine;
 using NuKeeper.Engine.Packages;
 using NuKeeper.Git;
 using NuKeeper.GitHub;
+using NuKeeper.Gitlab;
 using NuKeeper.Local;
 using NuKeeper.Update.Selection;
 using SimpleInjector;
@@ -56,6 +57,7 @@ namespace NuKeeper
                 typeof(VstsSettingsReader).Assembly,
                 typeof(BitbucketSettingsReader).Assembly,
                 typeof(BitBucketLocalSettingsReader).Assembly,
+                typeof(GitlabSettingsReader).Assembly
             });
 
             container.Collection.Register<ISettingsReader>(settingsRegistration);

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Nukeeper.BitBucketLocal\NuKeeper.BitBucketLocal.csproj" />
     <ProjectReference Include="..\NuKeeper.BitBucket\NuKeeper.BitBucket.csproj" />
     <ProjectReference Include="..\NuKeeper.GitHub\NuKeeper.GitHub.csproj" />
+    <ProjectReference Include="..\NuKeeper.Gitlab\NuKeeper.Gitlab.csproj" />
     <ProjectReference Include="..\NuKeeper.Git\NuKeeper.Git.csproj" />
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />
     <ProjectReference Include="..\NuKeeper.Update\NuKeeper.Update.csproj" />

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The intergration for the following platforms is supported.
 
 |     Github         |     AzureDevOps    |      BitBucket     |       GitLab        |
 |:------------------:|:------------------:|:------------------:| :------------------:| 
-| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         :x:         |
+| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  |
 
 ### Commands
 


### PR DESCRIPTION
Started to work on GitLab (issue #327) support for NuKeeper based on https://docs.gitlab.com/ee/api/

What's already there:
- Implementation of settings reader + some barebones tests
- Basic implementation of gitlab rest client and token authentication
- `GetCurrentUser` api call

Looking for some initial feedback.

I see quite some duplication in client implementations for Azure/Bitbucket and co. I thought first to focus on bringing Single repository support for GitLab and continuing with a cleanup a bit later. What do you guys think?

Update:
- Finished the implementation for a single repository

TODO:
- Unit tests