### PR TITLE
Automatic update of McMaster.Extensions.CommandLineUtils to 2.3.4

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="NuGet.Protocol" Version="4.9.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `McMaster.Extensions.CommandLineUtils` to `2.3.4` from `2.3.3`
`McMaster.Extensions.CommandLineUtils 2.3.4` was published at `2019-04-11T07:47:14Z`, 1 month ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `McMaster.Extensions.CommandLineUtils` `2.3.4` from `2.3.3`

[McMaster.Extensions.CommandLineUtils 2.3.4 on NuGet.org](https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils/2.3.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
