### PR TITLE
Add nugetconfigpath CLI argument across all commands

### DIFF
--- a/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
@@ -82,6 +82,8 @@ namespace NuKeeper.Abstractions.Tests.Configuration
                ""exclude"":""fish"",
                ""includeRepos"":""repoIn"",
                ""excludeRepos"":""repoOut"",
+               ""nuGetConfigPath"":""pathToNuGetConfig"",
+               ""sources"": [ ""source1"", ""source2"" ],
                ""label"": [ ""foo"", ""bar"" ],
                ""logFile"":""somefile.log"",
                ""branchNamePrefix"": ""nukeeper"",
@@ -133,6 +135,32 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Label.Count, Is.EqualTo(2));
             Assert.That(data.Label, Does.Contain("foo"));
             Assert.That(data.Label, Does.Contain("bar"));
+        }
+
+        [Test]
+        public void PopulatedConfigReturnsSources()
+        {
+            var path = MakeTestFile(FullFileData);
+
+            var fsr = new FileSettingsReader(Substitute.For<INuKeeperLogger>());
+
+            var data = fsr.Read(path);
+
+            Assert.That(data.Sources.Count, Is.EqualTo(2));
+            Assert.That(data.Sources, Does.Contain("source1"));
+            Assert.That(data.Sources, Does.Contain("source2"));
+        }
+
+        [Test]
+        public void PopulatedConfigReturnsNuGetConfigPath()
+        {
+            var path = MakeTestFile(FullFileData);
+
+            var fsr = new FileSettingsReader(Substitute.For<INuKeeperLogger>());
+
+            var data = fsr.Read(path);
+
+            Assert.That(data.NuGetConfigPath, Does.Contain("pathToNuGetConfig"));
         }
 
         [Test]

--- a/NuKeeper.Abstractions/Concat.cs
+++ b/NuKeeper.Abstractions/Concat.cs
@@ -15,6 +15,21 @@ namespace NuKeeper.Abstractions
             return values.FirstOrDefault(i => i.HasValue) ?? default;
         }
 
+        public static IReadOnlyCollection<string> FirstPopulatedList(List<string> list1, List<string> list2)
+        {
+            if (HasElements(list1))
+            {
+                return list1;
+            }
+
+            if (HasElements(list2))
+            {
+                return list2;
+            }
+
+            return null;
+        }
+
         public static IReadOnlyCollection<string> FirstPopulatedList(List<string> list1, List<string> list2, List<string> list3)
         {
             if (HasElements(list1))

--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -23,6 +23,9 @@ namespace NuKeeper.Abstractions.Configuration
         public string IncludeRepos { get; set; }
         public string ExcludeRepos { get; set; }
 
+        public string NuGetConfigPath { get; set; }
+        public List<string> Sources { get; set; }
+
         public List<string> Label { get; set; }
 
         public string LogFile { get; set; }

--- a/NuKeeper.Tests/Commands/CommandBaseTests.cs
+++ b/NuKeeper.Tests/Commands/CommandBaseTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Output;
+using NuKeeper.Commands;
+using NuKeeper.Inspection.Logging;
+using NUnit.Framework;
+
+namespace NuKeeper.Tests.Commands
+{
+    public class CommandBaseTests
+    {
+        [Test]
+        public async Task EmptyFileResultsInDefaultSettings()
+        {
+            var fileSettings = FileSettings.Empty();
+
+            var settings = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.PackageFilters.MinimumAge, Is.EqualTo(TimeSpan.FromDays(7)));
+            Assert.That(settings.PackageFilters.Excludes, Is.Null);
+            Assert.That(settings.PackageFilters.Includes, Is.Null);
+            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(0));
+
+            Assert.That(settings.UserSettings, Is.Not.Null);
+            Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
+            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
+            Assert.That(settings.UserSettings.OutputDestination, Is.EqualTo(OutputDestination.Console));
+            Assert.That(settings.UserSettings.OutputFormat, Is.EqualTo(OutputFormat.Text));
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(0));
+            Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.False);
+
+            Assert.That(settings.BranchSettings, Is.Not.Null);
+            Assert.That(settings.BranchSettings.BranchNamePrefix, Is.Null);
+            Assert.That(settings.BranchSettings.DeleteBranchAfterMerge, Is.EqualTo(false));
+
+            Assert.That(settings.SourceControlServerSettings.IncludeRepos, Is.Null);
+            Assert.That(settings.SourceControlServerSettings.ExcludeRepos, Is.Null);
+        }
+
+        [Test]
+        public async Task NuGetConfigPathOnCommandLine()
+        {
+            var fileSettings = new FileSettings();
+
+            var settings = await CaptureSettings(fileSettings, nugetConfigFile: "via-cli.config");
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(),
+                Is.EqualTo("http://source-from-nuget-config-via-cli.nuget.org/"));
+        }
+
+        [Test]
+        public async Task NuGetConfigPathInFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                NuGetConfigPath = Path.Combine("NuGetConfigs", "via-file.config")
+            };
+
+            var settings = await CaptureSettings(fileSettings);
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(),
+                Is.EqualTo("http://source-from-nuget-config-via-file.nuget.org/"));
+        }
+
+        [Test]
+        public async Task NuGetConfigPathOnCommandLineWillReplaceFileNuGetConfigPath()
+        {
+            var fileSettings = new FileSettings
+            {
+                NuGetConfigPath = Path.Combine("NuGetConfigs", "via-file.config")
+            };
+
+            var settings = await CaptureSettings(fileSettings, nugetConfigFile: "via-cli.config");
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(),
+                Is.EqualTo("http://source-from-nuget-config-via-cli.nuget.org/"));
+        }
+
+        [Test]
+        public async Task SourcesOnCommandLine()
+        {
+            var fileSettings = new FileSettings();
+
+            var settings = await CaptureSettings(fileSettings, sources: new[] {"http://cli-source.nuget.org/"});
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(), Is.EqualTo("http://cli-source.nuget.org/"));
+        }
+
+        [Test]
+        public async Task SourcesInFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                Sources = new List<string> {"http://file-source.nuget.org/"}
+            };
+
+            var settings = await CaptureSettings(fileSettings);
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(), Is.EqualTo("http://file-source.nuget.org/"));
+        }
+
+        [Test]
+        public async Task SourcesOnCommandLineWillReplaceFileSources()
+        {
+            var fileSettings = new FileSettings
+            {
+                Sources = new List<string> {"http://file-source.nuget.org/"}
+            };
+
+            var settings = await CaptureSettings(fileSettings, sources: new[] {"http://cli-source.nuget.org/"});
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(), Is.EqualTo("http://cli-source.nuget.org/"));
+        }
+
+        [Test]
+        public async Task SourcesOnCommandLineWillBeAppendedToNuGetConfigInFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                NuGetConfigPath = Path.Combine("NuGetConfigs", "via-file.config")
+            };
+
+            var settings = await CaptureSettings(fileSettings, sources: new[] {"http://cli-source.nuget.org/"});
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(),
+                Is.EqualTo("http://source-from-nuget-config-via-file.nuget.org/, http://cli-source.nuget.org/"));
+        }
+
+        [Test]
+        public async Task SourcesInFileWillBeAppendedToNuGetConfigOnCommandLine()
+        {
+            var fileSettings = new FileSettings
+            {
+                Sources = new List<string> {"http://file-source.nuget.org/"}
+            };
+
+            var settings = await CaptureSettings(fileSettings, nugetConfigFile: "via-cli.config");
+
+            Assert.That(settings.UserSettings.NuGetSources, Is.Not.Null);
+            Assert.That(settings.UserSettings.NuGetSources.ToString(),
+                Is.EqualTo("http://source-from-nuget-config-via-cli.nuget.org/, http://file-source.nuget.org/"));
+        }
+
+        private static async Task<SettingsContainer> CaptureSettings(
+            FileSettings settingsIn,
+            string nugetConfigFile = null,
+            IEnumerable<string> sources = null)
+        {
+            var logger = Substitute.For<IConfigureLogger>();
+            var fileSettings = Substitute.For<IFileSettingsCache>();
+            fileSettings.GetSettings().Returns(settingsIn);
+
+            var command = new TestCommand(logger, fileSettings)
+            {
+                Sources = sources?.ToList(),
+                NuGetConfigPath = nugetConfigFile != null ? Path.Combine("NuGetConfigs", nugetConfigFile) : null
+            };
+
+            await command.OnExecute();
+
+            return command.LastRunSettings;
+        }
+
+        private class TestCommand : CommandBase
+        {
+            public SettingsContainer LastRunSettings { get; private set; }
+
+            public TestCommand(IConfigureLogger logger, IFileSettingsCache fileSettingsCache) : base(logger,
+                fileSettingsCache)
+            {
+            }
+
+            protected override Task<int> Run(SettingsContainer settings)
+            {
+                LastRunSettings = settings;
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/NuKeeper.Tests/NuGetConfigs/via-cli.config
+++ b/NuKeeper.Tests/NuGetConfigs/via-cli.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="source-via-cli" value="http://source-from-nuget-config-via-cli.nuget.org/" />
+  </packageSources>
+</configuration>

--- a/NuKeeper.Tests/NuGetConfigs/via-file.config
+++ b/NuKeeper.Tests/NuGetConfigs/via-file.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="source-via-file" value="http://source-from-nuget-config-via-file.nuget.org/" />
+  </packageSources>
+</configuration>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -19,4 +19,12 @@
     <ProjectReference Include="..\NuKeeper.Update\NuKeeper.Update.csproj" />
     <ProjectReference Include="..\NuKeeper\NuKeeper.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="NuGetConfigs\via-cli.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="NuGetConfigs\via-file.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

New feature

### :arrow_heading_down: What is the current behavior?

Individual sources can be specified on the command line.

### :new: What is the new behavior (if this is a feature change)?

Individual sources can be specified via file.
NuGet config files can be specified on the command line and via file.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Combinations of sources, nuget configs in file and on command line.

### :memo: Links to relevant issues/docs

This implements feature https://github.com/NuKeeperDotNet/NuKeeper/issues/817

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
