### PR TITLE
Only delete temporary folders older than 1 hour so parallel running of NuKeeper will work

### DIFF
--- a/NuKeeper.Inspection.Tests/Files/FolderFactoryTest.cs
+++ b/NuKeeper.Inspection.Tests/Files/FolderFactoryTest.cs
@@ -43,8 +43,7 @@ namespace NuKeeper.Inspection.Tests.Files
             var folder2 = factory.UniqueTemporaryFolder();
             Directory.SetLastWriteTime(folder2.FullPath, DateTime.Now.AddHours(-1).AddMinutes(1));
 
-            var baseFolder = Path.GetDirectoryName(folder1.FullPath);
-            var baseDirInfo = new DirectoryInfo(baseFolder);
+            var baseDirInfo = new DirectoryInfo(FolderFactory.NuKeeperTempFilesPath());
 
             var toDelete = FolderFactory.GetTempDirsToCleanup(baseDirInfo).ToArray();
 
@@ -60,12 +59,11 @@ namespace NuKeeper.Inspection.Tests.Files
             // set up edge cases
             var folder1 = factory.UniqueTemporaryFolder();
             Directory.SetLastWriteTime(folder1.FullPath, DateTime.Now.AddHours(-2));
-
-            var baseFolder = Path.GetDirectoryName(folder1.FullPath);
-            var baseDirInfo = new DirectoryInfo(baseFolder);
-            var notToToDeletePath = Path.Combine(baseFolder, "tools");
+            var notToToDeletePath = Path.Combine(FolderFactory.NuKeeperTempFilesPath(), "tools");
             Directory.CreateDirectory(notToToDeletePath);
             Directory.SetLastWriteTime(notToToDeletePath, DateTime.Now.AddHours(-2));
+
+            var baseDirInfo = new DirectoryInfo(FolderFactory.NuKeeperTempFilesPath());
 
             var toDelete = FolderFactory.GetTempDirsToCleanup(baseDirInfo).ToArray();
 

--- a/NuKeeper.Inspection.Tests/Files/FolderFactoryTest.cs
+++ b/NuKeeper.Inspection.Tests/Files/FolderFactoryTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Linq;
+using NSubstitute;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Inspection.Files;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.Files
+{
+    [TestFixture]
+    public class FolderFactoryTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            ClearTemp();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ClearTemp();
+        }
+
+        private void ClearTemp()
+        {
+            var path = FolderFactory.NuKeeperTempFilesPath();
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+
+        [Test]
+        public void OnlySelectTempFoldersOlderThanOneHour()
+        {
+            var factory = new FolderFactory(Substitute.For<INuKeeperLogger>());
+
+            // set up edge cases
+            var folder1 = factory.UniqueTemporaryFolder();
+            Directory.SetLastWriteTime(folder1.FullPath, DateTime.Now.AddHours(-1).AddMinutes(-1));
+            var folder2 = factory.UniqueTemporaryFolder();
+            Directory.SetLastWriteTime(folder2.FullPath, DateTime.Now.AddHours(-1).AddMinutes(1));
+
+            var baseFolder = Path.GetDirectoryName(folder1.FullPath);
+            var baseDirInfo = new DirectoryInfo(baseFolder);
+
+            var toDelete = FolderFactory.GetTempDirsToCleanup(baseDirInfo).ToArray();
+
+            Assert.AreEqual(1, toDelete.Length, "Only 1 folder should be marked for deletion");
+            Assert.AreEqual(folder1.FullPath, toDelete[0].FullName, "wrong folder marked for deletion");
+        }
+
+        [Test]
+        public void OnlySelectTempFoldersWithPrefix()
+        {
+            var factory = new FolderFactory(Substitute.For<INuKeeperLogger>());
+
+            // set up edge cases
+            var folder1 = factory.UniqueTemporaryFolder();
+            Directory.SetLastWriteTime(folder1.FullPath, DateTime.Now.AddHours(-2));
+
+            var baseFolder = Path.GetDirectoryName(folder1.FullPath);
+            var baseDirInfo = new DirectoryInfo(baseFolder);
+            var notToToDeletePath = Path.Combine(baseFolder, "tools");
+            Directory.CreateDirectory(notToToDeletePath);
+            Directory.SetLastWriteTime(notToToDeletePath, DateTime.Now.AddHours(-2));
+
+            var toDelete = FolderFactory.GetTempDirsToCleanup(baseDirInfo).ToArray();
+
+            Assert.AreEqual(1, toDelete.Length, "Only 1 folder should be marked for deletion");
+            Assert.AreEqual(folder1.FullPath, toDelete[0].FullName, "wrong folder marked for deletion");
+        }
+    }
+}

--- a/NuKeeper.Inspection/Files/FolderFactory.cs
+++ b/NuKeeper.Inspection/Files/FolderFactory.cs
@@ -34,11 +34,16 @@ namespace NuKeeper.Inspection.Files
             return Path.Combine(NuKeeperTempFilesPath(), uniqueName);
         }
 
+        /// <summary>
+        /// Cleanup folders that are not automatically have been cleaned.
+        /// Only delete folders older than 1 hour to 
+        /// </summary>
         public void DeleteExistingTempDirs()
         {
             var dirInfo = new DirectoryInfo(NuKeeperTempFilesPath());
             var dirs = dirInfo.Exists ? dirInfo.EnumerateDirectories() : Enumerable.Empty<DirectoryInfo>();
-            foreach (var dir in dirs)
+            var filterDatetime = DateTime.Now.AddHours(-1);
+            foreach (var dir in dirs.Where(d => d.LastWriteTime < filterDatetime))
             {
                 var folder = new Folder(_logger, dir);
                 folder.TryDelete();

--- a/NuKeeper.Inspection/Files/FolderFactory.cs
+++ b/NuKeeper.Inspection/Files/FolderFactory.cs
@@ -10,6 +10,7 @@ namespace NuKeeper.Inspection.Files
     public class FolderFactory : IFolderFactory
     {
         private readonly INuKeeperLogger _logger;
+        private const string FolderPrefix = "repo-";
 
         public FolderFactory(INuKeeperLogger logger)
         {
@@ -31,19 +32,20 @@ namespace NuKeeper.Inspection.Files
         private static string GetUniqueTemporaryPath()
         {
             var uniqueName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-            return Path.Combine(NuKeeperTempFilesPath(), uniqueName);
+            return Path.Combine(NuKeeperTempFilesPath(), $"{FolderPrefix}{uniqueName}");
         }
 
         /// <summary>
         /// Cleanup folders that are not automatically have been cleaned.
-        /// Only delete folders older than 1 hour to 
+        /// Only delete folders older than 1 hour
+        /// Only delete folders that contain repositories
         /// </summary>
         public void DeleteExistingTempDirs()
         {
             var dirInfo = new DirectoryInfo(NuKeeperTempFilesPath());
             var dirs = dirInfo.Exists ? dirInfo.EnumerateDirectories() : Enumerable.Empty<DirectoryInfo>();
             var filterDatetime = DateTime.Now.AddHours(-1);
-            foreach (var dir in dirs.Where(d => d.LastWriteTime < filterDatetime))
+            foreach (var dir in dirs.Where(d => d.Name.StartsWith(FolderPrefix, StringComparison.InvariantCultureIgnoreCase) && d.LastWriteTime < filterDatetime))
             {
                 var folder = new Folder(_logger, dir);
                 folder.TryDelete();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature #738

### :arrow_heading_down: What is the current behavior?
When multiple NuKeepers run parallel, the cleanup of the temp folders at startup will crash NuKeepers as the working (temp-)folder of some instances will be deleted

### :new: What is the new behavior (if this is a feature change)?
Working (temp-) folders will only be deleted when they are more than 1 hour old.
(The folders will normally already be deleted when NuKeeper ends gracefully)

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
Run 2 instances of NuKeeper on the same machine, with the same account

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [ ] Relevant documentation was updated 
