### PR TITLE
Adding target branch funcionality and commit worder for BitBucket

### DIFF
--- a/NuKeeper.BitBucket/BitbucketCommitWorder.cs
+++ b/NuKeeper.BitBucket/BitbucketCommitWorder.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Formats;
+using NuKeeper.Abstractions.RepositoryInspection;
+
+namespace NuKeeper.BitBucket
+{
+    public class BitbucketCommitWorder : ICommitWorder
+    {
+        private const string CommitEmoji = "📦";
+
+        public string MakePullRequestTitle(IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            if (updates.Count == 1)
+            {
+                return PackageTitle(updates.First());
+            }
+
+            return $"Automatic update of {updates.Count} packages";
+        }
+
+        private static string PackageTitle(PackageUpdateSet updates)
+        {
+            return $"Automatic update of {updates.SelectedId} to {updates.SelectedVersion}";
+        }
+
+        public string MakeCommitMessage(PackageUpdateSet updates)
+        {
+            return $":{CommitEmoji}: {PackageTitle(updates)}";
+        }
+
+        public string MakeCommitDetails(IReadOnlyCollection<PackageUpdateSet> updates)
+        {
+            var builder = new StringBuilder();
+
+            if (updates.Count > 1)
+            {
+                MultiPackagePrefix(updates, builder);
+            }
+
+            foreach (var update in updates)
+            {
+                builder.AppendLine(MakeCommitVersionDetails(update));
+            }
+
+            AddCommitFooter(builder);
+
+            return builder.ToString();
+        }
+
+        private static void MultiPackagePrefix(IReadOnlyCollection<PackageUpdateSet> updates, StringBuilder builder)
+        {
+            var packageNames = updates
+                .Select(p => CodeQuote(p.SelectedId))
+                .JoinWithCommas();
+
+            var projects = updates.SelectMany(
+                    u => u.CurrentPackages)
+                .Select(p => p.Path.FullName)
+                .Distinct()
+                .ToList();
+
+            var projectOptS = (projects.Count > 1) ? "s" : string.Empty;
+
+            builder.AppendLine($"{updates.Count} packages were updated in {projects.Count} project{projectOptS}:");
+            builder.AppendLine(packageNames);
+            builder.AppendLine("");
+            builder.AppendLine("**Details of updated packages**");
+            builder.AppendLine("");
+        }
+
+        private static string MakeCommitVersionDetails(PackageUpdateSet updates)
+        {
+            var versionsInUse = updates.CurrentPackages
+                .Select(u => u.Version)
+                .Distinct()
+                .ToList();
+
+            var oldVersions = versionsInUse
+                .Select(v => CodeQuote(v.ToString()))
+                .ToList();
+
+            var minOldVersion = versionsInUse.Min();
+
+            var newVersion = CodeQuote(updates.SelectedVersion.ToString());
+            var packageId = CodeQuote(updates.SelectedId);
+
+            var changeLevel = ChangeLevel(minOldVersion, updates.SelectedVersion);
+
+            var builder = new StringBuilder();
+
+            if (oldVersions.Count == 1)
+            {
+                builder.AppendLine($"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion} from {oldVersions.JoinWithCommas()}");
+            }
+            else
+            {
+                builder.AppendLine($"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion}");
+                builder.AppendLine($"{oldVersions.Count} versions of {packageId} were found in use: {oldVersions.JoinWithCommas()}");
+            }
+
+            if (updates.Selected.Published.HasValue)
+            {
+                var packageWithVersion = CodeQuote(updates.SelectedId + " " + updates.SelectedVersion);
+                var pubDateString = CodeQuote(DateFormat.AsUtcIso8601(updates.Selected.Published));
+                var pubDate = updates.Selected.Published.Value.UtcDateTime;
+                var ago = TimeSpanFormat.Ago(pubDate, DateTime.UtcNow);
+
+                builder.AppendLine($"{packageWithVersion} was published at {pubDateString}, {ago}");
+            }
+
+            var highestVersion = updates.Packages.Major?.Identity.Version;
+            if (highestVersion != null && (highestVersion > updates.SelectedVersion))
+            {
+                LogHighestVersion(updates, highestVersion, builder);
+            }
+
+            builder.AppendLine();
+
+            if (updates.CurrentPackages.Count == 1)
+            {
+                builder.AppendLine("1 project update:");
+            }
+            else
+            {
+                builder.AppendLine($"{updates.CurrentPackages.Count} project updates:");
+            }
+
+            foreach (var current in updates.CurrentPackages)
+            {
+                var line = $"Updated {CodeQuote(current.Path.RelativePath)} to {packageId} {CodeQuote(updates.SelectedVersion.ToString())} from {CodeQuote(current.Version.ToString())}";
+                builder.AppendLine(line);
+            }
+
+            if (SourceIsPublicNuget(updates.Selected.Source.SourceUri))
+            {
+                builder.AppendLine(NugetPackageLink(updates.Selected.Identity));
+            }
+
+            return builder.ToString();
+        }
+
+        private static void AddCommitFooter(StringBuilder builder)
+        {
+            builder.AppendLine();
+            builder.AppendLine("This is an automated update. Merge only if it passes tests");
+            builder.AppendLine("**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper");
+        }
+
+        private static string ChangeLevel(NuGetVersion oldVersion, NuGetVersion newVersion)
+        {
+            if (newVersion.Major > oldVersion.Major)
+            {
+                return "major";
+            }
+
+            if (newVersion.Minor > oldVersion.Minor)
+            {
+                return "minor";
+            }
+
+            if (newVersion.Patch > oldVersion.Patch)
+            {
+                return "patch";
+            }
+
+            if (!newVersion.IsPrerelease && oldVersion.IsPrerelease)
+            {
+                return "out of beta";
+            }
+
+            return string.Empty;
+        }
+
+        private static void LogHighestVersion(PackageUpdateSet updates, NuGetVersion highestVersion, StringBuilder builder)
+        {
+            var allowedChange = CodeQuote(updates.AllowedChange.ToString());
+            var highest = CodeQuote(updates.SelectedId + " " + highestVersion);
+
+            var highestPublishedAt = HighestPublishedAt(updates.Packages.Major.Published);
+
+            builder.AppendLine(
+                $"There is also a higher version, {highest}{highestPublishedAt}, " +
+                $"but this was not applied as only {allowedChange} version changes are allowed.");
+        }
+
+        private static string HighestPublishedAt(DateTimeOffset? highestPublishedAt)
+        {
+            if (!highestPublishedAt.HasValue)
+            {
+                return string.Empty;
+            }
+
+            var highestPubDate = highestPublishedAt.Value;
+            var formattedPubDate = CodeQuote(DateFormat.AsUtcIso8601(highestPubDate));
+            var highestAgo = TimeSpanFormat.Ago(highestPubDate.UtcDateTime, DateTime.UtcNow);
+
+            return $" published at {formattedPubDate}, {highestAgo}";
+        }
+
+        private static string CodeQuote(string value)
+        {
+            return "`" + value + "`";
+        }
+
+        private static bool SourceIsPublicNuget(Uri sourceUrl)
+        {
+            return
+                sourceUrl != null &&
+                sourceUrl.ToString().StartsWith("https://api.nuget.org/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NugetPackageLink(PackageIdentity package)
+        {
+            var url = $"https://www.nuget.org/packages/{package.Id}/{package.Version}";
+            return $"[{package.Id} {package.Version} on NuGet.org]({url})";
+        }
+    }
+}

--- a/NuKeeper.BitBucket/BitbucketPlatform.cs
+++ b/NuKeeper.BitBucket/BitbucketPlatform.cs
@@ -36,8 +36,7 @@ namespace NuKeeper.BitBucket
 
         public Task<User> GetCurrentUser()
         {
-
-            return Task.FromResult(new User(_settings.Username, "", ""));
+            return Task.FromResult(new User(_settings.Username, _settings.Username, _settings.Username));
         }
 
         public async Task OpenPullRequest(ForkData target, PullRequestRequest request, IEnumerable<string> labels)

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -72,7 +72,8 @@ namespace NuKeeper.BitBucket
                 ApiUri = new Uri("https://api.bitbucket.org/2.0/"),
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
-                RepositoryOwner = owner
+                RepositoryOwner = owner,
+                RemoteInfo = targetBranch != null ? new RemoteInfo { BranchName = targetBranch } : null
             });
         }
     }

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -153,7 +153,7 @@ namespace NuKeeper.Collaboration
                     CollaborationPlatform = new BitbucketPlatform(_nuKeeperLogger);
                     RepositoryDiscovery = new BitbucketRepositoryDiscovery(_nuKeeperLogger);
                     ForkFinder = new BitbucketForkFinder(CollaborationPlatform, _nuKeeperLogger, forkMode);
-                    CommitWorder = new DefaultCommitWorder();
+                    CommitWorder = new BitbucketCommitWorder();
                     break;
 
                 case Platform.BitbucketLocal:

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently NuKeeper using BitBucket ignores target branch setting and add some unused tags in the pull request description.

### :new: What is the new behavior (if this is a feature change)?
Now, NuKeeper use the target branch setting (I used the same as GitHub settings) and the pull request description can be read more easily

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
I created an account at BitBucket and use it to test. You should do the same.

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
