### PR TITLE
Added support for PackageDownload items

### DIFF
--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -51,7 +51,8 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return Array.Empty<PackageInProject>();
             }
 
-            var packageNodeList = packagesNode.Elements("PackageReference");
+            var packageNodeList = packagesNode.Elements("PackageReference")
+                .Concat(packagesNode.Elements("PackageDownload"));
 
             return packageNodeList
                 .Select(el => XmlToPackage(el, path))
@@ -66,7 +67,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
             {
                 id = el.Attribute("Update")?.Value;
             }
-            var version = el.Attribute("Version")?.Value;
+            var version = (el.Attribute("Version")?.Value ?? el.Element("Version")?.Value)?.Trim('[', ']');
 
             return _packageInProjectReader.Read(id, version, path, null);
         }

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -46,16 +46,28 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
-            var packageNodeList = packagesNode.Elements("PackageReference")
+            var packageReferenceList = packagesNode.Elements("PackageReference")
                 .Where(x =>
                     (x.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
-                  || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id,StringComparison.InvariantCultureIgnoreCase))));
+                  || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))));
 
-            foreach (var dependencyToUpdate in packageNodeList)
+            foreach (var dependencyToUpdate in packageReferenceList)
             {
                 _logger.Detailed(
                     $"Updating directory-level dependencies: {currentPackage.Id} in path {currentPackage.Path.FullName}");
                 dependencyToUpdate.Attribute("Version").Value = newVersion.ToString();
+            }
+
+            var packageDownloadList = packagesNode.Elements("PackageDownload")
+                .Where(x =>
+                    (x.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
+                  || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))));
+
+            foreach (var dependencyToUpdate in packageDownloadList)
+            {
+                _logger.Detailed(
+                    $"Updating directory-level dependencies: {currentPackage.Id} in path {currentPackage.Path.FullName}");
+                dependencyToUpdate.Attribute("Version").Value = $"[{newVersion}]";
             }
 
             xml.Save(fileContents);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature!

### :arrow_heading_down: What is the current behavior?
Currently `PackageDownload` is not a supported target as supported element that can contain a version.  (This is seriously a thing)

### :new: What is the new behavior (if this is a feature change)?
Adds support for `PackageDownload`. The behavior is very similar to `PackageReference` except that the version must be defined as an exact version `[1.0.0]` instead of just `1.0.0`.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Testing with and without `PackageDownload`.

### :memo: Links to relevant issues/docs
This is seriously a thing, today Nuke is using it ensure that packages are downloaded, but they are not implicitly referenced.  This is used in the Nuke context to ensure that the binaries exist.  I could not however find any specific documentation on this behavior, but it is a thing.

https://github.com/NuGet/NuGet.Client/blob/f5916a527c442f896f787c593252b37a345da835/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets#L845-L850

### :thinking: Checklist before submitting

- [X] All projects build
- [ ] Relevant documentation was updated 
  * Are there any docs to update around this?

