### PR TITLE
Automatic update of LibGit2Sharp to 0.26.1

### DIFF
--- a/NuKeeper.Git/NuKeeper.Git.csproj
+++ b/NuKeeper.Git/NuKeeper.Git.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `LibGit2Sharp` to `0.26.1` from `0.26.0`
`LibGit2Sharp 0.26.1` was published at `2019-08-13T21:00:23Z`, 1 month ago

1 project update:
Updated `NuKeeper.Git\NuKeeper.Git.csproj` to `LibGit2Sharp` `0.26.1` from `0.26.0`

[LibGit2Sharp 0.26.1 on NuGet.org](https://www.nuget.org/packages/LibGit2Sharp/0.26.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
