### PR TITLE
Added support Imports and GlobalPackageReference

### DIFF
--- a/NuKeeper.Abstractions/RepositoryInspection/PackageReferenceType.cs
+++ b/NuKeeper.Abstractions/RepositoryInspection/PackageReferenceType.cs
@@ -6,6 +6,7 @@ namespace NuKeeper.Abstractions.RepositoryInspection
         ProjectFile,
         ProjectFileOldStyle,
         Nuspec,
-        DirectoryBuildTargets
+        DirectoryBuildTargets,
+        ProjectImport
     }
 }

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
@@ -18,6 +18,8 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             @"<Project><ItemGroup><PackageReference Include=""foo"" Version=""1.2.3.4"" /></ItemGroup></Project>";
         const string GlobalPackageReferenceFileWithSinglePackage =
             @"<Project><ItemGroup><GlobalPackageReference Include=""foo"" Version=""1.2.3.4"" /></ItemGroup></Project>";
+        const string SdkFileWithSinglePackage =
+            @"<Project><Sdk Name=""foo"" Version=""1.2.3.4"" /></Project>";
 
         private const string PackagesFileWithTwoPackages = @"<Project><ItemGroup>
 <PackageReference Include=""foo"" Version=""1.2.3.4"" />
@@ -95,6 +97,40 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         {
             var reader = MakeReader();
             var packages = reader.Read(StreamFromString(GlobalPackageReferenceFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Id, Is.EqualTo("foo"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
+        public void SingleSdkShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(SdkFileWithSinglePackage), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Not.Empty);
+        }
+
+        [Test]
+        public void SingleSdkShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(SdkFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SingleSdkShouldBeCorrect()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(SdkFileWithSinglePackage), TempPath());
 
             var package = packages.FirstOrDefault();
 

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderTests.cs
@@ -251,6 +251,29 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         }
 
         [Test]
+        public void ThreePackagesShouldBeReadByCentralPackagesFileBeRead()
+        {
+            var temp = Path.Combine(_uniqueTemporaryFolder.FullPath, Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + ".props");
+            File.WriteAllText(temp, PackagesFileWithTwoPackages);
+            var PackagesFileWithImport = $@"<Project>
+<PropertyGroup>
+<CentralPackagesFile>{Path.GetRelativePath(_uniqueTemporaryFolder.FullPath, temp)}</CentralPackagesFile>
+</PropertyGroup>
+</Project>";
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithImport), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+
+            Assert.That(packages[1].Id, Is.EqualTo("bar"));
+            Assert.That(packages[1].Version, Is.EqualTo(new NuGetVersion("2.3.4.5")));
+        }
+
+        [Test]
         public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
         {
             var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/ProjectFileReaderTests.cs
@@ -288,7 +288,7 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
         }
 
         [Test]
-        public void WhenThreePackagesAreRead_ValuesAreCorrect_WithGlobalPackageReference()
+        public void WhenThreePackagesAreRead_ValuesAreCorrect_WithImport()
         {
             var temp = Path.GetTempFileName();
             var projectFile = $@"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -319,6 +319,42 @@ namespace NuKeeper.Inspection.Tests.RepositoryInspection
             {
                 File.Delete(temp);
             }
+        }
+
+        [Test]
+        public void WhenOnePackagesAreRead_ValuesAreCorrect_WithSdk()
+        {
+            var projectFile = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Sdk Name=""foo"" Version=""4.3.2"" />
+</Project>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
+                .ToList();
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("4.3.2")));
+            Assert.That(packages[0].Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
+        public void WhenZeroPackagesAreRead_NoVersion_WithSdk()
+        {
+            var projectFile = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Sdk Name=""foo"" />
+</Project>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(projectFile), _sampleDirectory, _sampleFile)
+                .ToList();
+
+            Assert.That(packages, Is.Empty);
         }
 
         [Test]

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -52,21 +52,16 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return Array.Empty<PackageInProject>();
             }
 
-            var importNodes = project.Elements("Import");
-            foreach (var import in importNodes)
+            var imports = MsBuildExtensions.ExtractImports(project, Path.GetDirectoryName(path.RelativePath));
+            foreach (var importPath in imports)
             {
-                var projectAttribute = import.Attribute("Project");
-                if (projectAttribute == null) continue;
-                var importPath = projectAttribute.Value
-                    .Replace("$(MSBuildThisFileDirectory)", "")
-                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                 try
                 {
                     results.AddRange(ReadFile(path.BaseDirectory, importPath));
                 }
                 catch (NuKeeperException)
                 {
-                    _logger.Detailed($"Unable to handle path for importPath {importPath}");
+                    _logger.Detailed($"Unable to handle path for importPath {importPath} with base directory {path.BaseDirectory} {path.RelativePath}");
                 }
             }
 

--- a/NuKeeper.Inspection/RepositoryInspection/MsBuildExtensions.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/MsBuildExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NuKeeper.Inspection.RepositoryInspection
+{
+    internal static class MsBuildExtensions
+    {
+        public static IEnumerable<string> ExtractImports(XElement project, string relativePath)
+        {
+            var msBuildBaseDirectory =
+                (relativePath.EndsWith(Path.AltDirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase) || relativePath.EndsWith(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+                ? relativePath
+                : $"{relativePath}{Path.DirectorySeparatorChar}";
+
+            var centralPackagesFile = project.Elements("PropertyGroup")
+                .SelectMany(pg => pg.Elements("CentralPackagesFile"))
+                .FirstOrDefault();
+            if (centralPackagesFile != null)
+            {
+                yield return centralPackagesFile.Value
+                    .Replace("$(MSBuildThisFileDirectory)", msBuildBaseDirectory)
+                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            }
+
+            var importNodes = project.Elements("Import");
+            foreach (var import in importNodes)
+            {
+
+                var projectAttribute = import.Attribute("Project");
+                if (projectAttribute == null) continue;
+                var importPath = projectAttribute.Value
+                    .Replace("$(MSBuildThisFileDirectory)", msBuildBaseDirectory)
+                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                yield return importPath;
+            }
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -59,21 +59,16 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return Array.Empty<PackageInProject>();
             }
 
-            var importNodes = project.Elements("Import");
-            foreach (var import in importNodes)
+            var imports = MsBuildExtensions.ExtractImports(project, Path.GetDirectoryName(path.RelativePath));
+            foreach (var importPath in imports)
             {
-                var projectAttribute = import.Attribute("Project");
-                if (projectAttribute == null) continue;
-                var importPath = projectAttribute.Value
-                    .Replace("$(MSBuildThisFileDirectory)", "")
-                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                 try
                 {
                     results.AddRange(_directoryBuildTargetsReader.ReadFile(path.BaseDirectory, importPath));
                 }
                 catch (NuKeeperException)
                 {
-                    _logger.Detailed($"Unable to handle path for importPath {importPath}");
+                    _logger.Detailed($"Unable to handle path for importPath {importPath} with base directory {baseDirectory} {relativePath}");
                 }
             }
 

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -47,6 +47,7 @@ namespace NuKeeper.Update.Process
             }
 
             var packageNodeList = packagesNode.Elements("PackageReference")
+                .Concat(packagesNode.Elements("GlobalPackageReference"))
                 .Where(x =>
                     (x.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
                   || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id,StringComparison.InvariantCultureIgnoreCase))));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
* Imported projects are not inspected when searching through Project files or `Directory.Build.props`/`Directory.Build.targets`
* The `Sdk` element is picked up for updates when it's using the `Version` attribute.
* The `GlobalPackageReference` from [Microsoft.Build.CentralPackageVersions](https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions) is not picked up for updates.

### :new: What is the new behavior (if this is a feature change)?
* This change adds logic to support `Import` elements, pretty naively, there are all sorts of MSBuild properties that could be used here, but it works for simple `<Import Project="path/to/project.props" />`.
* Adds support for the `Sdk` element (`<Sdk Name="foo" Version="1.2.3" />`)
* Adds support for `GlobalPackageReference` from [Microsoft.Build.CentralPackageVersions](https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions) (which is a shorthand for `<PackageReference IncludeAssets="Analyzers;Build" PrivateAssets="All" />`)

### :boom: Does this PR introduce a breaking change?
Not that I'm aware of, the new functionality should be additive.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
I couldn't find any.  There didn't really seem to be a good way to introduce files to be found that weren't patterns, so I don't know if this implementation is the best, but it was the most straight forward as `RepositoryScanner` is focused on just file paths.

### :thinking: Checklist before submitting

- [X] All projects build
- [ ] Relevant documentation was updated 
    Let me know if any docs need to be added or updated, and I'll make the adjustment!
