### PR TITLE
Automatic update of NuGet.Protocol to 5.1.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="NuGet.Protocol" Version="4.9.2" />
+    <PackageReference Include="NuGet.Protocol" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="4.9.2" />
+    <PackageReference Include="NuGet.Protocol" Version="5.1.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `NuGet.Protocol` to `5.1.0` from `4.9.2`
`NuGet.Protocol 5.1.0` was published at `2019-05-21T21:24:33Z`, 4 days ago

2 project updates:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `NuGet.Protocol` `5.1.0` from `4.9.2`
Updated `NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `NuGet.Protocol` `5.1.0` from `4.9.2`

[NuGet.Protocol 5.1.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Protocol/5.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
