### PR TITLE
Automatic update of McMaster.Extensions.CommandLineUtils to 2.4.2

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.2" />
     <PackageReference Include="NuGet.Protocol" Version="5.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `McMaster.Extensions.CommandLineUtils` to `2.4.2` from `2.3.4`
`McMaster.Extensions.CommandLineUtils 2.4.2` was published at `2019-09-24T16:11:58Z`, 15 days ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `McMaster.Extensions.CommandLineUtils` `2.4.2` from `2.3.4`

[McMaster.Extensions.CommandLineUtils 2.4.2 on NuGet.org](https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils/2.4.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
