### PR TITLE
Initialize NuGet's Credential Service

### DIFF
--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -90,10 +90,12 @@ namespace NuKeeper.Tests.Local
 
             var logger = Substitute.For<INuKeeperLogger>();
 
-            var reporter = Substitute.For<IReporter>();
+            var nugetLogger = Substitute.For<NuGet.Common.ILogger>();
 
+            var reporter = Substitute.For<IReporter>();
+            
             var engine = new LocalEngine(reader, finder, sorter, updater,
-                reporter, logger);
+                reporter, logger, nugetLogger);
             Assert.That(engine, Is.Not.Null);
             return engine;
         }

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Credentials;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Inspections.Files;
@@ -25,6 +26,7 @@ namespace NuKeeper.Local
         private readonly ILocalUpdater _updater;
         private readonly IReporter _reporter;
         private readonly INuKeeperLogger _logger;
+        private readonly ILogger _nugetLogger;
 
         public LocalEngine(
             INuGetSourcesReader nuGetSourcesReader,
@@ -32,7 +34,8 @@ namespace NuKeeper.Local
             IPackageUpdateSetSort sorter,
             ILocalUpdater updater,
             IReporter reporter,
-            INuKeeperLogger logger)
+            INuKeeperLogger logger,
+            ILogger nugetLogger)
         {
             _nuGetSourcesReader = nuGetSourcesReader;
             _updateFinder = updateFinder;
@@ -40,11 +43,12 @@ namespace NuKeeper.Local
             _updater = updater;
             _reporter = reporter;
             _logger = logger;
+            _nugetLogger = nugetLogger;
         }
 
         public async Task Run(SettingsContainer settings, bool write)
         {
-            DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGet.Common.NullLogger(), true);
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(_nugetLogger, true);
 
             var folder = TargetFolder(settings.UserSettings);
 

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NuGet.Credentials;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
@@ -43,6 +44,8 @@ namespace NuKeeper.Local
 
         public async Task Run(SettingsContainer settings, bool write)
         {
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGet.Common.NullLogger(), true);
+
             var folder = TargetFolder(settings.UserSettings);
 
             var sources = _nuGetSourcesReader.Read(folder, settings.UserSettings.NuGetSources);

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Credentials" Version="5.2.0" />
     <PackageReference Include="SimpleInjector" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Somewhere between feature and bug fix.

### :arrow_heading_down: What is the current behavior?

When performing NuGet operations against private/authenticated feeds, Current behavior assumes that auth is done solely via basic http authentication. This is not always true in some cases (Azure DevOps Artifacts in my case) and NuGet has a plugin framework for credentials management.

### :new: What is the new behavior (if this is a feature change)?

We initialize NuGet's credentials service before performing operations, allowing the usage of NuGet's own providers for that. In my case, Microsoft's Azure Artifacts credentials provider.

### :boom: Does this PR introduce a breaking change?

Possibly, If a user has credentials providers installed that will override the old auth system.

### :bug: Recommendations for testing

The auth tests i saw seem to cover these cases, But we might consider adding more tests that specifically use the credential providers and/or Azure Artifacts authentication. It might be too much of an overhead though.

### :memo: Links to relevant issues/docs

https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-exe-credential-providers
https://github.com/microsoft/artifacts-credprovider

#542 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated (Not sure what constitutes relevant in this case - I'll be happy to do so with some pointers)