### PR TITLE
Read only through necessary settingsreaders

### DIFF
--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -48,10 +48,13 @@ namespace NuKeeper.Commands
             var didRead = false;
             foreach (var reader in _settingsReaders)
             {
+                if (didRead) continue;
+
                 if (reader.CanRead(repoUri))
                 {
                     didRead = true;
-                    settings.SourceControlServerSettings.Repository = reader.RepositorySettings(repoUri, TargetBranch);
+                    settings.SourceControlServerSettings.Repository =
+                        reader.RepositorySettings(repoUri, TargetBranch);
                 }
             }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
 
Bug fix

### :arrow_heading_down: What is the current behavior?

It's currently reads through all the settingsreader, but it can stop once it finds one.

### :new: What is the new behavior (if this is a feature change)?

It stops when it finds one

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
