### PR TITLE
Remove side effects from setting readers

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -13,7 +13,6 @@ namespace NuKeeper.AzureDevOps
         private const string UrlPattern = "https://dev.azure.com/{org}/{project}/_git/{repo}/";
 
         private readonly IGitDiscoveryDriver _gitDriver;
-        private bool _isLocalGitRepo;
 
         public AzureDevOpsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
             : base(environmentVariablesProvider)
@@ -31,7 +30,6 @@ namespace NuKeeper.AzureDevOps
             // Is the specified folder already a git repository?
             if (repositoryUri.IsFile)
             {
-                _isLocalGitRepo = true;
                 repositoryUri = repositoryUri.GetRemoteUriFromLocalRepo(_gitDriver, PlatformHost);
             }
 
@@ -46,10 +44,13 @@ namespace NuKeeper.AzureDevOps
                 return null;
             }
 
-            var settings = _isLocalGitRepo ? CreateSettingsFromLocal(repositoryUri, targetBranch) : CreateSettingsFromRemote(repositoryUri);
+            var settings = repositoryUri.IsFile
+                ? CreateSettingsFromLocal(repositoryUri, targetBranch)
+                : CreateSettingsFromRemote(repositoryUri);
+
             if (settings == null)
             {
-                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
+                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be {UrlPattern}");
             }
 
             return settings;

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -13,7 +13,6 @@ namespace NuKeeper.AzureDevOps
         private const string UrlPattern = "https://tfs.company.local:{port}/<nothingOrVirtualSite>/{project}/_git/{repo}";
 
         private readonly IGitDiscoveryDriver _gitDriver;
-        private bool _isLocalGitRepo;
 
         public TfsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
         : base(environmentVariablesProvider)
@@ -32,7 +31,6 @@ namespace NuKeeper.AzureDevOps
             if (repositoryUri.IsFile)
             {
                 repositoryUri = repositoryUri.GetRemoteUriFromLocalRepo(_gitDriver, PlatformHost);
-                _isLocalGitRepo = true;
             }
 
             var path = repositoryUri.AbsolutePath;
@@ -52,7 +50,9 @@ namespace NuKeeper.AzureDevOps
                 return null;
             }
 
-            var settings = _isLocalGitRepo ? CreateSettingsFromLocal(repositoryUri, targetBranch) : CreateSettingsFromRemote(repositoryUri);
+            var settings = repositoryUri.IsFile
+                ? CreateSettingsFromLocal(repositoryUri, targetBranch)
+                : CreateSettingsFromRemote(repositoryUri);
             if (settings == null)
             {
                 throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -13,7 +13,6 @@ namespace NuKeeper.AzureDevOps
         private const string UrlPattern = "https://{org}.visualstudio.com/{project}/_git/{repo}";
 
         private readonly IGitDiscoveryDriver _gitDriver;
-        private bool _isLocalGitRepo;
 
         public VstsSettingsReader(IGitDiscoveryDriver gitDriver, IEnvironmentVariablesProvider environmentVariablesProvider)
             : base(environmentVariablesProvider)
@@ -32,7 +31,6 @@ namespace NuKeeper.AzureDevOps
             if (repositoryUri.IsFile)
             {
                 repositoryUri = repositoryUri.GetRemoteUriFromLocalRepo(_gitDriver, PlatformHost);
-                _isLocalGitRepo = true;
             }
 
             return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
@@ -45,7 +43,9 @@ namespace NuKeeper.AzureDevOps
                 return null;
             }
 
-            var settings = _isLocalGitRepo ? CreateSettingsFromLocal(repositoryUri, targetBranch) : CreateSettingsFromRemote(repositoryUri);
+            var settings = repositoryUri.IsFile
+                ? CreateSettingsFromLocal(repositoryUri, targetBranch)
+                : CreateSettingsFromRemote(repositoryUri);
             if (settings == null)
             {
                 throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

That's sort of a bug fix. Every time `GitHubSettingsReader` `CanRead` was called it's internal state was altered.

### :arrow_heading_down: What is the current behavior?

Internal state of presumably stateless class is altered.

### :new: What is the new behavior (if this is a feature change)?

It's not altered anymore. :)

### :boom: Does this PR introduce a breaking change?

It shouldn't introduce any.

### :bug: Recommendations for testing

Should work as it used to.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
