### PR TITLE
run "dotnet format"

### DIFF
--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -94,7 +94,7 @@ namespace NuKeeper.AzureDevOps
                 {
                     remoteInfo.LocalRepositoryUri = _gitDriver.DiscoverRepo(repositoryUri); // Set to the folder, because we found a remote git repository
                     repositoryUri = origin.Url;
-                    remoteInfo.BranchName = targetBranch ??_gitDriver.GetCurrentHead(remoteInfo.LocalRepositoryUri);
+                    remoteInfo.BranchName = targetBranch ?? _gitDriver.GetCurrentHead(remoteInfo.LocalRepositoryUri);
                     remoteInfo.RemoteName = origin.Name;
                     remoteInfo.WorkingFolder = localFolder;
                 }

--- a/NuKeeper.Gitea/GiteaPlatform.cs
+++ b/NuKeeper.Gitea/GiteaPlatform.cs
@@ -77,7 +77,7 @@ namespace NuKeeper.Gitea
                 return MapRepository(repo);
             }
             catch (NuKeeperException)
-            { 
+            {
                 _logger.Detailed("User repo not found");
                 return null;
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Automated Formatting tidy-up. The `dotnet format` tool found 2 whitespaces that should not be there.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
