### PR TITLE
Automatic update of coverlet.msbuild to 2.6.3

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
    <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -3,7 +3,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -3,7 +3,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `coverlet.msbuild` to `2.6.3` from `2.6.1`
`coverlet.msbuild 2.6.3` was published at `2019-07-01T10:00:44Z`, 1 month ago

9 project updates:
Updated `NuKeeper.Abstractions.Tests\NuKeeper.Abstractions.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `Nukeeper.AzureDevOps.Tests\Nukeeper.AzureDevOps.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Gitea.Tests\NuKeeper.Gitea.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.GitHub.Tests\NuKeeper.GitHub.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`
Updated `NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj` to `coverlet.msbuild` `2.6.3` from `2.6.1`

[coverlet.msbuild 2.6.3 on NuGet.org](https://www.nuget.org/packages/coverlet.msbuild/2.6.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
