### PR TITLE
Update Docker images to NuKeeper release 0.24.0

### DIFF
--- a/Docker/SDK2.1/Dockerfile
+++ b/Docker/SDK2.1/Dockerfile
@@ -1,4 +1,4 @@
 FROM microsoft/dotnet:2.1-sdk
-RUN dotnet tool install --global NuKeeper --version 0.21.0
+RUN dotnet tool install --global NuKeeper --version 0.24.0
 ENV PATH="${PATH}:/root/.dotnet/tools"
 ENTRYPOINT ["nukeeper"]

--- a/Docker/SDK2.2/Dockerfile
+++ b/Docker/SDK2.2/Dockerfile
@@ -1,4 +1,4 @@
 FROM microsoft/dotnet:2.2-sdk
-RUN dotnet tool install --global NuKeeper --version 0.21.0
+RUN dotnet tool install --global NuKeeper --version 0.24.0
 ENV PATH="${PATH}:/root/.dotnet/tools"
 ENTRYPOINT ["nukeeper"]


### PR DESCRIPTION
Bumps published Docker images to https://github.com/NuKeeperDotNet/NuKeeper/releases/tag/0.24.0
Like #785 but we're not that far behind now.