### PR TITLE
Automatic update of NSubstitute to 4.2.0

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="SimpleInjector" Version="4.6.0" />

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NSubstitute` to `4.2.0` from `4.1.0`
`NSubstitute 4.2.0` was published at `2019-05-19T11:18:55Z`, 8 days ago

9 project updates:
Updated `NuKeeper.Abstractions.Tests\NuKeeper.Abstractions.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `Nukeeper.AzureDevOps.Tests\Nukeeper.AzureDevOps.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Gitea.Tests\NuKeeper.Gitea.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.GitHub.Tests\NuKeeper.GitHub.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`
Updated `NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj` to `NSubstitute` `4.2.0` from `4.1.0`

[NSubstitute 4.2.0 on NuGet.org](https://www.nuget.org/packages/NSubstitute/4.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
