### PR TITLE
Automatic update of SimpleInjector to 4.7.1

### DIFF
--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="SimpleInjector" Version="4.6.2" />
+    <PackageReference Include="SimpleInjector" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="4.6.2" />
+    <PackageReference Include="SimpleInjector" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `SimpleInjector` to `4.7.1` from `4.6.2`
`SimpleInjector 4.7.1` was published at `2019-09-02T08:42:30Z`, 14 days ago

2 project updates:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector` `4.7.1` from `4.6.2`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `SimpleInjector` `4.7.1` from `4.6.2`

[SimpleInjector 4.7.1 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/4.7.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
