### PR TITLE
Add http compression option to all http clients. 

### DIFF
--- a/NuKeeper.AzureDevOps/AssemblyInfo.cs
+++ b/NuKeeper.AzureDevOps/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Nukeeper.AzureDevOps.Tests")]
+

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -15,15 +15,16 @@ namespace NuKeeper.AzureDevOps
 {
     public class AzureDevOpsRestClient
     {
-        private readonly HttpClient _client;
+        internal readonly HttpClient _httpClient;
         private readonly INuKeeperLogger _logger;
 
         public AzureDevOpsRestClient(HttpClient client, INuKeeperLogger logger, string personalAccessToken)
         {
-            _client = client;
+            _httpClient = client;
             _logger = logger;
-            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _client.DefaultRequestHeaders.Authorization =
+            
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{string.Empty}:{personalAccessToken}")));
         }
 
@@ -32,7 +33,7 @@ namespace NuKeeper.AzureDevOps
             var fullUrl = BuildAzureDevOpsUri(url, previewApi);
             _logger.Detailed($"{caller}: Requesting {fullUrl}");
 
-            var response = await _client.PostAsync(fullUrl, content);
+            var response = await _httpClient.PostAsync(fullUrl, content);
             return await HandleResponse<T>(response, caller);
         }
 
@@ -41,7 +42,7 @@ namespace NuKeeper.AzureDevOps
             var fullUrl = BuildAzureDevOpsUri(url, previewApi);
             _logger.Detailed($"{caller}: Requesting {fullUrl}");
 
-            var response = await _client.GetAsync(fullUrl);
+            var response = await _httpClient.GetAsync(fullUrl);
             return await HandleResponse<T>(response, caller);
         }
 

--- a/NuKeeper.BitBucket/BitbucketPlatform.cs
+++ b/NuKeeper.BitBucket/BitbucketPlatform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
@@ -27,7 +28,14 @@ namespace NuKeeper.BitBucket
         public void Initialise(AuthSettings settings)
         {
             _settings = settings;
-            var httpClient = new HttpClient
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
+            {
+                // Add support for compression on the http calls. This will send an accept header to indicate that the server can send back compressed
+                // content. The handler will then decompress this. 
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+            var httpClient = new HttpClient(handler)
             {
                 BaseAddress = settings.ApiBase
             };

--- a/NuKeeper.Gitea/GiteaPlatform.cs
+++ b/NuKeeper.Gitea/GiteaPlatform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions;
@@ -23,7 +24,14 @@ namespace NuKeeper.Gitea
 
         public void Initialise(AuthSettings settings)
         {
-            var httpClient = new HttpClient
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
+            {
+                // Add support for compression on the http calls. This will send an accept header to indicate that the server can send back compressed
+                // content. The handler will then decompress this. 
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+            var httpClient = new HttpClient(handler)
             {
                 BaseAddress = settings.ApiBase
             };

--- a/NuKeeper.Gitea/GiteaSettingsReader.cs
+++ b/NuKeeper.Gitea/GiteaSettingsReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using NuKeeper.Abstractions;
@@ -30,7 +31,14 @@ namespace NuKeeper.Gitea
             try
             {
                 // There is no real identifier for gitea repos so try to get the gitea swagger json
-                var client = new HttpClient()
+                var handler = new HttpClientHandler();
+                if (handler.SupportsAutomaticDecompression)
+                {
+                    // Add support for compression on the http calls. This will send an accept header to indicate that the server can send back compressed
+                    // content. The handler will then decompress this. 
+                    handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+                }
+                var client = new HttpClient(handler)
                 {
                     BaseAddress = GetBaseAddress(repositoryUri)
                 };

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
@@ -23,7 +24,14 @@ namespace NuKeeper.Gitlab
 
         public void Initialise(AuthSettings settings)
         {
-            var httpClient = new HttpClient
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
+            {
+                // Add support for compression on the http calls. This will send an accept header to indicate that the server can send back compressed
+                // content. The handler will then decompress this. 
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+            var httpClient = new HttpClient(handler)
             {
                 BaseAddress = settings.ApiBase
             };

--- a/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
@@ -15,5 +15,16 @@ namespace Nukeeper.AzureDevOps.Tests
             var platform = new AzureDevOpsPlatform(Substitute.For<INuKeeperLogger>());
             platform.Initialise(new AuthSettings(new Uri("https://uri.com"), "token"));
         }
+
+        [Test]
+        public void AssertHttpClientIsCreated()
+        {
+            var platform = new AzureDevOpsPlatform(Substitute.For<INuKeeperLogger>());
+            platform.Initialise(new AuthSettings(new Uri("https://uri.com"), "token"));
+
+            Assert.IsNotNull(platform._restClient);
+            Assert.IsNotNull(platform._restClient._httpClient);
+         
+        }
     }
 }

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
@@ -27,7 +28,14 @@ namespace NuKeeper.BitBucketLocal
         public void Initialise(AuthSettings settings)
         {
             _settings = settings;
-            var httpClient = new HttpClient
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
+            {
+                // Add support for compression on the http calls. This will send an accept header to indicate that the server can send back compressed
+                // content. The handler will then decompress this. 
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+            var httpClient = new HttpClient(handler)
             {
                 BaseAddress = new Uri($"{settings.ApiBase.Scheme}://{settings.ApiBase.Authority}")
             };


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Adds the http compression option to all http clients. This will send an accept header to indicate that compression is supported. When the server (and most do) responds with a compressed payload, the client will automatically decompress. This will reduce the payload and decrease the time needed to fetch data.

### :arrow_heading_down: What is the current behavior?

By default, there is no compression.

### :new: What is the new behavior (if this is a feature change)?

Data send over the API will be compressed when supported.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

This is standard .NET `HttpClientHandler` behaviour. Normally you test the httpclient by providing a mocked `HttpClientHandler`. Which is actually the one we want to test.

### :memo: Links to relevant issues/docs

- https://github.com/dotnet/corefx/issues/18646#issuecomment-295818384
- https://mindbyte.nl/http-api/2019/02/27/add-http-compression-to-your-httpclient-in-dotnet-core-2-1.html


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
