### PR TITLE
Automatic update of Octokit to 0.36.0

### DIFF
--- a/NuKeeper.GitHub/NuKeeper.GitHub.csproj
+++ b/NuKeeper.GitHub/NuKeeper.GitHub.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.34.0" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Octokit" Version="0.34.0" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Octokit` to `0.36.0` from `0.34.0`
`Octokit 0.36.0` was published at `2019-10-08T00:25:36Z`, 8 days ago

2 project updates:
Updated `NuKeeper.GitHub\NuKeeper.GitHub.csproj` to `Octokit` `0.36.0` from `0.34.0`
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `Octokit` `0.36.0` from `0.34.0`

[Octokit 0.36.0 on NuGet.org](https://www.nuget.org/packages/Octokit/0.36.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
