### PR TITLE
Added support for mutliple item groups in Directory.Build.props/targets

### DIFF
--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         public IReadOnlyCollection<string> GetFilePatterns()
         {
-            return new[] { "Directory.Build.props", "Directory.Build.targets" };
+            return new[] { "Directory.Build.props", "Directory.Build.targets", "Packages.props" };
         }
 
         public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, PackagePath path)

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -45,14 +45,13 @@ namespace NuKeeper.Inspection.RepositoryInspection
         {
             var xml = XDocument.Load(fileContents);
 
-            var packagesNode = xml.Element("Project")?.Element("ItemGroup");
+            var packagesNode = xml.Element("Project")?.Elements("ItemGroup");
             if (packagesNode == null)
             {
                 return Array.Empty<PackageInProject>();
             }
 
-            var packageNodeList = packagesNode.Elements()
-                .Where(x => x.Name == "PackageReference");
+            var packageNodeList = packagesNode.Elements("PackageReference");
 
             return packageNodeList
                 .Select(el => XmlToPackage(el, path))

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -210,6 +210,23 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
         }
 
         [Test]
+        public void CorrectItemsInPackagesProps()
+        {
+            var scanner = MakeScanner();
+
+            WriteFile(_uniqueTemporaryFolder, "Packages.props", DirectoryBuildProps);
+
+            var results = scanner.FindAllNuGetPackages(_uniqueTemporaryFolder);
+
+            var item = results.FirstOrDefault();
+
+            Assert.That(item, Is.Not.Null);
+            Assert.That(item.Id, Is.EqualTo("foo"));
+            Assert.That(item.Version, Is.EqualTo(new NuGetVersion(1, 2, 3)));
+            Assert.That(item.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
         public void SelfTest()
         {
             var scanner = MakeScanner();

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -39,17 +39,16 @@ namespace NuKeeper.Update.Process
         private void UpdateFile(Stream fileContents, NuGetVersion newVersion,
             PackageInProject currentPackage, XDocument xml)
         {
-            var packagesNode = xml.Element("Project")?.Element("ItemGroup");
+            var packagesNode = xml.Element("Project")?.Elements("ItemGroup");
             if (packagesNode == null)
             {
                 return;
             }
 
-            var packageNodeList = packagesNode.Elements()
-                .Where(x => x.Name == "PackageReference" && (x.Attributes("Include")
-                                                                 .Any(a => a.Value == currentPackage.Id)
-                                                             || x.Attributes("Update")
-                                                                 .Any(a => a.Value == currentPackage.Id)));
+            var packageNodeList = packagesNode.Elements("PackageReference")
+                .Where(x =>
+                    (x.Attributes("Include").Any(a => a.Value == currentPackage.Id)
+                  || x.Attributes("Update").Any(a => a.Value == currentPackage.Id)));
 
             foreach (var dependencyToUpdate in packageNodeList)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently only the first `<ItemGroup>` is searched in a `Directory.Build.props` or `Directory.Build.targets` file.

### :new: What is the new behavior (if this is a feature change)?
Read and update all the `<PackageReference>`s in `Directory.Build.props` or `Directory.Build.targets`.

### :boom: Does this PR introduce a breaking change?
Not that I'm aware of.

### :bug: Recommendations for testing
Added 2 tests to the integration suite that demonstrate the problem.  Verified by creating the failing test first.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [x] Relevant documentation was updated 
Unsure if this needs updating in documentation.