### PR TITLE
Automatic update of Newtonsoft.Json to 12.0.2

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -10,7 +10,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NuGet.CommandLine" Version="4.9.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Newtonsoft.Json` to `12.0.2` from `12.0.1`
`Newtonsoft.Json 12.0.2` was published at `2019-04-22T01:21:49Z`, 23 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Newtonsoft.Json` `12.0.2` from `12.0.1`

[Newtonsoft.Json 12.0.2 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
