### PR TITLE
Update the analysers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,8 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Abstractions.Configuration
             {
                 _logger.Error($"Cannot read settings file at {fullPath}", ex);
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
                 _logger.Error($"Cannot read json from settings file at {fullPath}", ex);
             }

--- a/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
@@ -37,11 +37,16 @@ namespace NuKeeper.Abstractions.Configuration
                 _logger.Detailed($"Read settings file at {fullPath}");
                 return result;
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 _logger.Error($"Cannot read settings file at {fullPath}", ex);
-                return FileSettings.Empty();
             }
+            catch (JsonReaderException ex)
+            {
+                _logger.Error($"Cannot read json from settings file at {fullPath}", ex);
+            }
+
+            return FileSettings.Empty();
         }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.AzureDevOps
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (Exception ex)
+            catch (JsonReaderException ex)
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.AzureDevOps
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -119,7 +119,7 @@ namespace NuKeeper.AzureDevOps
             return CreateRepositorySettings(org, repositoryUri, project, repoName, remoteInfo);
         }
 
-        private RepositorySettings CreateRepositorySettings(string org, Uri repositoryUri, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
+        private static RepositorySettings CreateRepositorySettings(string org, Uri repositoryUri, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
         {
             ApiUri = new Uri($"https://dev.azure.com/{org}/"),
             RepositoryUri = repositoryUri,

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -138,7 +138,7 @@ namespace NuKeeper.AzureDevOps
             return RepositorySettings(org, project, repoName, remoteInfo);
         }
 
-        private RepositorySettings RepositorySettings(string org, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
+        private static RepositorySettings RepositorySettings(string org, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
         {
             ApiUri = new Uri($"https://{org}.visualstudio.com/"),
             RepositoryUri = new Uri($"https://{org}.visualstudio.com/{project}/_git/{repoName}/"),

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -112,7 +112,7 @@ namespace NuKeeper.GitHub
                 _logger.Normal($"User fork created at {result.GitUrl} for {result.Owner.Login}");
                 return new GitHubRepository(result);
             }
-            catch (Exception ex)
+            catch (ApiException ex)
             {
                 _logger.Error("User fork not created", ex);
                 return null;
@@ -184,7 +184,7 @@ namespace NuKeeper.GitHub
                         labelsToApply);
 
                 }
-                catch (Exception ex)
+                catch (ApiException ex)
                 {
                     _logger.Error("Failed to add labels. Continuing", ex);
                 }

--- a/NuKeeper.Gitlab/GitlabRestClient.cs
+++ b/NuKeeper.Gitlab/GitlabRestClient.cs
@@ -126,7 +126,7 @@ namespace NuKeeper.Gitlab
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);

--- a/NuKeeper.Gitlab/GitlabRestClient.cs
+++ b/NuKeeper.Gitlab/GitlabRestClient.cs
@@ -100,6 +100,7 @@ namespace NuKeeper.Gitlab
                 if (customErrorHandling != null)
                 {
                     var result = customErrorHandling(response.StatusCode);
+
                     if (result.IsSuccessful)
                         return result.Value;
                 }
@@ -125,7 +126,7 @@ namespace NuKeeper.Gitlab
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (Exception ex)
+            catch (JsonReaderException ex)
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);

--- a/NuKeeper.Gitlab/Result.cs
+++ b/NuKeeper.Gitlab/Result.cs
@@ -22,6 +22,42 @@ class Result<T>
 
     public static Result<T> Failure()
     {
-        return new Result<T>(default(T), false);
+        return new Result<T>(default, false);
+    }
+
+    public void Match(Action<T> success, Action failure)
+    {
+        if (IsSuccessful)
+        {
+            success(Value);
+        }
+        else
+        {
+            failure();
+        }
+    }
+
+    public Result<U> Select<U>(Func<T, Result<U>> transform)
+    {
+        if (IsSuccessful)
+        {
+            return transform(Value);
+        }
+        else
+        {
+            return Result<U>.Failure();
+        }
+    }
+
+    public Result<U> Select<U>(Func<T, U> transform)
+    {
+        if (IsSuccessful)
+        {
+            return Result<U>.Success(transform(Value));
+        }
+        else
+        {
+            return Result<U>.Failure();
+        }
     }
 }

--- a/NuKeeper.Gitlab/Result.cs
+++ b/NuKeeper.Gitlab/Result.cs
@@ -24,40 +24,4 @@ class Result<T>
     {
         return new Result<T>(default, false);
     }
-
-    public void Match(Action<T> success, Action failure)
-    {
-        if (IsSuccessful)
-        {
-            success(Value);
-        }
-        else
-        {
-            failure();
-        }
-    }
-
-    public Result<U> Select<U>(Func<T, Result<U>> transform)
-    {
-        if (IsSuccessful)
-        {
-            return transform(Value);
-        }
-        else
-        {
-            return Result<U>.Failure();
-        }
-    }
-
-    public Result<U> Select<U>(Func<T, U> transform)
-    {
-        if (IsSuccessful)
-        {
-            return Result<U>.Success(transform(Value));
-        }
-        else
-        {
-            return Result<U>.Failure();
-        }
-    }
 }

--- a/NuKeeper.Inspection/Files/Folder.cs
+++ b/NuKeeper.Inspection/Files/Folder.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Inspection.Files
                     .ToList();
 
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 _logger.Minimal(ex.Message);
                 return new List<FileInfo>();
@@ -45,7 +45,7 @@ namespace NuKeeper.Inspection.Files
                 DeleteDirectoryInternal(_root.FullName);
                 _logger.Detailed($"Deleted folder {_root.FullName}");
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 _logger.Detailed($"Folder delete failed: {ex.GetType().Name} {ex.Message}");
             }

--- a/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageVersionsLookup.cs
@@ -48,7 +48,9 @@ namespace NuKeeper.Inspection.NuGetApi
                 var metadatas = await FindPackage(metadataResource, packageName, includePrerelease);
                 return metadatas.Select(m => BuildPackageData(source, m));
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _nuKeeperLogger.Normal($"Getting {packageName} from {source} returned exception: {ex.Message}");
                 return Enumerable.Empty<PackageSearchMedatadata>();

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return Read(fileContents, packagePath);
                 }
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 throw new NuKeeperException($"Unable to parse file {packagePath.FullName}", ex);
             }
@@ -61,22 +61,14 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         private PackageInProject XmlToPackage(XElement el, PackagePath path)
         {
-            try
+            var id = el.Attribute("Include")?.Value;
+            if (id == null)
             {
-                var id = el.Attribute("Include")?.Value;
-                if (id == null)
-                {
-                    id = el.Attribute("Update")?.Value;
-                }
-                var version = el.Attribute("Version")?.Value;
+                id = el.Attribute("Update")?.Value;
+            }
+            var version = el.Attribute("Version")?.Value;
 
-                return _packageInProjectReader.Read(id, version, path, null);
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
-                return null;
-            }
+            return _packageInProjectReader.Read(id, version, path, null);
         }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/NuspecFileReader.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return Read(fileContents, packagePath);
                 }
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 throw new NuKeeperException($"Unable to parse file {packagePath.FullName}", ex);
             }
@@ -61,19 +61,10 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         private PackageInProject XmlToPackage(XElement el, PackagePath path)
         {
-            try
-            {
-                var id = el.Attribute("id")?.Value;
-                var version = el.Attribute("version")?.Value;
+            var id = el.Attribute("id")?.Value;
+            var version = el.Attribute("version")?.Value;
 
-                return _packageInProjectReader.Read(id, version, path, null);
-
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
-                return null;
-            }
+            return _packageInProjectReader.Read(id, version, path, null);
         }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackagesFileReader.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return Read(fileContents, packagePath);
                 }
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 throw new ApplicationException($"Unable to parse file {packagePath.FullName}", ex);
             }
@@ -61,18 +61,10 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         private PackageInProject XmlToPackage(XElement el, PackagePath path)
         {
-            try
-            {
-                var id = el.Attribute("id")?.Value;
-                var version = el.Attribute("version")?.Value;
+            var id = el.Attribute("id")?.Value;
+            var version = el.Attribute("version")?.Value;
 
-                return _packageInProjectReader.Read(id, version, path, null);
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
-                return null;
-            }
+            return _packageInProjectReader.Read(id, version, path, null);
         }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -29,7 +29,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
                     return Read(fileContents, baseDirectory, relativePath);
                 }
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 throw new ApplicationException($"Unable to parse file {filePath}", ex);
             }
@@ -92,18 +92,10 @@ namespace NuKeeper.Inspection.RepositoryInspection
         private PackageInProject XmlToPackage(XNamespace ns, XElement el,
             PackagePath path, IEnumerable<string> projectReferences)
         {
-            try
-            {
-                var id = el.Attribute("Include")?.Value;
-                var version = el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
+            var id = el.Attribute("Include")?.Value;
+            var version = el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
 
-                return _packageInProjectReader.Read(id, version, path, projectReferences);
-            }
-            catch (Exception ex)
-            {
-                _logger.Error($"Could not read package from {el} in file {path.FullName}", ex);
-                return null;
-            }
+            return _packageInProjectReader.Read(id, version, path, projectReferences);
         }
     }
 }

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -84,7 +84,9 @@ namespace NuKeeper.Commands
                     return collaborationResult;
                 }
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 return ValidationResult.Failure(ex.Message);
             }

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -203,7 +203,7 @@ namespace NuKeeper.Commands
             {
                 settings.PackageFilters.Includes = new Regex(value);
             }
-            catch (Exception ex)
+            catch (ArgumentException ex)
             {
                 {
                     return ValidationResult.Failure(
@@ -230,7 +230,7 @@ namespace NuKeeper.Commands
             {
                 settings.PackageFilters.Excludes = new Regex(value);
             }
-            catch (Exception ex)
+            catch (ArgumentException ex)
             {
                 {
                     return ValidationResult.Failure(

--- a/NuKeeper/Commands/MultipleRepositoryCommand.cs
+++ b/NuKeeper/Commands/MultipleRepositoryCommand.cs
@@ -70,7 +70,7 @@ namespace NuKeeper.Commands
             {
                 settings.SourceControlServerSettings.IncludeRepos = new Regex(value);
             }
-            catch (Exception ex)
+            catch (ArgumentException ex)
             {
                 return ValidationResult.Failure($"Unable to parse regex '{value}' for IncludeRepos: {ex.Message}");
             }
@@ -93,7 +93,7 @@ namespace NuKeeper.Commands
             {
                 settings.SourceControlServerSettings.ExcludeRepos = new Regex(value);
             }
-            catch (Exception ex)
+            catch (ArgumentException ex)
             {
                 return ValidationResult.Failure($"Unable to parse regex '{value}' for ExcludeRepos: {ex.Message}");
             }

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -29,6 +29,11 @@ namespace NuKeeper.Commands
 
         protected override ValidationResult PopulateSettings(SettingsContainer settings)
         {
+            if (string.IsNullOrWhiteSpace(RepositoryUri))
+            {
+                return ValidationResult.Failure($"Missing repository URI");
+            }
+
             Uri repoUri;
 
             try

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -35,7 +35,7 @@ namespace NuKeeper.Commands
             {
                 repoUri = RepositoryUri.ToUri();
             }
-            catch
+            catch (UriFormatException)
             {
                 return ValidationResult.Failure($"Bad repository URI: '{RepositoryUri}'");
             }

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -90,7 +90,9 @@ namespace NuKeeper.Engine
 
                 return updatesDone;
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.Error($"Failed on repo {repository.RepositoryName}", ex);
                 return 1;

--- a/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingBranchFilter.cs
@@ -27,7 +27,9 @@ namespace NuKeeper.Engine.Packages
                 var branchExists = await _collaborationFactory.CollaborationPlatform.RepositoryBranchExists(pushFork.Owner, pushFork.Name, branchName);
                 return !branchExists;
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.Error($"Failed on existing branch check at {pushFork.Owner}/{pushFork.Name}", ex);
                 return false;

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -50,7 +50,9 @@ namespace NuKeeper.Engine.Packages
                     totalCount += updatesMade;
                 }
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.Error("Updates failed", ex);
             }

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -45,7 +45,9 @@ namespace NuKeeper.Engine
 
                 return true;
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.Error("Repository search failed.", ex);
             }

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.BitBucketLocal
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (JsonReaderException)
+            catch (JsonException)
             {
                 msg = $"{caller}: Json exception";
                 _logger.Error(msg);

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -78,7 +78,7 @@ namespace NuKeeper.BitBucketLocal
             {
                 return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch (Exception)
+            catch (JsonReaderException)
             {
                 msg = $"{caller}: Json exception";
                 _logger.Error(msg);


### PR DESCRIPTION
Update the analysers.
Remove `Text.Analyzers` it seems to be deprecated.

The new version of analysers is a lot stricter on exception types, with  [CA1031: do not catch general exception types](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1031-do-not-catch-general-exception-types?view=vs-2019).  So general `catch` blocks have to be fixed, either
* Catch a more specific exception type - this is used where an exception type or base type can be determined. I have used
  * `IOException`: base class for file and directory exceptions.
  * `ApiException`: base class for octokit github exceptions.
  * `JsonException`: base class for Newtonsoft Json exceptions.
* Removed the block entirely - this is used where null checks in the code are the right way to do it
* Use a `#pragma` to ignore the warning for a line - this is used as a last resort, or where there is a lot of code / multiple possible providers inside the block and so an exception type is not simple to determine,.