### PR TITLE
Docker images with Mono

### DIFF
--- a/Docker/SDK2.1/Mono/Dockerfile
+++ b/Docker/SDK2.1/Mono/Dockerfile
@@ -1,0 +1,27 @@
+FROM microsoft/dotnet:2.1-sdk
+ENV PATH="${PATH}:/root/.dotnet/tools"
+RUN dotnet tool install --global NuKeeper --version 0.21.0
+
+ENV MONO_VERSION 5.18.1.3
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gnupg dirmngr \
+  && rm -rf /var/lib/apt/lists/* \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono.gpg.asc \
+  && gpgconf --kill all \
+  && rm -rf "$GNUPGHOME" \
+  && apt-key list | grep Xamarin \
+  && apt-get purge -y --auto-remove gnupg dirmngr
+
+RUN echo "deb http://download.mono-project.com/repo/debian stable-stretch/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && apt-get update \
+  && apt-get install -y mono-runtime \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update \
+  && apt-get install -y binutils curl mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENTRYPOINT ["nukeeper"]

--- a/Docker/SDK2.2/Mono/Dockerfile
+++ b/Docker/SDK2.2/Mono/Dockerfile
@@ -1,0 +1,27 @@
+FROM microsoft/dotnet:2.2-sdk
+ENV PATH="${PATH}:/root/.dotnet/tools"
+RUN dotnet tool install --global NuKeeper --add-source /app/nukeeper/
+
+ENV MONO_VERSION 5.18.1.3
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gnupg dirmngr \
+  && rm -rf /var/lib/apt/lists/* \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono.gpg.asc \
+  && gpgconf --kill all \
+  && rm -rf "$GNUPGHOME" \
+  && apt-key list | grep Xamarin \
+  && apt-get purge -y --auto-remove gnupg dirmngr
+
+RUN echo "deb http://download.mono-project.com/repo/debian stable-stretch/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && apt-get update \
+  && apt-get install -y mono-runtime \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update \
+  && apt-get install -y binutils curl mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENTRYPOINT ["nukeeper"]


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Introduces 2 more docker images (for each sdk type) that include mono installation.

Adding them as separate dockerfiles since not everyone might need it (i.e. running on Azure windows node shouldn't require it).

### :arrow_heading_down: What is the current behavior?

We don't have those images.

### :new: What is the new behavior (if this is a feature change)?

We are going to have new images.

### :boom: Does this PR introduce a breaking change?

Nope.

### :bug: Recommendations for testing

Try to run nukeeper on mono 🚀 

### :memo: Links to relevant issues/docs

Doesn't add much until this PR is merged https://github.com/NuKeeperDotNet/NuKeeper/pull/829

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
