### PR TITLE
Automatic update of System.Text.Encoding.CodePages to 4.6.0

### DIFF
--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="5.2.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.Text.Encoding.CodePages` to `4.6.0` from `4.5.1`
`System.Text.Encoding.CodePages 4.6.0` was published at `2019-09-23T14:17:03Z`, 16 days ago

1 project update:
Updated `NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `System.Text.Encoding.CodePages` `4.6.0` from `4.5.1`

[System.Text.Encoding.CodePages 4.6.0 on NuGet.org](https://www.nuget.org/packages/System.Text.Encoding.CodePages/4.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
