### PR TITLE
Fix naming of Gitea tests

### DIFF
--- a/NuKeeper.Gitea.Tests/GiteaSettingsReaderTests.cs
+++ b/NuKeeper.Gitea.Tests/GiteaSettingsReaderTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace NuKeeper.Gitea.Tests
 {
     [TestFixture]
-    public class GitlabSettingsReaderTests
+    public class GiteaSettingsReaderTests
     {
         private GiteaSettingsReader _giteaSettingsReader;
         private IEnvironmentVariablesProvider _environmentVariablesProvider;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes naming of Gitea tests

### :arrow_heading_down: What is the current behavior?

It's not right 🙂 

### :new: What is the new behavior (if this is a feature change)?

It's correct 🚀 

### :boom: Does this PR introduce a breaking change?

Nope

### :bug: Recommendations for testing

If it builds nothing is broken

### :memo: Links to relevant issues/docs

#711 introduced it, probably initial implementation was copied from GitLab'.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
