### PR TITLE
Display correct version.

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsCommitWorder.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsCommitWorder.cs
@@ -193,17 +193,8 @@ namespace NuKeeper.AzureDevOps
         private static void LogHighestVersion(PackageUpdateSet updates, NuGetVersion highestVersion, StringBuilder builder)
         {
             var allowedChange = CodeQuote(updates.AllowedChange.ToString());
+            var highest = CodeQuote(updates.SelectedId + " " + highestVersion);
             var highestPublishedAt = HighestPublishedAt(updates.Packages.Major.Published);
-
-            string highest;
-            if (SourceIsPublicNuget(updates.Selected.Source.SourceUri))
-            {
-                highest = $"{CodeQuote(updates.SelectedId)} {NuGetVersionPackageLink(updates.Selected.Identity)}";
-            }
-            else
-            {
-                highest = CodeQuote(updates.SelectedId + " " + highestVersion);
-            }
 
             builder.AppendLine(
                 $"There is also a higher version, {highest}{highestPublishedAt}, " +

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
@@ -242,7 +242,7 @@ namespace NuKeeper.AzureDevOps.Tests
 
             var report = _sut.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar` {NuGetVersionPackageLink("foo.bar", "1.2.3")}, but this was not applied as only `Minor` version changes are allowed."));
+            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 1.2.3`, but this was not applied as only `Minor` version changes are allowed."));
         }
 
         [Test]
@@ -255,7 +255,7 @@ namespace NuKeeper.AzureDevOps.Tests
 
             var report = _sut.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar` {NuGetVersionPackageLink("foo.bar", "1.2.3")} published at `2018-02-20T11:32:45Z`,"));
+            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 1.2.3` published at `2018-02-20T11:32:45Z`,"));
             Assert.That(report, Does.Contain(" ago, but this was not applied as only `Minor` version changes are allowed."));
         }
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
@@ -242,7 +242,7 @@ namespace NuKeeper.AzureDevOps.Tests
 
             var report = _sut.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 1.2.3`, but this was not applied as only `Minor` version changes are allowed."));
+            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 2.3.4`, but this was not applied as only `Minor` version changes are allowed."));
         }
 
         [Test]
@@ -255,7 +255,7 @@ namespace NuKeeper.AzureDevOps.Tests
 
             var report = _sut.MakeCommitDetails(updates);
 
-            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 1.2.3` published at `2018-02-20T11:32:45Z`,"));
+            Assert.That(report, Does.Contain($"There is also a higher version, `foo.bar 2.3.4` published at `2018-02-20T11:32:45Z`,"));
             Assert.That(report, Does.Contain(" ago, but this was not applied as only `Minor` version changes are allowed."));
         }
 


### PR DESCRIPTION
Now display correct highest version for Azure DevOps pull request descriptions.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?

Current:
> There is also a higher version, Polly 6.1.2 published at 2019-03-13T23:50:12Z, 3 months ago, but this was not applied as only Minor version changes are allowed.

Should be:
> There is also a higher version, Polly 7.1.0 published at 2019-03-13T23:50:12Z, 3 months ago, but this was not applied as only Minor version changes are allowed.

### :new: What is the new behavior (if this is a feature change)?
Now displaying correct version.

### :boom: Does this PR introduce a breaking change?
Nope/

### :bug: Recommendations for testing
Nope.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
