### PR TITLE
Automatic update of NuGet.CommandLine to 5.0.2

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NuGet.CommandLine" Version="4.9.2">
+    <PackageReference Include="NuGet.CommandLine" Version="5.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a major update of `NuGet.CommandLine` to `5.0.2` from `4.9.2`
`NuGet.CommandLine 5.0.2` was published at `2019-05-14T17:23:12Z`, 7 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.CommandLine` `5.0.2` from `4.9.2`

[NuGet.CommandLine 5.0.2 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/5.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
