### PR TITLE
Add environment abstraction to make related unit tests side effect free

### DIFF
--- a/NuKeeper.Abstractions/Configuration/EnvironmentVariablesProvider.cs
+++ b/NuKeeper.Abstractions/Configuration/EnvironmentVariablesProvider.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NuKeeper.Abstractions.Configuration
+{
+    public class EnvironmentVariablesProvider : IEnvironmentVariablesProvider
+    {
+        public string GetEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name);
+        }
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/EnvironmentVariablesProvider.cs
+++ b/NuKeeper.Abstractions/Configuration/EnvironmentVariablesProvider.cs
@@ -8,5 +8,10 @@ namespace NuKeeper.Abstractions.Configuration
         {
             return Environment.GetEnvironmentVariable(name);
         }
+
+        public string GetUserName()
+        {
+            return Environment.UserName;
+        }
     }
 }

--- a/NuKeeper.Abstractions/Configuration/IEnvironmentVariablesProvider.cs
+++ b/NuKeeper.Abstractions/Configuration/IEnvironmentVariablesProvider.cs
@@ -1,0 +1,7 @@
+namespace NuKeeper.Abstractions.Configuration
+{
+    public interface IEnvironmentVariablesProvider
+    {
+        string GetEnvironmentVariable(string name);
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/IEnvironmentVariablesProvider.cs
+++ b/NuKeeper.Abstractions/Configuration/IEnvironmentVariablesProvider.cs
@@ -3,5 +3,6 @@ namespace NuKeeper.Abstractions.Configuration
     public interface IEnvironmentVariablesProvider
     {
         string GetEnvironmentVariable(string name);
+        string GetUserName();
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -15,7 +15,8 @@ namespace NuKeeper.AzureDevOps
         private readonly IGitDiscoveryDriver _gitDriver;
         private bool _isLocalGitRepo;
 
-        public AzureDevOpsSettingsReader(IGitDiscoveryDriver gitDriver)
+        public AzureDevOpsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
+            : base(environmentVariablesProvider)
         {
             _gitDriver = gitDriver;
         }

--- a/NuKeeper.AzureDevOps/BaseSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/BaseSettingsReader.cs
@@ -7,20 +7,23 @@ namespace NuKeeper.AzureDevOps
 {
     public abstract class BaseSettingsReader : ISettingsReader
     {
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        public BaseSettingsReader(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
+
         public Platform Platform => Platform.AzureDevOps;
 
         public abstract bool CanRead(Uri repositoryUri);
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
-            UpdateTokenSettings(settings);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
-        }
+            var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_azure_devops_token");
 
-        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
-        {
-            var envToken = Environment.GetEnvironmentVariable("NuKeeper_azure_devops_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
         public abstract RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch);

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -15,7 +15,8 @@ namespace NuKeeper.AzureDevOps
         private readonly IGitDiscoveryDriver _gitDriver;
         private bool _isLocalGitRepo;
 
-        public TfsSettingsReader(IGitDiscoveryDriver gitDriver)
+        public TfsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
+        : base(environmentVariablesProvider)
         {
             _gitDriver = gitDriver;
         }

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -15,7 +15,8 @@ namespace NuKeeper.AzureDevOps
         private readonly IGitDiscoveryDriver _gitDriver;
         private bool _isLocalGitRepo;
 
-        public VstsSettingsReader(IGitDiscoveryDriver gitDriver)
+        public VstsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
+            : base(environmentVariablesProvider)
         {
             _gitDriver = gitDriver;
         }

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -17,7 +17,7 @@ namespace NuKeeper.BitBucket
         }
 
         public Platform Platform => Platform.Bitbucket;
-        
+
         private string Username { get; set; }
 
         public bool CanRead(Uri repositoryUri)

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -9,8 +9,15 @@ namespace NuKeeper.BitBucket
 {
     public class BitbucketSettingsReader : ISettingsReader
     {
-        public Platform Platform => Platform.Bitbucket;
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
 
+        public BitbucketSettingsReader(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
+
+        public Platform Platform => Platform.Bitbucket;
+        
         private string Username { get; set; }
 
         public bool CanRead(Uri repositoryUri)
@@ -21,14 +28,9 @@ namespace NuKeeper.BitBucket
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
             settings.Username = Username;
-            UpdateTokenSettings(settings);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
-        }
-
-        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
-        {
-            var envToken = Environment.GetEnvironmentVariable("NuKeeper_bitbucket_token");
+            var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_bitbucket_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
         public RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch)
@@ -45,10 +47,10 @@ namespace NuKeeper.BitBucket
 
             if (pathParts.Count != 2)
             {
-                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be https://username_@bitbucket.org/projectname/repositoryname.git");
+                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be https://username_@bitbucket.org/projectname/repositoryname.git");
             }
 
-            if (String.IsNullOrWhiteSpace(repositoryUri.UserInfo))
+            if (string.IsNullOrWhiteSpace(repositoryUri.UserInfo))
             {
                 Username = pathParts[0];
             }
@@ -56,6 +58,7 @@ namespace NuKeeper.BitBucket
             {
                 Username = repositoryUri.UserInfo.Split(':').First();
             }
+
             var repoName = pathParts[1];
             //Trim off any .git extension from repo name
             repoName = repoName.EndsWith(".git", StringComparison.InvariantCultureIgnoreCase) ?

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -9,7 +9,13 @@ namespace NuKeeper.GitHub
 {
     public class GitHubSettingsReader : ISettingsReader
     {
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
         private const string UrlPattern = "https://github.com/{owner}/{reponame}.git";
+
+        public GitHubSettingsReader(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
 
         public Platform Platform => Platform.GitHub;
 
@@ -20,14 +26,9 @@ namespace NuKeeper.GitHub
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
-            UpdateTokenSettings(settings);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
-        }
-
-        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
-        {
-            var envToken = Environment.GetEnvironmentVariable("NuKeeper_github_token");
+            var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_github_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
         }
 
         public RepositorySettings RepositorySettings(Uri repositoryUri, string targetBranch = null)

--- a/NuKeeper.Tests/Commands/GlobalCommandTests.cs
+++ b/NuKeeper.Tests/Commands/GlobalCommandTests.cs
@@ -19,8 +19,10 @@ namespace NuKeeper.Tests.Commands
     {
         private static CollaborationFactory GetCollaborationFactory()
         {
+            var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+
             return new CollaborationFactory(
-                new ISettingsReader[] { new GitHubSettingsReader() },
+                new ISettingsReader[] { new GitHubSettingsReader(environmentVariablesProvider) },
                 Substitute.For<INuKeeperLogger>()
             );
         }

--- a/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
+++ b/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
@@ -19,8 +19,10 @@ namespace NuKeeper.Tests.Commands
     {
         private static CollaborationFactory GetCollaborationFactory()
         {
+            var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+
             return new CollaborationFactory(
-                new ISettingsReader[] { new GitHubSettingsReader() },
+                new ISettingsReader[] { new GitHubSettingsReader(environmentVariablesProvider) },
                 Substitute.For<INuKeeperLogger>()
             );
         }

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -23,6 +23,14 @@ namespace NuKeeper.Tests.Commands
     [TestFixture]
     public class RepositoryCommandTests
     {
+        private IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+        }
+
         [Test]
         public async Task ShouldCallEngineAndNotSucceedWithoutParams()
         {
@@ -31,9 +39,9 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
-            var collaborationFactory = GetCollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(_environmentVariablesProvider, settingsReaders);
 
             var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
 
@@ -53,9 +61,9 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
-            var collaborationFactory = GetCollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(_environmentVariablesProvider, settingsReaders);
 
             var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders)
             {
@@ -79,7 +87,7 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
@@ -114,7 +122,7 @@ namespace NuKeeper.Tests.Commands
                     ForkMode = ForkMode.PreferFork
                 });
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
@@ -149,7 +157,7 @@ namespace NuKeeper.Tests.Commands
                     Platform = Platform.BitbucketLocal
                 });
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
@@ -333,11 +341,12 @@ namespace NuKeeper.Tests.Commands
         {
             var logger = Substitute.For<IConfigureLogger>();
             var fileSettings = Substitute.For<IFileSettingsCache>();
+            var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
             fileSettings.GetSettings().Returns(settingsIn);
 
-            var settingReader = new GitHubSettingsReader();
+            var settingReader = new GitHubSettingsReader(environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { settingReader };
-            var collaborationFactory = GetCollaborationFactory(settingsReaders);
+            var collaborationFactory = GetCollaborationFactory(environmentVariablesProvider, settingsReaders);
 
             SettingsContainer settingsOut = null;
             var engine = Substitute.For<ICollaborationEngine>();
@@ -394,10 +403,11 @@ namespace NuKeeper.Tests.Commands
                 Arg.Is<RepositoryData>(r => r.DefaultBranch == "custombranch"), Arg.Any<SettingsContainer>());
         }
 
-        private static ICollaborationFactory GetCollaborationFactory(IEnumerable<ISettingsReader> settingReaders = null)
+        private static ICollaborationFactory GetCollaborationFactory(IEnvironmentVariablesProvider environmentVariablesProvider,
+            IEnumerable<ISettingsReader> settingReaders = null)
         {
             return new CollaborationFactory(
-                settingReaders ?? new ISettingsReader[] { new GitHubSettingsReader() },
+                settingReaders ?? new ISettingsReader[] { new GitHubSettingsReader(environmentVariablesProvider) },
                 Substitute.For<INuKeeperLogger>()
             );
         }

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -45,6 +45,8 @@ namespace NuKeeper
             container.Register<IUpdateSelection, UpdateSelection>();
             container.Register<IFileSettingsCache, FileSettingsCache>();
 
+            container.RegisterSingleton<IEnvironmentVariablesProvider, EnvironmentVariablesProvider>();
+
             container.RegisterSingleton<IGitDiscoveryDriver, LibGit2SharpDiscoveryDriver>();
 
             container.RegisterSingleton<ICollaborationFactory, CollaborationFactory>();

--- a/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using NSubstitute;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -10,20 +11,28 @@ namespace Nukeeper.AzureDevOps.Tests
     [TestFixture]
     public class TfsSettingsReaderTests
     {
-        private static ISettingsReader AzureSettingsReader => new TfsSettingsReader(new MockedGitDiscoveryDriver());
+        private ISettingsReader _azureSettingsReader;
+        private IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+            _azureSettingsReader = new TfsSettingsReader(new MockedGitDiscoveryDriver(), _environmentVariablesProvider);
+        }
 
         [TestCase("https://tfs/")]
         [TestCase("https://internalserver/tfs/")]
         public void ReturnsTrueIfCanRead(string value)
         {
-            var canRead = AzureSettingsReader.CanRead(new Uri(value));
+            var canRead = _azureSettingsReader.CanRead(new Uri(value));
             Assert.IsTrue(canRead);
         }
 
         [Test]
         public void ReturnsCorrectPlatform()
         {
-            var platform = AzureSettingsReader.Platform;
+            var platform = _azureSettingsReader.Platform;
             Assert.IsNotNull(platform);
             Assert.AreEqual(platform, Platform.AzureDevOps);
         }
@@ -36,7 +45,7 @@ namespace Nukeeper.AzureDevOps.Tests
                 Token = "accessToken",
                 BaseApiUrl = new Uri("https://internalserver/tfs/")
             };
-            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
+            _azureSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.BaseApiUrl, "https://internalserver/tfs/");
@@ -47,13 +56,14 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void AuthSettings_GetsCorrectSettingsFromEnvironment()
         {
+            _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_azure_devops_token").Returns("envToken");
+
             var settings = new CollaborationPlatformSettings
             {
                 Token = "accessToken",
             };
-            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", "envToken");
-            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
-            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", null);
+
+            _azureSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
             Assert.AreEqual(settings.Token, "envToken");
         }
@@ -63,7 +73,7 @@ namespace Nukeeper.AzureDevOps.Tests
         public void InvalidUrlReturnsNull(string value)
         {
             var uriToTest = value == null ? null : new Uri(value);
-            var canRead = AzureSettingsReader.CanRead(uriToTest);
+            var canRead = _azureSettingsReader.CanRead(uriToTest);
 
             Assert.IsFalse(canRead);
         }
@@ -71,7 +81,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void RepositorySettings_GetsCorrectSettings()
         {
-            var settings = AzureSettingsReader.RepositorySettings(new Uri("https://internalserver/tfs/project/_git/reponame"));
+            var settings = _azureSettingsReader.RepositorySettings(new Uri("https://internalserver/tfs/project/_git/reponame"));
 
             Assert.IsNotNull(settings);
             Assert.AreEqual("https://internalserver/tfs", settings.ApiUri.ToString());
@@ -83,7 +93,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void RepositorySettings_ReturnsNull()
         {
-            var settings = AzureSettingsReader.RepositorySettings(null);
+            var settings = _azureSettingsReader.RepositorySettings(null);
             Assert.IsNull(settings);
         }
 
@@ -91,14 +101,14 @@ namespace Nukeeper.AzureDevOps.Tests
         public void RepositorySettings_InvalidFormat()
         {
             Assert.Throws<NuKeeperException>(() =>
-                AzureSettingsReader.RepositorySettings(
+                _azureSettingsReader.RepositorySettings(
                     new Uri("https://org.visualstudio.com/project/isnot_git/reponame/")));
         }
 
         [Test]
         public void RepositorySettings_HandlesSpaces()
         {
-            var settings = AzureSettingsReader.RepositorySettings(new Uri("https://internalserver/tfs/project%20name/_git/repo%20name"));
+            var settings = _azureSettingsReader.RepositorySettings(new Uri("https://internalserver/tfs/project%20name/_git/repo%20name"));
 
             Assert.IsNotNull(settings);
             Assert.AreEqual("https://internalserver/tfs", settings.ApiUri.ToString());

--- a/Nukeeper.AzureDevOps.Tests/VstsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/VstsSettingsReaderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using NSubstitute;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -10,19 +11,27 @@ namespace Nukeeper.AzureDevOps.Tests
     [TestFixture]
     public class VstsSettingsReaderTests
     {
-        private static ISettingsReader AzureSettingsReader => new VstsSettingsReader(new MockedGitDiscoveryDriver());
+        private ISettingsReader _azureSettingsReader;
+        private IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+            _azureSettingsReader = new VstsSettingsReader(new MockedGitDiscoveryDriver(), _environmentVariablesProvider);
+        }
 
         [Test]
         public void ReturnsTrueIfCanRead()
         {
-            var canRead = AzureSettingsReader.CanRead(new Uri("https://org.visualstudio.com"));
+            var canRead = _azureSettingsReader.CanRead(new Uri("https://org.visualstudio.com"));
             Assert.IsTrue(canRead);
         }
 
         [Test]
         public void ReturnsCorrectPlatform()
         {
-            var platform = AzureSettingsReader.Platform;
+            var platform = _azureSettingsReader.Platform;
             Assert.IsNotNull(platform);
             Assert.AreEqual(platform, Platform.AzureDevOps);
         }
@@ -35,7 +44,7 @@ namespace Nukeeper.AzureDevOps.Tests
                 Token = "accessToken",
                 BaseApiUrl = new Uri("https://dev.azure.com/")
             };
-            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
+            _azureSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.BaseApiUrl, "https://dev.azure.com/");
@@ -46,13 +55,14 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void AuthSettings_GetsCorrectSettingsFromEnvironment()
         {
+            _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_azure_devops_token").Returns("envToken");
+
             var settings = new CollaborationPlatformSettings
             {
                 Token = "accessToken",
             };
-            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", "envToken");
-            AzureSettingsReader.UpdateCollaborationPlatformSettings(settings);
-            Environment.SetEnvironmentVariable("NuKeeper_azure_devops_token", null);
+
+            _azureSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
             Assert.AreEqual(settings.Token, "envToken");
         }
@@ -62,7 +72,7 @@ namespace Nukeeper.AzureDevOps.Tests
         public void InvalidUrlReturnsNull(string value)
         {
             var uriToTest = value == null ? null : new Uri(value);
-            var canRead = AzureSettingsReader.CanRead(uriToTest);
+            var canRead = _azureSettingsReader.CanRead(uriToTest);
 
             Assert.IsFalse(canRead);
         }
@@ -70,7 +80,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void RepositorySettings_GetsCorrectSettings()
         {
-            var settings = AzureSettingsReader.RepositorySettings(new Uri("https://org.visualstudio.com/project/_git/reponame"));
+            var settings = _azureSettingsReader.RepositorySettings(new Uri("https://org.visualstudio.com/project/_git/reponame"));
 
             Assert.IsNotNull(settings);
             Assert.AreEqual("https://org.visualstudio.com/", settings.ApiUri.ToString());
@@ -82,7 +92,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public void RepositorySettings_ReturnsNull()
         {
-            var settings = AzureSettingsReader.RepositorySettings(null);
+            var settings = _azureSettingsReader.RepositorySettings(null);
             Assert.IsNull(settings);
         }
 
@@ -90,7 +100,7 @@ namespace Nukeeper.AzureDevOps.Tests
         public void RepositorySettings_InvalidFormat()
         {
             Assert.Throws<NuKeeperException>(() =>
-                AzureSettingsReader.RepositorySettings(
+                _azureSettingsReader.RepositorySettings(
                     new Uri("https://org.visualstudio.com/project/_git/reponame/thisShouldNotBeHere/")));
         }
     }

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -18,7 +18,7 @@ namespace NuKeeper.BitBucketLocal
         }
 
         public Platform Platform { get; } = Platform.BitbucketLocal;
-        
+
         private string Username { get; set; }
 
         public bool CanRead(Uri repositoryUri)

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.BitBucketLocal
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();
 
-            Username = Concat.FirstValue(repositoryUri.UserInfo, Environment.UserName);
+            Username = Concat.FirstValue(repositoryUri.UserInfo, _environmentVariablesProvider.GetUserName());
 
             if (pathParts.Count < 2)
             {
@@ -61,7 +61,7 @@ namespace NuKeeper.BitBucketLocal
 
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
-            settings.Username = Concat.FirstValue(Username, Environment.UserName);
+            settings.Username = Concat.FirstValue(Username, _environmentVariablesProvider.GetUserName());
 
             var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_bitbucketlocal_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -10,8 +10,15 @@ namespace NuKeeper.BitBucketLocal
 {
     public class BitBucketLocalSettingsReader : ISettingsReader
     {
-        public Platform Platform { get; } = Platform.BitbucketLocal;
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
 
+        public BitBucketLocalSettingsReader(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
+
+        public Platform Platform { get; } = Platform.BitbucketLocal;
+        
         private string Username { get; set; }
 
         public bool CanRead(Uri repositoryUri)
@@ -55,14 +62,10 @@ namespace NuKeeper.BitBucketLocal
         public void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings)
         {
             settings.Username = Concat.FirstValue(Username, Environment.UserName);
-            UpdateTokenSettings(settings);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
-        }
 
-        private static void UpdateTokenSettings(CollaborationPlatformSettings settings)
-        {
-            var envToken = Environment.GetEnvironmentVariable("NuKeeper_bitbucketlocal_token");
+            var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_bitbucketlocal_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);
+            settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
     }
 }


### PR DESCRIPTION
As discussed on Gitter this PR introduces `IEnvironmentVariablesProvider`. An abstraction layer on top of `Environment`,  so when checking for tokens coming from the environment we won't alter it between the test runs.