### PR TITLE
Automatic update of Microsoft.CodeQuality.Analyzers to 2.9.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -17,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeQuality.Analyzers` to `2.9.2` from `2.9.1`
`Microsoft.CodeQuality.Analyzers 2.9.2` was published at `2019-04-17T16:42:09Z`, 27 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeQuality.Analyzers` `2.9.2` from `2.9.1`

[Microsoft.CodeQuality.Analyzers 2.9.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeQuality.Analyzers/2.9.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
