### PR TITLE
Switch repo name in tests from deprecated dotnet/cli to the new dotne…

### DIFF
--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -33,7 +33,7 @@ namespace NuKeeper.Integration.Tests.Engine
             IRepositoryFilter subject = MakeRepositoryFilter();
 
             var result =
-                await subject.ContainsDotNetProjects(new RepositorySettings { RepositoryName = "cli", RepositoryOwner = "dotnet" });
+                await subject.ContainsDotNetProjects(new RepositorySettings { RepositoryName = "sdk", RepositoryOwner = "dotnet" });
             Assert.True(result);
         }
 


### PR DESCRIPTION
…t/sdk

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix a broken test referring to the now-deprecated dotnet/cli repo.
