### PR TITLE
Automatic update of Microsoft.CodeAnalysis.FxCopAnalyzers to 2.9.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -16,7 +17,7 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.1" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `2.9.2` from `2.9.1`
`Microsoft.CodeAnalysis.FxCopAnalyzers 2.9.2` was published at `2019-04-17T16:42:04Z`, 27 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `2.9.2` from `2.9.1`

[Microsoft.CodeAnalysis.FxCopAnalyzers 2.9.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/2.9.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
