### PR TITLE
When there are errors during the Integration tests, the Nukeeper and Nuget log is put into the test output

### DIFF
--- a/NuKeeper.Integration.Tests/BaseTest.cs
+++ b/NuKeeper.Integration.Tests/BaseTest.cs
@@ -1,0 +1,32 @@
+using NuGet.Common;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Integration.Tests.LogHelpers;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NuKeeper.Integration.Tests
+{
+    public class BaseTest
+    {
+        private NuKeeperTestLogger _nkLogger = new NuKeeperTestLogger();
+        private NugetTestLogger _ngLogger = new NugetTestLogger();
+
+        public INuKeeperLogger NukeeperLogger => _nkLogger;
+        public ILogger NugetLogger => _ngLogger;
+
+        [TearDown]
+        public void DumpLogWithError()
+        {
+            if (TestContext.CurrentContext.Result.Outcome != ResultState.Success)
+            {
+                _nkLogger.DumpLogToTestOutput();
+                _ngLogger.DumpLogToTestOutput();
+            }
+            _nkLogger.ClearLog();
+            _ngLogger.ClearLog();
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/BaseTest.cs
+++ b/NuKeeper.Integration.Tests/BaseTest.cs
@@ -3,9 +3,6 @@ using NuKeeper.Abstractions.Logging;
 using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NuKeeper.Integration.Tests
 {

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -3,9 +3,7 @@ using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Engine;
 using NuKeeper.GitHub;
-using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
 using System.Threading.Tasks;
 

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.Engine
 {
     [TestFixture]
-    public class RepositoryFilterTests : BaseTest
+    public class RepositoryFilterTests : TestWithFailureLogging
     {
         [Test]
         public async Task ShouldFilterOutNonDotnetRepository()

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -1,17 +1,18 @@
-using System;
-using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Engine;
 using NuKeeper.GitHub;
+using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using System;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.Engine
 {
     [TestFixture]
-    public class RepositoryFilterTests
+    public class RepositoryFilterTests : BaseTest
     {
         [Test]
         public async Task ShouldFilterOutNonDotnetRepository()
@@ -37,17 +38,16 @@ namespace NuKeeper.Integration.Tests.Engine
             Assert.True(result);
         }
 
-        private static RepositoryFilter MakeRepositoryFilter()
+        private RepositoryFilter MakeRepositoryFilter()
         {
             const string testKeyWithOnlyPublicAccess = "c13d2ce7774d39ae99ddaad46bd69c3d459b9992";
-            var logger = Substitute.For<INuKeeperLogger>();
 
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
-            var gitHubClient = new OctokitClient(logger);
+            var gitHubClient = new OctokitClient(NukeeperLogger);
             gitHubClient.Initialise(new AuthSettings(new Uri("https://api.github.com"), testKeyWithOnlyPublicAccess));
             collaborationFactory.CollaborationPlatform.Returns(gitHubClient);
 
-            return new RepositoryFilter(collaborationFactory, logger);
+            return new RepositoryFilter(collaborationFactory, NukeeperLogger);
         }
     }
 }

--- a/NuKeeper.Integration.Tests/LogHelpers/NuKeeperTestLogger.cs
+++ b/NuKeeper.Integration.Tests/LogHelpers/NuKeeperTestLogger.cs
@@ -1,0 +1,83 @@
+using NuKeeper.Abstractions.Logging;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace NuKeeper.Integration.Tests.LogHelpers
+{
+    public class NuKeeperTestLogger : INuKeeperLogger
+    {
+        private readonly LogLevel _logLevel;
+
+        private readonly List<string> _buffer = new List<string>();
+
+        public NuKeeperTestLogger(LogLevel logLevel = LogLevel.Detailed)
+        {
+            _logLevel = logLevel;
+        }
+
+        public void ClearLog()
+        {
+            _buffer.Clear();
+        }
+
+        public void DumpLogToTestOutput()
+        {
+            var test = TestContext.CurrentContext.Test.Name;
+
+            if (_buffer.Count > 0)
+            {
+                TestContext.Error.WriteLine($"{test}: NuKeeper Log:");
+            }
+            foreach (var line in _buffer)
+            {
+                TestContext.Error.WriteLine(line);
+            }
+            _buffer.Clear();
+        }
+
+        public void Error(string message, Exception ex = null)
+        {
+            Log(message, ex: ex);
+        }
+
+        public void Detailed(string message)
+        {
+            Log(message, LogLevel.Detailed);
+        }
+
+        public void Minimal(string message)
+        {
+            Log(message, LogLevel.Minimal);
+        }
+
+        public void Normal(string message)
+        {
+            Log(message, LogLevel.Normal);
+        }
+
+        private void Log(string message, LogLevel? level = null, Exception ex = null)
+        {
+            var test = TestContext.CurrentContext.Test.Name;
+
+            if (_logLevel >= (level ?? LogLevel.Detailed))
+            {
+                var levelString = level?.ToString() ?? "Error";
+
+                _buffer.Add($"{test}: {levelString} - {message}");
+
+                if (ex != null)
+                {
+                    _buffer.Add($"{test}:   {ex.GetType().Name} : {ex.Message}");
+                    foreach (var line in ex.StackTrace.Split(Environment.NewLine.ToCharArray()))
+                    {
+                        if (!string.IsNullOrEmpty(line))
+                        {
+                            _buffer.Add($"{test}:     {line}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
+++ b/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
@@ -1,8 +1,6 @@
 using NuGet.Common;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.LogHelpers

--- a/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
+++ b/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
@@ -1,0 +1,108 @@
+using NuGet.Common;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Integration.Tests.LogHelpers
+{
+    class NugetTestLogger : ILogger
+    {
+        private readonly LogLevel _logLevel;
+
+        private readonly List<string> _buffer = new List<string>();
+
+        public NugetTestLogger(LogLevel logLevel = LogLevel.Verbose)
+        {
+            _logLevel = logLevel;
+        }
+
+        public void ClearLog()
+        {
+            _buffer.Clear();
+        }
+
+        public void DumpLogToTestOutput()
+        {
+            var test = TestContext.CurrentContext.Test.Name;
+
+            if (_buffer.Count > 0)
+            {
+                TestContext.Error.WriteLine($"{test}: NuGet Log:");
+            }
+
+            foreach (var line in _buffer)
+            {
+                TestContext.Error.WriteLine(line);
+            }
+            _buffer.Clear();
+        }
+
+        public void Log(LogLevel level, string data)
+        {
+            var test = TestContext.CurrentContext.Test.Name;
+
+            if (level >= _logLevel )
+            {
+                _buffer.Add($"{test}: {level} - {data}");
+            }
+        }
+
+        public void Log(ILogMessage message)
+        {
+            Log(message.Level, message.Message);
+        }
+
+        public Task LogAsync(LogLevel level, string data)
+        {
+            return Task.Run(() =>
+            {
+                Log(level, data);
+            });
+        }
+
+        public Task LogAsync(ILogMessage message)
+        {
+            return Task.Run(() =>
+            {
+                Log(message);
+            });
+        }
+
+        public void LogDebug(string data)
+        {
+            Log(LogLevel.Debug, data);
+        }
+
+        public void LogError(string data)
+        {
+            Log(LogLevel.Error, data);
+        }
+
+        public void LogInformation(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            Log(LogLevel.Minimal, data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            Log(LogLevel.Verbose, data);
+        }
+
+        public void LogWarning(string data)
+        {
+            Log(LogLevel.Warning, data);
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Api
 {
     [TestFixture]
-    public class ApiPackageLookupTests : BaseTest
+    public class ApiPackageLookupTests : TestWithFailureLogging
     {
         [Test]
         public async Task AmbiguousPackageName_ShouldReturnCorrectResult()

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -8,12 +8,14 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace NuKeeper.Integration.Tests.NuGet.Api
 {
     [TestFixture]
-    public class ApiPackageLookupTests
+    public class ApiPackageLookupTests : BaseTest
     {
         [Test]
         public async Task AmbiguousPackageName_ShouldReturnCorrectResult()
@@ -124,10 +126,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
         //            Assert.That(isBeta, Is.True);
         //        }
 
-        private static IApiPackageLookup BuildPackageLookup()
+        private IApiPackageLookup BuildPackageLookup()
         {
             return new ApiPackageLookup(
-                new PackageVersionsLookup(Substitute.For<ILogger>(), Substitute.For<INuKeeperLogger>()));
+                new PackageVersionsLookup(NugetLogger, NukeeperLogger));
         }
 
         private static PackageIdentity Current(string packageId)

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -1,16 +1,11 @@
-using System;
-using System.Threading.Tasks;
-using NSubstitute;
-using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.NuGetApi;
-using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
+using System;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Api
 {
@@ -106,25 +101,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             Assert.That(package.Minor.Identity.Version.Major, Is.EqualTo(8));
             Assert.That(package.Major.Identity.Version.Major, Is.GreaterThan(8));
         }
-
-        //        [Test]
-        //        public async Task BetaVersion_ShouldReturnBetas()
-        //        {
-        //            var lookup = BuildPackageLookup();
-        //
-        //            // libgit2sharp is known for staying in preview for ages
-        //            var package = await lookup.FindVersionUpdate(
-        //                new PackageIdentity("libgit2sharp", new NuGetVersion(0, 26, 0, "preview-0017")),
-        //                NuGetSources.GlobalFeed,
-        //                VersionChange.Minor,
-        //                UsePrerelease.FromPrerelease);
-        //
-        //            Assert.That(package, Is.Not.Null);
-        //            Assert.That(package.Selected(), Is.Not.Null);
-        //
-        //            var isBeta = package.Patch.Identity.Version.IsPrerelease;
-        //            Assert.That(isBeta, Is.True);
-        //        }
 
         private IApiPackageLookup BuildPackageLookup()
         {

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Api
 {
     [TestFixture]
-    public class BulkPackageLookupTests : BaseTest
+    public class BulkPackageLookupTests : TestWithFailureLogging
     {
         [Test]
         public async Task CanFindUpdateForOneWellKnownPackage()

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -1,14 +1,9 @@
-using NSubstitute;
-using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.NuGetApi;
-using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using NSubstitute;
 using NuGet.Common;
 using NuGet.Packaging.Core;
@@ -10,12 +6,18 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Inspection.NuGetApi;
+using NuKeeper.Integration.Tests.LogHelpers;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Api
 {
     [TestFixture]
-    public class BulkPackageLookupTests
+    public class BulkPackageLookupTests : BaseTest
     {
         [Test]
         public async Task CanFindUpdateForOneWellKnownPackage()
@@ -129,12 +131,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             Assert.That(results, Does.ContainKey("Newtonsoft.Json"));
         }
 
-        private static BulkPackageLookup BuildBulkPackageLookup()
+        private BulkPackageLookup BuildBulkPackageLookup()
         {
-            var nuKeeperLogger = Substitute.For<INuKeeperLogger>();
-            var lookup = new ApiPackageLookup(new PackageVersionsLookup(
-                Substitute.For<ILogger>(), nuKeeperLogger));
-            return new BulkPackageLookup(lookup, new PackageLookupResultReporter(nuKeeperLogger));
+            var lookup = new ApiPackageLookup(new PackageVersionsLookup(NugetLogger, NukeeperLogger));
+            return new BulkPackageLookup(lookup, new PackageLookupResultReporter(NukeeperLogger));
         }
 
         private static PackageIdentity Current(string packageId)

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.Nuget.Api
 {
     [TestFixture]
-    public class PackageVersionsLookupTests : BaseTest
+    public class PackageVersionsLookupTests : TestWithFailureLogging
     {
         [Test]
         public async Task WellKnownPackageName_ShouldReturnResultsList()

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -1,13 +1,10 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using NSubstitute;
-using NuGet.Common;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Abstractions.NuGetApi;
 using NuKeeper.Inspection.NuGetApi;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.Nuget.Api
 {

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.Nuget.Api
 {
     [TestFixture]
-    public class PackageVersionsLookupTests
+    public class PackageVersionsLookupTests : BaseTest
     {
         [Test]
         public async Task WellKnownPackageName_ShouldReturnResultsList()
@@ -130,10 +130,9 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
             }
         }
 
-        private static IPackageVersionsLookup BuildPackageLookup()
+        private IPackageVersionsLookup BuildPackageLookup()
         {
-            return new PackageVersionsLookup(
-                Substitute.For<ILogger>(), Substitute.For<INuKeeperLogger>());
+            return new PackageVersionsLookup(NugetLogger, NukeeperLogger);
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class DotNetUpdatePackageCommandTests : BaseTest
+    public class DotNetUpdatePackageCommandTests : TestWithFailureLogging
     {
         private readonly string _testWebApiProject =
 @"<Project ToolsVersion=""15.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -17,7 +17,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class DotNetUpdatePackageCommandTests
+    public class DotNetUpdatePackageCommandTests : BaseTest
     {
         private readonly string _testWebApiProject =
 @"<Project ToolsVersion=""15.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
@@ -131,7 +131,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var projectPath = Path.Combine(workDirectory, testProject);
             await File.WriteAllTextAsync(projectPath, projectContents);
 
-            var command = new DotNetUpdatePackageCommand(new ExternalProcess(Substitute.For<INuKeeperLogger>()));
+            var command = new DotNetUpdatePackageCommand(new ExternalProcess(NukeeperLogger));
 
             var packageToUpdate = new PackageInProject("Microsoft.AspNet.WebApi.Client", oldPackageVersion,
                 new PackagePath(workDirectory, testProject, packageReferenceType));
@@ -145,9 +145,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
                 Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase)));
         }
 
-        private static IFolder UniqueTemporaryFolder()
+        private IFolder UniqueTemporaryFolder()
         {
-            var factory = new FolderFactory(Substitute.For<INuKeeperLogger>());
+            var factory = new FolderFactory(NukeeperLogger);
             return factory.UniqueTemporaryFolder();
         }
     }

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -1,18 +1,16 @@
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Inspections.Files;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Update.Process;
 using NuKeeper.Update.ProcessRunner;
 using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
@@ -1,5 +1,3 @@
-using NSubstitute;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
 

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class NuGetPathTests : BaseTest
+    public class NuGetPathTests : TestWithFailureLogging
     {
         [Test]
         public void HasNugetPath()

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetPathTests.cs
@@ -6,12 +6,12 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class NuGetPathTests
+    public class NuGetPathTests : BaseTest
     {
         [Test]
         public void HasNugetPath()
         {
-            var nugetPath = new NuGetPath(Substitute.For<INuKeeperLogger>()).Executable;
+            var nugetPath = new NuGetPath(NukeeperLogger).Executable;
 
             Assert.That(nugetPath, Is.Not.Empty);
             FileAssert.Exists(nugetPath);

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -1,17 +1,15 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
-using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Inspections.Files;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
-using NUnit.Framework;
+using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Update.Process;
 using NuKeeper.Update.ProcessRunner;
-using NuKeeper.Abstractions.RepositoryInspection;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -16,7 +16,7 @@ using NuKeeper.Abstractions.RepositoryInspection;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class NuGetUpdatePackageCommandTests
+    public class NuGetUpdatePackageCommandTests : BaseTest
     {
         private readonly string _testDotNetClassicProject =
             @"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
@@ -75,7 +75,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
 
             await File.WriteAllTextAsync(Path.Combine(workDirectory, "nuget.config"), _nugetConfig);
 
-            var logger = Substitute.For<INuKeeperLogger>();
+            var logger = NukeeperLogger;
             var externalProcess = new ExternalProcess(logger);
 
             var monoExecutor = new MonoExecutor(logger, externalProcess);
@@ -103,9 +103,9 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
                     StringComparison.OrdinalIgnoreCase)));
         }
 
-        private static IFolder UniqueTemporaryFolder()
+        private IFolder UniqueTemporaryFolder()
         {
-            var factory = new FolderFactory(Substitute.For<INuKeeperLogger>());
+            var factory = new FolderFactory(NukeeperLogger);
             return factory.UniqueTemporaryFolder();
         }
     }

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class NuGetUpdatePackageCommandTests : BaseTest
+    public class NuGetUpdatePackageCommandTests : TestWithFailureLogging
     {
         private readonly string _testDotNetClassicProject =
             @"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class UpdateDirectoryBuildTargetsCommandTests
+    public class UpdateDirectoryBuildTargetsCommandTests : BaseTest
     {
         private readonly string _testFileWithUpdate =
 @"<Project><ItemGroup><PackageReference Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
@@ -33,7 +33,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageReference Include=\"foo\" Version=\"{packageVersion}\" />");
         }
 
-        private static async Task ExecuteValidUpdateTest(string testProjectContents, string expectedPackageString, [CallerMemberName] string memberName = "")
+        private async Task ExecuteValidUpdateTest(string testProjectContents, string expectedPackageString, [CallerMemberName] string memberName = "")
         {
             const string oldPackageVersion = "5.2.31";
             const string newPackageVersion = "5.3.4";
@@ -46,7 +46,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var projectPath = Path.Combine(workDirectory, testFile);
             await File.WriteAllTextAsync(projectPath, projectContents);
 
-            var command = new UpdateDirectoryBuildTargetsCommand(Substitute.For<INuKeeperLogger>());
+            var command = new UpdateDirectoryBuildTargetsCommand(NukeeperLogger);
 
             var package = new PackageInProject("foo", oldPackageVersion,
                 new PackagePath(workDirectory, testFile, PackageReferenceType.DirectoryBuildTargets));

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
@@ -1,14 +1,12 @@
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-using NSubstitute;
 using NuGet.Versioning;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandTests.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class UpdateDirectoryBuildTargetsCommandTests : BaseTest
+    public class UpdateDirectoryBuildTargetsCommandTests : TestWithFailureLogging
     {
         private readonly string _testFileWithUpdate =
 @"<Project><ItemGroup><PackageReference Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class UpdateNuspecCommandTests
+    public class UpdateNuspecCommandTests : BaseTest
     {
         private readonly string _testNuspec =
 @"<package><metadata><dependencies>
@@ -27,7 +27,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await ExecuteValidUpdateTest(_testNuspec);
         }
 
-        private static async Task ExecuteValidUpdateTest(string testProjectContents, [CallerMemberName] string memberName = "")
+        private async Task ExecuteValidUpdateTest(string testProjectContents, [CallerMemberName] string memberName = "")
         {
             const string oldPackageVersion = "5.2.31";
             const string newPackageVersion = "5.3.4";
@@ -42,7 +42,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             var projectPath = Path.Combine(workDirectory, testNuspec);
             await File.WriteAllTextAsync(projectPath, projectContents);
 
-            var command = new UpdateNuspecCommand(Substitute.For<INuKeeperLogger>());
+            var command = new UpdateNuspecCommand(NukeeperLogger);
 
             var package = new PackageInProject("foo", oldPackageVersion,
                 new PackagePath(workDirectory, testNuspec, PackageReferenceType.Nuspec));

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -1,14 +1,12 @@
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-using NSubstitute;
 using NuGet.Versioning;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateNuspecCommandTests.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class UpdateNuspecCommandTests : BaseTest
+    public class UpdateNuspecCommandTests : TestWithFailureLogging
     {
         private readonly string _testNuspec =
 @"<package><metadata><dependencies>

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateProjectImportsCommandTests.cs
@@ -1,11 +1,10 @@
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using NuKeeper.Abstractions.NuGet;
-using NuKeeper.Abstractions.RepositoryInspection;
-using NuKeeper.Inspection.RepositoryInspection;
-using NuKeeper.Update.Process;
-using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -1,10 +1,8 @@
+using NuKeeper.Update.ProcessRunner;
+using NUnit.Framework;
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
-using NSubstitute;
-using NuKeeper.Abstractions.Logging;
-using NuKeeper.Update.ProcessRunner;
-using NUnit.Framework;
 
 namespace NuKeeper.Integration.Tests.ProcessRunner
 {

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.ProcessRunner
 {
     [TestFixture]
-    public class ExternalProcessTests
+    public class ExternalProcessTests : BaseTest
     {
         [Test]
         public async Task ValidCommandShouldSucceed()
@@ -44,14 +44,14 @@ namespace NuKeeper.Integration.Tests.ProcessRunner
                 () => RunExternalProcess(Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture), true));
         }
 
-        private static async Task<ProcessOutput> RunExternalProcess(string command, bool ensureSuccess)
+        private async Task<ProcessOutput> RunExternalProcess(string command, bool ensureSuccess)
         {
             return await RunExternalProcess(command, "", ensureSuccess);
         }
 
-        private static async Task<ProcessOutput> RunExternalProcess(string command, string args, bool ensureSuccess)
+        private async Task<ProcessOutput> RunExternalProcess(string command, string args, bool ensureSuccess)
         {
-            IExternalProcess process = new ExternalProcess(Substitute.For<INuKeeperLogger>());
+            IExternalProcess process = new ExternalProcess(NukeeperLogger);
             return await process.Run(".", command, args, ensureSuccess);
         }
 

--- a/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
+++ b/NuKeeper.Integration.Tests/ProcessRunner/ExternalProcessTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace NuKeeper.Integration.Tests.ProcessRunner
 {
     [TestFixture]
-    public class ExternalProcessTests : BaseTest
+    public class ExternalProcessTests : TestWithFailureLogging
     {
         [Test]
         public async Task ValidCommandShouldSucceed()

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -1,15 +1,13 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using NSubstitute;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Inspections.Files;
-using NuKeeper.Abstractions.Logging;
 using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.RepositoryInspection;
 using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace NuKeeper.Integration.Tests.RepositoryInspection
 {

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace NuKeeper.Integration.Tests.RepositoryInspection
 {
     [TestFixture]
-    public class RepositoryScannerTests
+    public class RepositoryScannerTests : BaseTest
     {
         const string SinglePackageInFile =
             @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -230,7 +230,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
         public void SelfTest()
         {
             var scanner = MakeScanner();
-            var baseFolder = new Folder(Substitute.For<INuKeeperLogger>(), GetOwnRootDir());
+            var baseFolder = new Folder(NukeeperLogger, GetOwnRootDir());
 
             var results = scanner.FindAllNuGetPackages(baseFolder);
 
@@ -253,15 +253,15 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             return projectRootDir;
         }
 
-        private static IFolder UniqueTemporaryFolder()
+        private IFolder UniqueTemporaryFolder()
         {
-            var folderFactory = new FolderFactory(Substitute.For<INuKeeperLogger>());
+            var folderFactory = new FolderFactory(NukeeperLogger);
             return folderFactory.UniqueTemporaryFolder();
         }
 
-        private static IRepositoryScanner MakeScanner()
+        private IRepositoryScanner MakeScanner()
         {
-            var logger = Substitute.For<INuKeeperLogger>();
+            var logger = NukeeperLogger;
             return new RepositoryScanner(
                 new ProjectFileReader(logger),
                 new PackagesFileReader(logger),

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 namespace NuKeeper.Integration.Tests.RepositoryInspection
 {
     [TestFixture]
-    public class RepositoryScannerTests : BaseTest
+    public class RepositoryScannerTests : TestWithFailureLogging
     {
         const string SinglePackageInFile =
             @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/NuKeeper.Integration.Tests/TestWithFailureLogging.cs
+++ b/NuKeeper.Integration.Tests/TestWithFailureLogging.cs
@@ -6,7 +6,7 @@ using NUnit.Framework.Interfaces;
 
 namespace NuKeeper.Integration.Tests
 {
-    public class BaseTest
+    public abstract class TestWithFailureLogging
     {
         private NuKeeperTestLogger _nkLogger = new NuKeeperTestLogger();
         private NugetTestLogger _ngLogger = new NugetTestLogger();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
In the Integration tests, some tests are sometimes failing without a clear reason.
With this change, whenever a test fails, it wil put the output of the logging into the output of the test.

### :arrow_heading_down: What is the current behavior?
No logging available

### :new: What is the new behavior (if this is a feature change)?
Logging available

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Fail a test

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
