### PR TITLE
Fix for Casing problems Nugets

### DIFF
--- a/NuKeeper.Abstractions/RepositoryInspection/PackageUpdateSet.cs
+++ b/NuKeeper.Abstractions/RepositoryInspection/PackageUpdateSet.cs
@@ -59,12 +59,12 @@ namespace NuKeeper.Abstractions.RepositoryInspection
 
         private void CheckIdConsistency()
         {
-            if (CurrentPackages.Any(p => p.Id != SelectedId))
+            if (CurrentPackages.Any(p => !p.Id.Equals(SelectedId,StringComparison.InvariantCultureIgnoreCase)))
             {
                 var errorIds = CurrentPackages
                     .Select(p => p.Id)
                     .Distinct()
-                    .Where(id => id != SelectedId);
+                    .Where(id => !id.Equals(SelectedId,StringComparison.InvariantCultureIgnoreCase));
 
                 throw new ArgumentException($"Updates must all be for package '{SelectedId}', got '{errorIds.JoinWithCommas()}'");
             }

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -37,7 +38,7 @@ namespace NuKeeper.Inspection.NuGetApi
                 var matchVersion = latestPackage.Selected().Identity.Version;
 
                 var updatesForThisPackage = packages
-                    .Where(p => p.Id == packageId && p.Version < matchVersion)
+                    .Where(p => p.Id.Equals(packageId,StringComparison.InvariantCultureIgnoreCase) && p.Version < matchVersion)
                     .ToList();
 
                 if (updatesForThisPackage.Count > 0)

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -47,8 +48,8 @@ namespace NuKeeper.Update.Process
 
             var packageNodeList = packagesNode.Elements("PackageReference")
                 .Where(x =>
-                    (x.Attributes("Include").Any(a => a.Value == currentPackage.Id)
-                  || x.Attributes("Update").Any(a => a.Value == currentPackage.Id)));
+                    (x.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
+                  || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id,StringComparison.InvariantCultureIgnoreCase))));
 
             foreach (var dependencyToUpdate in packageNodeList)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
**Bug Fix:**
When someone adds a nuget with ```dotnet add``` and gets the casing wrong, it will be added with the wrong casing to the csproj file and Nukeeper won't recognize it for updates.

Example: 
```dotnet add package newtonsoft.json -v 8.0.1``` 
will add it as 
```<PackageReference Include="newtonsoft.json" Version="8.0.1" />```
to the .csproj file.
Visual Studio has no problem with that but NuKeeper tries to match it to "Newtonsoft.Json" and does not recognize it.

### :arrow_heading_down: What is the current behavior?
NuKeeper does not update nugets where the casing is wrong in the .csproj file

### :new: What is the new behavior (if this is a feature change)?
NuKeeper will update nugets where the casing is wrong in the .csproj file because the checks have been made case-insensitive.


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See Description

### :memo: Links to relevant issues/docs
No Issue (yet)

### :thinking: Checklist before submitting

- [X] All projects build
 
