### PR TITLE
Fallback to mono when running on Linux or MacOS for Nuget.exe

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -1,8 +1,8 @@
 strategy:
   matrix:
-    linux:
+    Linux:
       imageName: 'ubuntu-16.04'
-    windows:
+    Windows:
       imageName: 'vs2017-win2016'
 
 pool:
@@ -41,6 +41,7 @@ steps:
     dotnet tool install -g dotnet-reportgenerator-globaltool
     reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage -reporttypes:HtmlInline_AzurePipelines;Cobertura
   displayName: Create Code coverage report
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage'
@@ -48,9 +49,10 @@ steps:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
     reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: drop for master'
   inputs:
     PathtoPublish: '$(Build.SourcesDirectory)'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -1,5 +1,13 @@
-queue:
-  name: Hosted VS2017
+strategy:
+  matrix:
+    linux:
+      imageName: 'ubuntu-16.04'
+    windows:
+      imageName: 'vs2017-win2016'
+
+pool:
+  vmImage: $(imageName)
+
 variables:
   buildConfiguration: Release
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
-mono: none
+mono: 5.18.1
 dist: xenial
 dotnet: 2.2.202
 script:
   - dotnet build -c Release NuKeeper.sln /m:1
-  - dotnet test -c Release NuKeeper.sln --filter "TestCategory!=WindowsOnly"
+  - dotnet test -c Release NuKeeper.sln

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -75,7 +75,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await File.WriteAllTextAsync(Path.Combine(workDirectory, "nuget.config"), _nugetConfig);
 
             var logger = Substitute.For<INuKeeperLogger>();
-            var command = new NuGetUpdatePackageCommand(logger, new NuGetPath(logger), new ExternalProcess(logger));
+            var externalProcess = new ExternalProcess(logger);
+            var command = new NuGetUpdatePackageCommand(logger, new NuGetPath(logger),
+                new MonoExecutor(logger, externalProcess), externalProcess);
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                     new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -16,11 +16,10 @@ using NuKeeper.Abstractions.RepositoryInspection;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    [Category("WindowsOnly")] // Windows only due to NuGetUpdatePackageCommand
     public class NuGetUpdatePackageCommandTests
     {
         private readonly string _testDotNetClassicProject =
-@"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            @"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
@@ -29,10 +28,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 </Project>";
 
         private readonly string _testPackagesConfig =
-@"<packages><package id=""Microsoft.AspNet.WebApi.Client"" version=""{packageVersion}"" targetFramework=""net47"" /></packages>";
+            @"<packages><package id=""Microsoft.AspNet.WebApi.Client"" version=""{packageVersion}"" targetFramework=""net47"" /></packages>";
 
         private readonly string _nugetConfig =
-@"<configuration><config><add key=""repositoryPath"" value="".\packages"" /></config></configuration>";
+            @"<configuration><config><add key=""repositoryPath"" value="".\packages"" /></config></configuration>";
 
         private IFolder _uniqueTemporaryFolder = null;
 
@@ -64,11 +63,13 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var packagesFolder = Path.Combine(workDirectory, "packages");
             Directory.CreateDirectory(packagesFolder);
 
-            var projectContents = _testDotNetClassicProject.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase);
+            var projectContents = _testDotNetClassicProject.Replace("{packageVersion}", oldPackageVersion,
+                StringComparison.OrdinalIgnoreCase);
             var projectPath = Path.Combine(workDirectory, testProject);
             await File.WriteAllTextAsync(projectPath, projectContents);
 
-            var packagesConfigContents = _testPackagesConfig.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase);
+            var packagesConfigContents = _testPackagesConfig.Replace("{packageVersion}", oldPackageVersion,
+                StringComparison.OrdinalIgnoreCase);
             var packagesConfigPath = Path.Combine(workDirectory, "packages.config");
             await File.WriteAllTextAsync(packagesConfigPath, packagesConfigContents);
 
@@ -76,18 +77,30 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             var logger = Substitute.For<INuKeeperLogger>();
             var externalProcess = new ExternalProcess(logger);
-            var command = new NuGetUpdatePackageCommand(logger, new NuGetPath(logger),
-                new MonoExecutor(logger, externalProcess), externalProcess);
+
+            var monoExecutor = new MonoExecutor(logger, externalProcess);
+
+            var nuGetPath = new NuGetPath(logger);
+            var nuGetVersion = new NuGetVersion(newPackageVersion);
+            var packageSource = new PackageSource(NuGetConstants.V3FeedUrl);
+
+            var restoreCommand = new NuGetFileRestoreCommand(logger, nuGetPath, monoExecutor, externalProcess);
+            var updateCommand = new NuGetUpdatePackageCommand(logger, nuGetPath, monoExecutor, externalProcess);
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
-                    new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));
+                new PackagePath(workDirectory, testProject, PackageReferenceType.PackagesConfig));
 
-            await command.Invoke(packageToUpdate, new NuGetVersion(newPackageVersion),
-                new PackageSource(NuGetConstants.V3FeedUrl), NuGetSources.GlobalFeed);
+            await restoreCommand.Invoke(packageToUpdate, nuGetVersion, packageSource, NuGetSources.GlobalFeed);
+
+            await updateCommand.Invoke(packageToUpdate, nuGetVersion, packageSource, NuGetSources.GlobalFeed);
 
             var contents = await File.ReadAllTextAsync(packagesConfigPath);
-            Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion, StringComparison.OrdinalIgnoreCase)));
-            Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase)));
+            Assert.That(contents,
+                Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion,
+                    StringComparison.OrdinalIgnoreCase)));
+            Assert.That(contents,
+                Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion,
+                    StringComparison.OrdinalIgnoreCase)));
         }
 
         private static IFolder UniqueTemporaryFolder()

--- a/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
+++ b/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
@@ -13,11 +13,10 @@ namespace NuKeeper.Update.Tests.Process
     {
         [TestCase(0, true)]
         [TestCase(1, false)]
-        public async Task WhenCallingCanRun_ShouldCheckExtrernalProccessResult(int exitCode, bool expectedCanExecute)
+        public async Task WhenCallingCanRun_ShouldCheckExternalProcessResult(int exitCode, bool expectedCanExecute)
         {
             var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
             var externalProcess = Substitute.For<IExternalProcess>();
-
 
             externalProcess.Run("","mono","--version",false).
                 Returns(Task.FromResult(new ProcessOutput("","",exitCode)));
@@ -34,7 +33,6 @@ namespace NuKeeper.Update.Tests.Process
         {
             var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
             var externalProcess = Substitute.For<IExternalProcess>();
-
 
             externalProcess.Run("","mono","--version",false).
                 Returns(Task.FromResult(new ProcessOutput("","",0)));
@@ -57,7 +55,6 @@ namespace NuKeeper.Update.Tests.Process
         {
             var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
             var externalProcess = Substitute.For<IExternalProcess>();
-
 
             externalProcess.Run("","mono","--version",false).
                 Returns(Task.FromResult(new ProcessOutput("","",1)));

--- a/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
+++ b/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Update.Process;
+using NuKeeper.Update.ProcessRunner;
+using NUnit.Framework;
+
+namespace NuKeeper.Update.Tests.Process
+{
+    [TestFixture]
+    public class MonoExecutorTests
+    {
+        [TestCase(0, true)]
+        [TestCase(1, false)]
+        public async Task WhenCallingCanRun_ShouldCheckExtrernalProccessResult(int exitCode, bool expectedCanExecute)
+        {
+            var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+
+
+            externalProcess.Run("","mono","--version",false).
+                Returns(Task.FromResult(new ProcessOutput("","",exitCode)));
+
+            var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
+
+            var canRun = await monoExecutor.CanRun();
+
+            Assert.AreEqual(expectedCanExecute, canRun);
+        }
+
+        [Test]
+        public async Task WhenCallingCanRun_ShouldOnlyCallExternalProcessOnce()
+        {
+            var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+
+
+            externalProcess.Run("","mono","--version",false).
+                Returns(Task.FromResult(new ProcessOutput("","",0)));
+
+            var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
+
+            await monoExecutor.CanRun();
+            await monoExecutor.CanRun();
+            await monoExecutor.CanRun();
+
+            await externalProcess.Received(1).Run(
+                "",
+                "mono",
+                "--version",
+                false);
+        }
+
+        [Test]
+        public void WhenCallingRun_ShouldThrowIfMonoWasNotFound()
+        {
+            var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+
+
+            externalProcess.Run("","mono","--version",false).
+                Returns(Task.FromResult(new ProcessOutput("","",1)));
+
+            var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await monoExecutor.Run("wd", "command", "args", true));
+        }
+
+        [Test]
+        public async Task WhenCallingRun_ShouldPassArgumentToUnderlyingExternalProcess()
+        {
+            var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+
+            externalProcess.Run("","mono","--version",false).
+                Returns(Task.FromResult(new ProcessOutput("","",0)));
+
+            var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
+            await monoExecutor.Run("wd", "command", "args", true);
+
+            await externalProcess.Received(1).Run("wd", "mono", "command args", true);
+        }
+    }
+}

--- a/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
+++ b/NuKeeper.Update.Tests/Process/MonoExecutorTests.cs
@@ -19,7 +19,7 @@ namespace NuKeeper.Update.Tests.Process
             var externalProcess = Substitute.For<IExternalProcess>();
 
             externalProcess.Run("","mono","--version",false).
-                Returns(Task.FromResult(new ProcessOutput("","",exitCode)));
+                Returns(new ProcessOutput("","",exitCode));
 
             var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
 
@@ -35,7 +35,7 @@ namespace NuKeeper.Update.Tests.Process
             var externalProcess = Substitute.For<IExternalProcess>();
 
             externalProcess.Run("","mono","--version",false).
-                Returns(Task.FromResult(new ProcessOutput("","",0)));
+                Returns(new ProcessOutput("","",0));
 
             var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
 
@@ -57,7 +57,7 @@ namespace NuKeeper.Update.Tests.Process
             var externalProcess = Substitute.For<IExternalProcess>();
 
             externalProcess.Run("","mono","--version",false).
-                Returns(Task.FromResult(new ProcessOutput("","",1)));
+                Returns(new ProcessOutput("","",1));
 
             var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
 
@@ -72,7 +72,7 @@ namespace NuKeeper.Update.Tests.Process
             var externalProcess = Substitute.For<IExternalProcess>();
 
             externalProcess.Run("","mono","--version",false).
-                Returns(Task.FromResult(new ProcessOutput("","",0)));
+                Returns(new ProcessOutput("","",0));
 
             var monoExecutor = new MonoExecutor(nuKeeperLogger, externalProcess);
             await monoExecutor.Run("wd", "command", "args", true);

--- a/NuKeeper.Update/Process/IMonoExecutor.cs
+++ b/NuKeeper.Update/Process/IMonoExecutor.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using NuKeeper.Update.ProcessRunner;
+
+namespace NuKeeper.Update.Process
+{
+    public interface IMonoExecutor: IExternalProcess
+    {
+        Task<bool> HasMono();
+    }
+}

--- a/NuKeeper.Update/Process/IMonoExecutor.cs
+++ b/NuKeeper.Update/Process/IMonoExecutor.cs
@@ -5,6 +5,6 @@ namespace NuKeeper.Update.Process
 {
     public interface IMonoExecutor: IExternalProcess
     {
-        Task<bool> HasMono();
+        Task<bool> CanRun();
     }
 }

--- a/NuKeeper.Update/Process/MonoExecutor.cs
+++ b/NuKeeper.Update/Process/MonoExecutor.cs
@@ -40,8 +40,7 @@ namespace NuKeeper.Update.Process
 
         private async Task<bool> CheckMonoExists()
         {
-            var process = new ExternalProcess(_logger);
-            var result = await process.Run("", "mono", "--version", false);
+            var result = await _externalProcess.Run("", "mono", "--version", false);
 
             return result.Success;
         }

--- a/NuKeeper.Update/Process/MonoExecutor.cs
+++ b/NuKeeper.Update/Process/MonoExecutor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Update.ProcessRunner;
+
+namespace NuKeeper.Update.Process
+{
+    public class MonoExecutor : IMonoExecutor
+    {
+        private readonly INuKeeperLogger _logger;
+        private readonly IExternalProcess _externalProcess;
+
+        private readonly AsyncLazy<bool> _checkMono;
+
+        public MonoExecutor(INuKeeperLogger logger, IExternalProcess externalProcess)
+        {
+            _logger = logger;
+            _externalProcess = externalProcess;
+            _checkMono = new AsyncLazy<bool>(CheckMonoExists);
+        }
+
+        public async Task<bool> HasMono()
+        {
+            return await _checkMono;
+        }
+
+        public async Task<ProcessOutput> Run(string workingDirectory, string command, string arguments, bool ensureSuccess)
+        {
+            _logger.Normal($"Using mono to run '{command}'");
+
+            if (!await HasMono())
+            {
+                _logger.Error($"Cannot run '{command}' on mono since mono was not found");
+                throw new InvalidOperationException("Mono was not found");
+            }
+
+            var process = new ExternalProcess(_logger);
+            var processOutput = await process.Run(workingDirectory, "mono", $"{command} {arguments}", false);
+
+            return processOutput;
+        }
+
+        private async Task<bool> CheckMonoExists()
+        {
+            var process = new ExternalProcess(_logger);
+            var result = await process.Run("", "mono", "--version", false);
+
+            return result.Success;
+        }
+    }
+}

--- a/NuKeeper.Update/Process/MonoExecutor.cs
+++ b/NuKeeper.Update/Process/MonoExecutor.cs
@@ -35,9 +35,7 @@ namespace NuKeeper.Update.Process
                 throw new InvalidOperationException("Mono installation was not found");
             }
 
-            var processOutput = await _externalProcess.Run(workingDirectory, "mono", $"{command} {arguments}", false);
-
-            return processOutput;
+            return await _externalProcess.Run(workingDirectory, "mono", $"{command} {arguments}", ensureSuccess);
         }
 
         private async Task<bool> CheckMonoExists()

--- a/NuKeeper.Update/Process/MonoExecutor.cs
+++ b/NuKeeper.Update/Process/MonoExecutor.cs
@@ -20,23 +20,22 @@ namespace NuKeeper.Update.Process
             _checkMono = new AsyncLazy<bool>(CheckMonoExists);
         }
 
-        public async Task<bool> HasMono()
+        public async Task<bool> CanRun()
         {
             return await _checkMono;
         }
 
         public async Task<ProcessOutput> Run(string workingDirectory, string command, string arguments, bool ensureSuccess)
         {
-            _logger.Normal($"Using mono to run '{command}'");
+            _logger.Normal($"Using Mono to run '{command}'");
 
-            if (!await HasMono())
+            if (!await CanRun())
             {
-                _logger.Error($"Cannot run '{command}' on mono since mono was not found");
-                throw new InvalidOperationException("Mono was not found");
+                _logger.Error($"Cannot run '{command}' on Mono since Mono installation was not found");
+                throw new InvalidOperationException("Mono installation was not found");
             }
 
-            var process = new ExternalProcess(_logger);
-            var processOutput = await process.Run(workingDirectory, "mono", $"{command} {arguments}", false);
+            var processOutput = await _externalProcess.Run(workingDirectory, "mono", $"{command} {arguments}", false);
 
             return processOutput;
         }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -57,7 +57,7 @@ namespace NuKeeper.Update.Process
                 }
                 else
                 {
-                    _logger.Normal("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
+                    _logger.Error("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
                     return;
                 }
             }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -48,7 +48,7 @@ namespace NuKeeper.Update.Process
             ProcessOutput processOutput;
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (await _monoExecutor.HasMono())
+                if (await _monoExecutor.CanRun())
                 {
                     processOutput = await _monoExecutor.Run(file.DirectoryName,
                         nuget,
@@ -57,7 +57,7 @@ namespace NuKeeper.Update.Process
                 }
                 else
                 {
-                    _logger.Normal("Cannot run NuGet.exe file restore as OS Platform is not Windows");
+                    _logger.Normal("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
                     return;
                 }
             }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -14,15 +14,18 @@ namespace NuKeeper.Update.Process
     {
         private readonly INuKeeperLogger _logger;
         private readonly INuGetPath _nuGetPath;
+        private readonly IMonoExecutor _monoExecutor;
         private readonly IExternalProcess _externalProcess;
 
         public NuGetFileRestoreCommand(
             INuKeeperLogger logger,
             INuGetPath nuGetPath,
+            IMonoExecutor monoExecutor,
             IExternalProcess externalProcess)
         {
             _logger = logger;
             _nuGetPath = nuGetPath;
+            _monoExecutor = monoExecutor;
             _externalProcess = externalProcess;
         }
 
@@ -30,17 +33,11 @@ namespace NuKeeper.Update.Process
         {
             _logger.Normal($"Nuget restore on {file.DirectoryName} {file.Name}");
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                _logger.Normal("Cannot run NuGet.exe file restore as OS Platform is not Windows");
-                return;
-            }
-
             var nuget = _nuGetPath.Executable;
 
             if (string.IsNullOrWhiteSpace(nuget))
             {
-                _logger.Normal("Cannot find NuGet exe for solution restore");
+                _logger.Normal("Cannot find NuGet.exe for solution restore");
                 return;
             }
 
@@ -48,8 +45,29 @@ namespace NuKeeper.Update.Process
 
             var restoreCommand = $"restore {file.Name} {sourcesCommandLine}  -NonInteractive";
 
-            var processOutput = await _externalProcess.Run(file.DirectoryName, nuget,
-                restoreCommand, ensureSuccess: false);
+            ProcessOutput processOutput;
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (await _monoExecutor.HasMono())
+                {
+                    processOutput = await _monoExecutor.Run(file.DirectoryName,
+                        nuget,
+                        restoreCommand,
+                        ensureSuccess: false);
+                }
+                else
+                {
+                    _logger.Normal("Cannot run NuGet.exe file restore as OS Platform is not Windows");
+                    return;
+                }
+            }
+            else
+            {
+                processOutput = await _externalProcess.Run(file.DirectoryName,
+                    nuget,
+                    restoreCommand,
+                    ensureSuccess: false);
+            }
 
             if (processOutput.Success)
             {
@@ -57,7 +75,8 @@ namespace NuKeeper.Update.Process
             }
             else
             {
-                _logger.Detailed($"Nuget restore failed on {file.DirectoryName} {file.Name}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
+                _logger.Detailed(
+                    $"Nuget restore failed on {file.DirectoryName} {file.Name}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
             }
         }
 

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -45,13 +45,13 @@ namespace NuKeeper.Update.Process
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (await _monoExecutor.HasMono())
+                if (await _monoExecutor.CanRun())
                 {
                     await _monoExecutor.Run(projectPath, nuget, updateCommand, true);
                 }
                 else
                 {
-                    _logger.Normal("Cannot run NuGet.exe file restore as OS Platform is not Windows");
+                    _logger.Normal("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
                 }
             }
             else

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -36,7 +36,7 @@ namespace NuKeeper.Update.Process
             var nuget = _nuGetPath.Executable;
             if (string.IsNullOrWhiteSpace(nuget))
             {
-                _logger.Normal("Cannot find NuGet exe for package update");
+                _logger.Normal("Cannot find NuGet.exe for package update");
                 return;
             }
 

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -51,7 +51,7 @@ namespace NuKeeper.Update.Process
                 }
                 else
                 {
-                    _logger.Normal("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
+                    _logger.Error("Cannot run NuGet.exe. It requires either Windows OS Platform or Mono installation");
                 }
             }
             else

--- a/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/NuGetUpdatePackageCommand.cs
@@ -14,26 +14,23 @@ namespace NuKeeper.Update.Process
         private readonly IExternalProcess _externalProcess;
         private readonly INuKeeperLogger _logger;
         private readonly INuGetPath _nuGetPath;
+        private readonly IMonoExecutor _monoExecutor;
 
         public NuGetUpdatePackageCommand(
             INuKeeperLogger logger,
             INuGetPath nuGetPath,
+            IMonoExecutor monoExecutor,
             IExternalProcess externalProcess)
         {
             _logger = logger;
             _nuGetPath = nuGetPath;
+            _monoExecutor = monoExecutor;
             _externalProcess = externalProcess;
         }
 
         public async Task Invoke(PackageInProject currentPackage,
             NuGetVersion newVersion, PackageSource packageSource, NuGetSources allSources)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                _logger.Normal("Cannot run NuGet.exe package update as OS Platform is not Windows");
-                return;
-            }
-
             var projectPath = currentPackage.Path.Info.DirectoryName;
 
             var nuget = _nuGetPath.Executable;
@@ -45,7 +42,22 @@ namespace NuKeeper.Update.Process
 
             var sources = allSources.CommandLine("-Source");
             var updateCommand = $"update packages.config -Id {currentPackage.Id} -Version {newVersion} {sources} -NonInteractive";
-            await _externalProcess.Run(projectPath, nuget, updateCommand, true);
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (await _monoExecutor.HasMono())
+                {
+                    await _monoExecutor.Run(projectPath, nuget, updateCommand, true);
+                }
+                else
+                {
+                    _logger.Normal("Cannot run NuGet.exe file restore as OS Platform is not Windows");
+                }
+            }
+            else
+            {
+                await _externalProcess.Run(projectPath, nuget, updateCommand, true);
+            }
         }
     }
 }

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -16,6 +16,7 @@ namespace NuKeeper
             container.Register<IUpdateNuspecCommand, UpdateNuspecCommand>();
             container.Register<IUpdateDirectoryBuildTargetsCommand, UpdateDirectoryBuildTargetsCommand>();
             container.Register<IExternalProcess, ExternalProcess>();
+            container.Register<IMonoExecutor, MonoExecutor>();
             container.Register<IUpdateRunner, UpdateRunner>();
             container.Register<INuGetPath, NuGetPath>();
         }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation is very easy. Just run this command and the tool will be installed.
 
 Install: `dotnet tool install nukeeper --global`
 
-> Note: NuKeeper has experimental support for running package updates on Linux/MacOs. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
+> Note: NuKeeper has experimental support for running package updates on Linux/macOS. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
 
 ### Platform support
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Installation is very easy. Just run this command and the tool will be installed.
 
 Install: `dotnet tool install nukeeper --global`
 
+> Note: NuKeeper has experimental support for running package updates on Linux/MacOs. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
+
 ### Platform support
 
 NuKeeper works for .NET Framework and for .NET Core projects. It also has the ability to target private NuGet feeds.

--- a/site/content/basics/installation.md
+++ b/site/content/basics/installation.md
@@ -20,7 +20,7 @@ Update NuKeeper with:
 dotnet tool update nukeeper --global
 ``` 
 
-> Note: NuKeeper has experimental support for running package updates on Linux/MacOs. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
+> Note: NuKeeper has experimental support for running package updates on Linux/macOS. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
 
 # Using NuKeeper
 

--- a/site/content/basics/installation.md
+++ b/site/content/basics/installation.md
@@ -20,6 +20,8 @@ Update NuKeeper with:
 dotnet tool update nukeeper --global
 ``` 
 
+> Note: NuKeeper has experimental support for running package updates on Linux/MacOs. This functionality relies on Mono installation on local system. Please refer to https://www.mono-project.com/ for more information about how to install mono.
+
 # Using NuKeeper
 
 Running `nukeeper` with no arguments shows the help.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
With this PR we will try to fallback to mono when running Nuget.exe commands. Crossplatform nukeeper 🎉 

### :arrow_heading_down: What is the current behavior?
We are crashing with `Cannot run NuGet.exe file restore as OS Platform is not Windows`

### :new: What is the new behavior (if this is a feature change)?
We are trying to run nuget.exe with mono.

### :boom: Does this PR introduce a breaking change?
Should not.

### :bug: Recommendations for testing
Try running it on mono on Linux or MacOS

### :memo: Links to relevant issues/docs
https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
