### PR TITLE
Add code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://dev.azure.com/nukeeper/NuKeeper/_apis/build/status/PR%20build?branchName=master&label=build)](https://dev.azure.com/nukeeper/NuKeeper/_build/latest?definitionId=3?branchName=master)
 [![Gitter](https://img.shields.io/gitter/room/NuKeeperDotNet/Lobby.js.svg?maxAge=2592000)](https://gitter.im/NuKeeperDotNet/Lobby)
-[![NuGet](https://img.shields.io/nuget/v/NuKeeper.svg?maxAge=3600)](https://www.nuget.org/packages/NuKeeper/)   
+[![NuGet](https://img.shields.io/nuget/v/NuKeeper.svg?maxAge=3600)](https://www.nuget.org/packages/NuKeeper/)
+[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/nukeeper/NuKeeper/4.svg)](https://dev.azure.com/nukeeper/NuKeeper/_build?definitionId=4)   
 <p align="center">
   <a href="https://github.com/NuKeeperDotNet/NuKeeper/wiki">NuKeeper Wiki Home</a> •
   <a href="https://github.com/NuKeeperDotNet/NuKeeper/wiki/Getting-Started#getting-nukeeper">Installation</a> •


### PR DESCRIPTION
The title says it's all.

Using shields constructor from https://shields.io/category/coverage for Azure Devops. Getting statuses for this build definition https://dev.azure.com/nukeeper/NuKeeper/_build?definitionId=4.