### PR TITLE
Update #794 was missing update to the NuKeeper tool packaging

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
@@ -35,7 +35,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)\nuget.commandline\4.9.2\tools\NuGet.exe">
+    <Content Include="$(NuGetPackageRoot)\nuget.commandline\5.0.2\tools\NuGet.exe">
       <Pack>true</Pack>
       <PackagePath>tools\netcoreapp2.1\any\NuGet.exe</PackagePath>
     </Content>


### PR DESCRIPTION
#794  was still packaging the old NuGet command line version, and would fail if it wasn't present.