### PR TITLE
Automatic update of Microsoft.CodeQuality.Analyzers to 2.9.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.2" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeQuality.Analyzers` to `2.9.4` from `2.9.2`
`Microsoft.CodeQuality.Analyzers 2.9.4` was published at `2019-07-29T17:05:36Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeQuality.Analyzers` `2.9.4` from `2.9.2`

[Microsoft.CodeQuality.Analyzers 2.9.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeQuality.Analyzers/2.9.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
