### PR TITLE
Support labels for GitLab merge requests

### DIFF
--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Formats;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Gitlab.Model;
 using User = NuKeeper.Abstractions.CollaborationModels.User;
@@ -49,7 +50,8 @@ namespace NuKeeper.Gitlab
                 Description = request.Body,
                 TargetBranch = request.BaseRef,
                 Id = $"{projectName}/{repositoryName}",
-                RemoveSourceBranch = request.DeleteBranchAfterMerge
+                RemoveSourceBranch = request.DeleteBranchAfterMerge,
+                Labels = labels.JoinWithCommas()
             };
 
             await _client.OpenMergeRequest(projectName, repositoryName, mergeRequest);

--- a/NuKeeper.Gitlab/Model/MergeRequest.cs
+++ b/NuKeeper.Gitlab/Model/MergeRequest.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Gitlab.Model
         [JsonProperty("remove_source_branch")]
         public bool RemoveSourceBranch { get; set; }
 
-        [JsonProperty("lables")]
+        [JsonProperty("labels")]
         public string Labels { get; set; }
     }
 }

--- a/NuKeeper.Gitlab/Model/MergeRequest.cs
+++ b/NuKeeper.Gitlab/Model/MergeRequest.cs
@@ -21,5 +21,8 @@ namespace NuKeeper.Gitlab.Model
 
         [JsonProperty("remove_source_branch")]
         public bool RemoveSourceBranch { get; set; }
+
+        [JsonProperty("lables")]
+        public string Labels { get; set; }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Brings support for label to GitLab merge requests.

### :arrow_heading_down: What is the current behavior?

We don't support it.

### :new: What is the new behavior (if this is a feature change)?

We support it.

### :boom: Does this PR introduce a breaking change?

Nope.

### :bug: Recommendations for testing

Try to create a gitlab MR.

### :memo: Links to relevant issues/docs

Already supported by the API. https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
Just never bother to implement it.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
