### PR TITLE
Automatic update of NuGet.CommandLine to 5.2.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.1.0">
+    <PackageReference Include="NuGet.CommandLine" Version="5.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -35,7 +35,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)\nuget.commandline\5.1.0\tools\NuGet.exe">
+    <Content Include="$(NuGetPackageRoot)\nuget.commandline\5.2.0\tools\NuGet.exe">
       <Pack>true</Pack>
       <PackagePath>tools\netcoreapp2.1\any\NuGet.exe</PackagePath>
     </Content>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.CommandLine` to `5.2.0` from `5.1.0`
`NuGet.CommandLine 5.2.0` was published at `2019-09-04T21:25:31Z`, 11 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.CommandLine` `5.2.0` from `5.1.0`

[NuGet.CommandLine 5.2.0 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/5.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
