### PR TITLE
--targetBranch support for GitHub

### DIFF
--- a/NuKeeper.Abstractions/Git/IGitDriver.cs
+++ b/NuKeeper.Abstractions/Git/IGitDriver.cs
@@ -9,6 +9,8 @@ namespace NuKeeper.Abstractions.Git
 
         void Clone(Uri pullEndpoint);
 
+        void Clone(Uri pullEndpoint, string branchName);
+
         void AddRemote(string name, Uri endpoint);
 
         void Checkout(string branchName);

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -42,13 +42,19 @@ namespace NuKeeper.Git
 
         public void Clone(Uri pullEndpoint)
         {
-            _logger.Normal($"Git clone {pullEndpoint} to {WorkingFolder.FullPath}");
+            Clone(pullEndpoint, null);
+        }
+
+        public void Clone(Uri pullEndpoint, string branchName)
+        {
+            _logger.Normal($"Git clone {pullEndpoint}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");
 
             Repository.Clone(pullEndpoint.AbsoluteUri, WorkingFolder.FullPath,
                 new CloneOptions
                 {
                     CredentialsProvider = UsernamePasswordCredentials,
-                    OnTransferProgress = OnTransferProgress
+                    OnTransferProgress = OnTransferProgress,
+                    BranchName = branchName
                 });
 
             _logger.Detailed("Git clone complete");

--- a/NuKeeper.GitHub.Tests/GitHubSettingsReaderTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubSettingsReaderTests.cs
@@ -39,9 +39,9 @@ namespace NuKeeper.GitHub.Tests
             _gitHubSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
             Assert.IsNotNull(settings);
-            Assert.AreEqual(settings.BaseApiUrl, "https://github.custom.com/");
-            Assert.AreEqual(settings.Token, "accessToken");
-            Assert.AreEqual(settings.ForkMode, ForkMode.PreferFork);
+            Assert.AreEqual(new Uri("https://github.custom.com/"), settings.BaseApiUrl);
+            Assert.AreEqual("accessToken", settings.Token);
+            Assert.AreEqual(ForkMode.PreferFork, settings.ForkMode);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NuKeeper.GitHub.Tests
 
             _gitHubSettingsReader.UpdateCollaborationPlatformSettings(settings);
 
-            Assert.AreEqual(settings.Token, "envToken");
+            Assert.AreEqual("envToken", settings.Token);
         }
 
         [TestCase(null)]
@@ -75,9 +75,23 @@ namespace NuKeeper.GitHub.Tests
             var settings = _gitHubSettingsReader.RepositorySettings(new Uri("https://github.com/owner/reponame.git"));
 
             Assert.IsNotNull(settings);
-            Assert.AreEqual(settings.RepositoryUri, "https://github.com/owner/reponame.git");
-            Assert.AreEqual(settings.RepositoryName, "reponame");
-            Assert.AreEqual(settings.RepositoryOwner, "owner");
+            Assert.AreEqual(new Uri("https://github.com/owner/reponame.git"), settings.RepositoryUri);
+            Assert.AreEqual("reponame", settings.RepositoryName);
+            Assert.AreEqual("owner", settings.RepositoryOwner);
+        }
+
+        [Test]
+        public void RepositorySettings_GetsCorrectSettingsWithTargetBranch()
+        {
+            var settings =
+                _gitHubSettingsReader.RepositorySettings(new Uri("https://github.com/owner/reponame.git"), "Feature1");
+
+            Assert.IsNotNull(settings);
+            Assert.AreEqual(new Uri("https://github.com/owner/reponame.git"), settings.RepositoryUri);
+            Assert.AreEqual("reponame", settings.RepositoryName);
+            Assert.AreEqual("owner", settings.RepositoryOwner);
+            Assert.NotNull(settings.RemoteInfo);
+            Assert.AreEqual("origin/Feature1", settings.RemoteInfo.BranchName);
         }
 
         [TestCase(null)]

--- a/NuKeeper.GitHub.Tests/GitHubSettingsReaderTests.cs
+++ b/NuKeeper.GitHub.Tests/GitHubSettingsReaderTests.cs
@@ -91,7 +91,7 @@ namespace NuKeeper.GitHub.Tests
             Assert.AreEqual("reponame", settings.RepositoryName);
             Assert.AreEqual("owner", settings.RepositoryOwner);
             Assert.NotNull(settings.RemoteInfo);
-            Assert.AreEqual("origin/Feature1", settings.RemoteInfo.BranchName);
+            Assert.AreEqual("Feature1", settings.RemoteInfo.BranchName);
         }
 
         [TestCase(null)]

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -59,7 +59,7 @@ namespace NuKeeper.GitHub
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner,
-                RemoteInfo = targetBranch != null ? new RemoteInfo { BranchName = $"origin/{targetBranch}" } : null
+                RemoteInfo = targetBranch != null ? new RemoteInfo { BranchName = targetBranch } : null
             };
         }
     }

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -59,7 +59,7 @@ namespace NuKeeper.GitHub
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner,
-                RemoteInfo = ( targetBranch != null ? new RemoteInfo() { BranchName = $"origin/{targetBranch}" } : null )
+                RemoteInfo = targetBranch != null ? new RemoteInfo { BranchName = $"origin/{targetBranch}" } : null
             };
         }
     }

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -59,6 +59,7 @@ namespace NuKeeper.GitHub
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
                 RepositoryOwner = repoOwner,
+                RemoteInfo = ( targetBranch != null ? new RemoteInfo() { BranchName = $"origin/{targetBranch}" } : null )
             };
         }
     }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -106,15 +106,8 @@ namespace NuKeeper.Engine
 
         private static void GitInit(IGitDriver git, RepositoryData repository)
         {
-            if (repository.DefaultBranch == null)
-            {
-                git.Clone(repository.Pull.Uri);
-                repository.DefaultBranch = git.GetCurrentHead();
-            }
-            else
-            {
-                git.Clone(repository.Pull.Uri, repository.DefaultBranch);
-            }
+            git.Clone(repository.Pull.Uri, repository.DefaultBranch);
+            repository.DefaultBranch = repository.DefaultBranch ?? git.GetCurrentHead();
             git.AddRemote(repository.Remote, repository.Push.Uri);
         }
     }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -106,8 +106,15 @@ namespace NuKeeper.Engine
 
         private static void GitInit(IGitDriver git, RepositoryData repository)
         {
-            repository.DefaultBranch = repository.DefaultBranch ?? git.GetCurrentHead();
-            git.Clone(repository.Pull.Uri, repository.DefaultBranch);
+            if (repository.DefaultBranch == null)
+            {
+                git.Clone(repository.Pull.Uri);
+                repository.DefaultBranch = git.GetCurrentHead();
+            }
+            else
+            {
+                git.Clone(repository.Pull.Uri, repository.DefaultBranch);
+            }
             git.AddRemote(repository.Remote, repository.Push.Uri);
         }
     }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -108,6 +108,9 @@ namespace NuKeeper.Engine
         {
             git.Clone(repository.Pull.Uri);
             repository.DefaultBranch = repository.DefaultBranch ?? git.GetCurrentHead();
+            // checkout will change the branch to the correct one if it is changed
+            // with the --targetBranch option
+            git.Checkout(repository.DefaultBranch);
             git.AddRemote(repository.Remote, repository.Push.Uri);
         }
     }

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -106,11 +106,8 @@ namespace NuKeeper.Engine
 
         private static void GitInit(IGitDriver git, RepositoryData repository)
         {
-            git.Clone(repository.Pull.Uri);
             repository.DefaultBranch = repository.DefaultBranch ?? git.GetCurrentHead();
-            // checkout will change the branch to the correct one if it is changed
-            // with the --targetBranch option
-            git.Checkout(repository.DefaultBranch);
+            git.Clone(repository.Pull.Uri, repository.DefaultBranch);
             git.AddRemote(repository.Remote, repository.Push.Uri);
         }
     }


### PR DESCRIPTION
To make it possible to run NuKeeper on a different branch in GitHub

Case: 
 updating of the nugets in feature-branches of different projects that work on the same feature.
In this way the update of one projects nugets will be populated automaticly to the other projects wich work on the same feature.
