### PR TITLE
Support for transistive dependencies.

### DIFF
--- a/NuKeeper.Abstractions/Configuration/ISettingsContainer.cs
+++ b/NuKeeper.Abstractions/Configuration/ISettingsContainer.cs
@@ -1,0 +1,17 @@
+using NuKeeper.Abstractions.Inspections.Files;
+
+namespace NuKeeper.Abstractions.Configuration
+{
+    public interface ISettingsContainer
+    {
+        SourceControlServerSettings SourceControlServerSettings { get; set; }
+
+        UserSettings UserSettings { get; set; }
+
+        FilterSettings PackageFilters { get; set; }
+
+        BranchSettings BranchSettings { get; set; }
+
+        IFolder WorkingFolder { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/UserSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/UserSettings.cs
@@ -21,5 +21,7 @@ namespace NuKeeper.Abstractions.Configuration
         public string OutputFileName { get; set; }
 
         public string Directory { get; set; }
+
+        public bool RestoreBeforePackageUpdate { get; set; }
     }
 }

--- a/NuKeeper.Update.Tests/UpdateRunnerTests.cs
+++ b/NuKeeper.Update.Tests/UpdateRunnerTests.cs
@@ -52,7 +52,7 @@ namespace NuKeeper.Update.Tests
                 _updateDirectoryBuildTargetsCommand);
         }
 
-        [TestCase(true, Description = "Should also perform dotnet restore's before each package update.")]
+        [TestCase(true, Description = "Should perform dotnet restore's before each package update.")]
         [TestCase(false, Description = "Should not perform dotnet restore's before each package update.")]
         public async Task CorrectCommandsAreExecutedForProjectFileUpdate(bool restoreBeforePackageUpdate)
         {
@@ -68,7 +68,7 @@ namespace NuKeeper.Update.Tests
             await AssertCorrectProjectFileCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
         }
 
-        [TestCase(true, Description = "Should also perform dotnet restore's before each package update.")]
+        [TestCase(true, Description = "Should perform dotnet restore's before each package update.")]
         [TestCase(false, Description = "Should not perform dotnet restore's before each package update.")]
         public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate(bool restoreBeforePackageUpdate)
         {

--- a/NuKeeper.Update.Tests/UpdateRunnerTests.cs
+++ b/NuKeeper.Update.Tests/UpdateRunnerTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.NuGetApi;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NSubstitute;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
+using NuKeeper.Abstractions.NuGet;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace NuKeeper.Update.Tests
+{
+    [TestFixture]
+    public class UpdateRunnerTests
+    {
+        private INuKeeperLogger _nuKeeperLogger;
+        private IFileRestoreCommand _fileRestoreCommand;
+        private INuGetUpdatePackageCommand _nuGetUpdatePackageCommand;
+        private IDotNetUpdatePackageCommand _dotNetUpdatePackageCommand;
+        private IDotNetRestoreCommand _dotNetRestoreCommand;
+        private IUpdateProjectImportsCommand _updateProjectImportsCommand;
+        private IUpdateNuspecCommand _updateNuspecCommand;
+        private IUpdateDirectoryBuildTargetsCommand _updateDirectoryBuildTargetsCommand;
+        private IUpdateRunner _sut;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+            _fileRestoreCommand = Substitute.For<IFileRestoreCommand>();
+            _nuGetUpdatePackageCommand = Substitute.For<INuGetUpdatePackageCommand>();
+            _dotNetUpdatePackageCommand = Substitute.For<IDotNetUpdatePackageCommand>();
+            _dotNetRestoreCommand = Substitute.For<IDotNetRestoreCommand>();
+            _updateProjectImportsCommand = Substitute.For<IUpdateProjectImportsCommand>();
+            _updateNuspecCommand = Substitute.For<IUpdateNuspecCommand>();
+            _updateDirectoryBuildTargetsCommand = Substitute.For<IUpdateDirectoryBuildTargetsCommand>();
+
+            _sut = new UpdateRunner(
+                _nuKeeperLogger,
+                _fileRestoreCommand,
+                _nuGetUpdatePackageCommand,
+                _dotNetUpdatePackageCommand,
+                _dotNetRestoreCommand,
+                _updateProjectImportsCommand,
+                _updateNuspecCommand,
+                _updateDirectoryBuildTargetsCommand);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForProjectFileUpdate_RestoreBeforePackageUpdate()
+        {
+            // Arrange
+            var restoreBeforePackageUpdate = true;
+            var packageReferenceType = PackageReferenceType.ProjectFile;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectProjectFileCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForProjectFileUpdate_NoRestoreBeforePackageUpdate()
+        {
+            // Arrange
+            var restoreBeforePackageUpdate = false;
+            var packageReferenceType = PackageReferenceType.ProjectFile;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectProjectFileCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate_RestoreBeforePackageUpdate()
+        {
+            // Arrange
+            var restoreBeforePackageUpdate = true;
+            var packageReferenceType = PackageReferenceType.ProjectFileOldStyle;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectProjectFileOldStyleCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate_NoRestoreBeforePackageUpdate()
+        {
+            // Arrange
+            var restoreBeforePackageUpdate = false;
+            var packageReferenceType = PackageReferenceType.ProjectFileOldStyle;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectProjectFileOldStyleCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForPackagesConfigUpdate()
+        {
+            // Arrange
+            var packageReferenceType = PackageReferenceType.PackagesConfig;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectPackagesConfigCommandsAreExecuted(packageUpdateSet, sources);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForNuspecUpdate()
+        {
+            // Arrange
+            var packageReferenceType = PackageReferenceType.Nuspec;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectNuspecCommandsAreExecuted(packageUpdateSet, sources);
+        }
+
+        [Test]
+        public async Task CorrectCommandsAreExecutedForDirectoryBuildTargetsUpdate()
+        {
+            // Arrange
+            var packageReferenceType = PackageReferenceType.DirectoryBuildTargets;
+            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
+            var sources = NuGetSources.GlobalFeed;
+
+            // Act
+            await _sut.Update(packageUpdateSet, sources);
+
+            // Assert
+            await AssertCorrectDirectoryBuildTargetsCommandsAreExecuted(packageUpdateSet, sources);
+        }
+
+        private async Task AssertCorrectProjectFileCommandsAreExecuted(PackageUpdateSet packageUpdateSet, NuGetSources sources, bool restoreBeforePackageUpdate)
+        {
+            if (!restoreBeforePackageUpdate)
+            {
+                await Task.WhenAll(
+                    _dotNetUpdatePackageCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                    _dotNetRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), sources));
+                return;
+            }
+
+            await Task.WhenAll(
+                _dotNetUpdatePackageCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                _dotNetRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count * 2).Invoke(Arg.Any<PackageInProject>(), sources));
+        }
+
+        private async Task AssertCorrectProjectFileOldStyleCommandsAreExecuted(PackageUpdateSet packageUpdateSet, NuGetSources sources, bool restoreBeforePackageUpdate)
+        {
+            if (!restoreBeforePackageUpdate)
+            {
+                await Task.WhenAll(
+                    _updateProjectImportsCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                    _fileRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                    _dotNetUpdatePackageCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                    _dotNetRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), sources));
+                return;
+            }
+
+            await Task.WhenAll(
+                _updateProjectImportsCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                _fileRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                _dotNetUpdatePackageCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                _dotNetRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count * 2).Invoke(Arg.Any<PackageInProject>(), sources));
+        }
+
+        private async Task AssertCorrectPackagesConfigCommandsAreExecuted(PackageUpdateSet packageUpdateSet, NuGetSources sources)
+        {
+            await Task.WhenAll(
+                _fileRestoreCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources),
+                _nuGetUpdatePackageCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources));
+        }
+
+        private async Task AssertCorrectNuspecCommandsAreExecuted(PackageUpdateSet packageUpdateSet, NuGetSources sources)
+        {
+            await _updateNuspecCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources);
+        }
+
+        private async Task AssertCorrectDirectoryBuildTargetsCommandsAreExecuted(PackageUpdateSet packageUpdateSet, NuGetSources sources)
+        {
+            await _updateDirectoryBuildTargetsCommand.Received(packageUpdateSet.CurrentPackages.Count).Invoke(Arg.Any<PackageInProject>(), Arg.Any<NuGetVersion>(), Arg.Any<PackageSource>(), sources);
+        }
+
+        private static PackageUpdateSet UpdateFooFromOneVersion(PackageReferenceType packageReferenceType, TimeSpan? packageAge = null)
+        {
+            var pubDate = DateTimeOffset.Now.Subtract(packageAge ?? TimeSpan.Zero);
+
+            var currentPackages = new List<PackageInProject>
+            {
+                new PackageInProject("foo", "1.0.1", PathToProjectOne(packageReferenceType)),
+                new PackageInProject("foo", "1.0.1", PathToProjectTwo(packageReferenceType))
+            };
+
+            var matchVersion = new NuGetVersion("4.0.0");
+            var match = new PackageSearchMetadata(new PackageIdentity("foo", matchVersion),
+                new PackageSource("http://none"), pubDate, null);
+
+            var updates = new PackageLookupResult(VersionChange.Major, match, null, null);
+            return new PackageUpdateSet(updates, currentPackages);
+        }
+
+        private static PackagePath PathToProjectOne(PackageReferenceType packageReferenceType)
+        {
+            return new PackagePath("c_temp", "projectOne", packageReferenceType);
+        }
+
+        private static PackagePath PathToProjectTwo(PackageReferenceType packageReferenceType)
+        {
+            return new PackagePath("c_temp", "projectTwo", packageReferenceType);
+        }
+    }
+}

--- a/NuKeeper.Update.Tests/UpdateRunnerTests.cs
+++ b/NuKeeper.Update.Tests/UpdateRunnerTests.cs
@@ -12,7 +12,6 @@ using NuKeeper.Update.Process;
 using NUnit.Framework;
 using NuKeeper.Abstractions.NuGet;
 using System.Threading.Tasks;
-using System.IO;
 
 namespace NuKeeper.Update.Tests
 {
@@ -20,6 +19,7 @@ namespace NuKeeper.Update.Tests
     public class UpdateRunnerTests
     {
         private INuKeeperLogger _nuKeeperLogger;
+        private ISettingsContainer _settingsContainer;
         private IFileRestoreCommand _fileRestoreCommand;
         private INuGetUpdatePackageCommand _nuGetUpdatePackageCommand;
         private IDotNetUpdatePackageCommand _dotNetUpdatePackageCommand;
@@ -33,6 +33,10 @@ namespace NuKeeper.Update.Tests
         public void SetUp()
         {
             _nuKeeperLogger = Substitute.For<INuKeeperLogger>();
+
+            _settingsContainer = Substitute.For<ISettingsContainer>();
+            _settingsContainer.UserSettings = new UserSettings();
+
             _fileRestoreCommand = Substitute.For<IFileRestoreCommand>();
             _nuGetUpdatePackageCommand = Substitute.For<INuGetUpdatePackageCommand>();
             _dotNetUpdatePackageCommand = Substitute.For<IDotNetUpdatePackageCommand>();
@@ -43,6 +47,7 @@ namespace NuKeeper.Update.Tests
 
             _sut = new UpdateRunner(
                 _nuKeeperLogger,
+                _settingsContainer,
                 _fileRestoreCommand,
                 _nuGetUpdatePackageCommand,
                 _dotNetUpdatePackageCommand,
@@ -57,6 +62,7 @@ namespace NuKeeper.Update.Tests
         public async Task CorrectCommandsAreExecutedForProjectFileUpdate(bool restoreBeforePackageUpdate)
         {
             // Arrange
+            _settingsContainer.UserSettings.RestoreBeforePackageUpdate = restoreBeforePackageUpdate;
             var packageReferenceType = PackageReferenceType.ProjectFile;
             var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
             var sources = NuGetSources.GlobalFeed;
@@ -73,6 +79,7 @@ namespace NuKeeper.Update.Tests
         public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate(bool restoreBeforePackageUpdate)
         {
             // Arrange
+            _settingsContainer.UserSettings.RestoreBeforePackageUpdate = restoreBeforePackageUpdate;
             var packageReferenceType = PackageReferenceType.ProjectFileOldStyle;
             var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
             var sources = NuGetSources.GlobalFeed;

--- a/NuKeeper.Update.Tests/UpdateRunnerTests.cs
+++ b/NuKeeper.Update.Tests/UpdateRunnerTests.cs
@@ -52,11 +52,11 @@ namespace NuKeeper.Update.Tests
                 _updateDirectoryBuildTargetsCommand);
         }
 
-        [Test]
-        public async Task CorrectCommandsAreExecutedForProjectFileUpdate_RestoreBeforePackageUpdate()
+        [TestCase(true, Description = "Should also perform dotnet restore's before each package update.")]
+        [TestCase(false, Description = "Should not perform dotnet restore's before each package update.")]
+        public async Task CorrectCommandsAreExecutedForProjectFileUpdate(bool restoreBeforePackageUpdate)
         {
             // Arrange
-            var restoreBeforePackageUpdate = true;
             var packageReferenceType = PackageReferenceType.ProjectFile;
             var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
             var sources = NuGetSources.GlobalFeed;
@@ -68,43 +68,11 @@ namespace NuKeeper.Update.Tests
             await AssertCorrectProjectFileCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
         }
 
-        [Test]
-        public async Task CorrectCommandsAreExecutedForProjectFileUpdate_NoRestoreBeforePackageUpdate()
+        [TestCase(true, Description = "Should also perform dotnet restore's before each package update.")]
+        [TestCase(false, Description = "Should not perform dotnet restore's before each package update.")]
+        public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate(bool restoreBeforePackageUpdate)
         {
             // Arrange
-            var restoreBeforePackageUpdate = false;
-            var packageReferenceType = PackageReferenceType.ProjectFile;
-            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
-            var sources = NuGetSources.GlobalFeed;
-
-            // Act
-            await _sut.Update(packageUpdateSet, sources);
-
-            // Assert
-            await AssertCorrectProjectFileCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
-        }
-
-        [Test]
-        public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate_RestoreBeforePackageUpdate()
-        {
-            // Arrange
-            var restoreBeforePackageUpdate = true;
-            var packageReferenceType = PackageReferenceType.ProjectFileOldStyle;
-            var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
-            var sources = NuGetSources.GlobalFeed;
-
-            // Act
-            await _sut.Update(packageUpdateSet, sources);
-
-            // Assert
-            await AssertCorrectProjectFileOldStyleCommandsAreExecuted(packageUpdateSet, sources, restoreBeforePackageUpdate);
-        }
-
-        [Test]
-        public async Task CorrectCommandsAreExecutedForProjectFileOldStyleUpdate_NoRestoreBeforePackageUpdate()
-        {
-            // Arrange
-            var restoreBeforePackageUpdate = false;
             var packageReferenceType = PackageReferenceType.ProjectFileOldStyle;
             var packageUpdateSet = UpdateFooFromOneVersion(packageReferenceType);
             var sources = NuGetSources.GlobalFeed;

--- a/NuKeeper.Update/Process/DotNetRestoreCommand.cs
+++ b/NuKeeper.Update/Process/DotNetRestoreCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Update.ProcessRunner;
+
+namespace NuKeeper.Update.Process
+{
+    public class DotNetRestoreCommand : IDotNetRestoreCommand
+    {
+        private readonly IExternalProcess _externalProcess;
+
+        public DotNetRestoreCommand(IExternalProcess externalProcess)
+        {
+            _externalProcess = externalProcess;
+        }
+
+        public Task Invoke(PackageInProject currentPackage, NuGetSources allSources)
+        {
+            var projectPath = currentPackage.Path.Info.DirectoryName;
+            var projectFileName = currentPackage.Path.Info.Name;
+            var sources = allSources.CommandLine("-s");
+
+            var restoreCommand = $"restore {projectFileName} {sources}";
+            return _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
+        }
+
+        public Task Invoke(PackageInProject currentPackage, NuGetVersion newVersion, PackageSource packageSource, NuGetSources allSources)
+        {
+            return Invoke(currentPackage, allSources);
+        }
+    }
+}

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Update.Process
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl} --no-restore";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
     }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -22,10 +22,6 @@ namespace NuKeeper.Update.Process
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
             var sourceUrl = packageSource.SourceUri.ToString();
-            var sources = allSources.CommandLine("-s");
-
-            var restoreCommand = $"restore {projectFileName} {sources}";
-            await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {

--- a/NuKeeper.Update/Process/IDotNetRestoreCommand.cs
+++ b/NuKeeper.Update/Process/IDotNetRestoreCommand.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+
+namespace NuKeeper.Update.Process
+{
+    public interface IDotNetRestoreCommand : IPackageCommand
+    {
+        Task Invoke(PackageInProject currentPackage, NuGetSources allSources);
+    }
+}

--- a/NuKeeper.Update/UpdateRunner.cs
+++ b/NuKeeper.Update/UpdateRunner.cs
@@ -80,10 +80,6 @@ namespace NuKeeper.Update
 
             switch (packageReferenceType)
             {
-                case PackageReferenceType.PackagesConfig:
-                    commands.Add(_fileRestoreCommand);
-                    commands.Add(_nuGetUpdatePackageCommand);
-                    break;
                 case PackageReferenceType.ProjectFileOldStyle:
                     commands.Add(_updateProjectImportsCommand);
                     commands.Add(_fileRestoreCommand);
@@ -91,6 +87,10 @@ namespace NuKeeper.Update
                     break;
                 case PackageReferenceType.ProjectFile:
                     commands.AddRange(GetDotNetUpdatePackageCommand(restoreBeforePackageUpdate));
+                    break;
+                case PackageReferenceType.PackagesConfig:
+                    commands.Add(_fileRestoreCommand);
+                    commands.Add(_nuGetUpdatePackageCommand);
                     break;
                 case PackageReferenceType.Nuspec:
                     commands.Add(_updateNuspecCommand);

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -19,6 +19,10 @@ namespace NuKeeper.Commands
             Description = "If the target branch is another branch than that you are currently on, set this to the target")]
         public string TargetBranch { get; set; }
 
+        [Option(CommandOptionType.SingleValue, ShortName = "r", LongName = "restorebeforepackageupdate",
+            Description = "Performs 'dotnet restore' before each package update. Defaults to false.")]
+        public bool? RestoreBeforePackageUpdate { get; set; }
+
         private readonly IEnumerable<ISettingsReader> _settingsReaders;
 
         public RepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory, IEnumerable<ISettingsReader> settingsReaders)
@@ -76,6 +80,7 @@ namespace NuKeeper.Commands
 
             settings.SourceControlServerSettings.Scope = ServerScope.Repository;
             settings.UserSettings.MaxRepositoriesChanged = 1;
+            settings.UserSettings.RestoreBeforePackageUpdate = RestoreBeforePackageUpdate ?? false;
             return ValidationResult.Success;
         }
     }

--- a/NuKeeper/ContainerUpdateRegistration.cs
+++ b/NuKeeper/ContainerUpdateRegistration.cs
@@ -12,6 +12,7 @@ namespace NuKeeper
             container.Register<IFileRestoreCommand, NuGetFileRestoreCommand>();
             container.Register<INuGetUpdatePackageCommand, NuGetUpdatePackageCommand>();
             container.Register<IDotNetUpdatePackageCommand, DotNetUpdatePackageCommand>();
+            container.Register<IDotNetRestoreCommand, DotNetRestoreCommand>();
             container.Register<IUpdateProjectImportsCommand, UpdateProjectImportsCommand>();
             container.Register<IUpdateNuspecCommand, UpdateNuspecCommand>();
             container.Register<IUpdateDirectoryBuildTargetsCommand, UpdateDirectoryBuildTargetsCommand>();

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -12,6 +12,7 @@ title: "Configuration"
 | exclude          | e         | _all_                     | _null_                  |
 | include          | i         | _all_                     | _null_                  |
 | source           | s         | _all_                     |[NuGet.org public api url](https://api.nuget.org/v3/index.json)|
+| restorebeforepackageupdate | r | _all_                   | false                   |
 |                  |           |                           |                         |
 | verbosity        | v         | _all_                     | Normal                  |
 | logdestination   |           | _all_                     | Console                 |
@@ -55,6 +56,7 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
 * *exclude* Do not consider packages matching this regex pattern.
 * *include* Only consider packages matching this regex pattern.
 * *source* Specifies a NuGet package source to use during the operation. This setting overrides all of the sources specified in the `NuGet.config` files. Multiple sources can be provided by specifying this option multiple times.
+* *restorebeforepackageupdate* Specifies whether NuKeeper should perform a `dotnet restore` before each package update. Defaults to false.
 
 * *verbosity*. Controls how much log data is produced. Values are, from least output to most output: `Quiet`, `Minimal`, `Normal`, `Detailed`. `Quiet` should produce no output unless there is an error, and `Detailed` is suitable for debugging issues.  You can also use short names for these log levels: `Q`, `M`, `N`, `D`.
 * *logdestination*: Where log data is sent: One of: `Console`, `File`, `Off`. Default is `Console`.


### PR DESCRIPTION
Can someone put the `Work In Progress` label on here?

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature.

### :arrow_heading_down: What is the current behavior?
Currently, NuKeeper performs a `dotnet restore` per project it is going to create a package update for.
It also performs the package update using `dotnet add package` which by default does a restore preview. Doing both of these restore's when in the middle of updating transistive packages will result in a failing restore and thus failing NuKeeper execution.

### :new: What is the new behavior (if this is a feature change)?
NuKeeper should now support transistive dependencies.

We by default no longer perform a `dotnet restore` before updating a `ProjectFileOldStyle` or `ProjectFile` project. However this behavior can be toggled with the new UserSetting: `RestoreBeforePackageUpdate`.

We now also set the `--no-restore` flag when performing the package update with `dotnet add package`, this prevents an additional restore.

After doing the package updates we are still backtracking what `ProjectFileOldStyle` or `ProjectFile` projects received package updates and we will then perform the `dotnet restore` per project at the end of the run.

### :boom: Does this PR introduce a breaking change?
Yes, but it shouldn't 'hurt'. We changed the way we are performing dotnet restore's.


### :bug: Recommendations for testing
I still need to write tests for the new and changed functionality.

### :memo: Links to relevant issues/docs
We discussed this feature at the dutch Hackathon (2019/06/25).

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
