### PR TITLE
Update GitLab MergeRequest's Labels to be an array vs a single value

### DIFF
--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
@@ -51,7 +52,7 @@ namespace NuKeeper.Gitlab
                 TargetBranch = request.BaseRef,
                 Id = $"{projectName}/{repositoryName}",
                 RemoveSourceBranch = request.DeleteBranchAfterMerge,
-                Labels = labels.JoinWithCommas()
+                Labels = labels.ToList()
             };
 
             await _client.OpenMergeRequest(projectName, repositoryName, mergeRequest);

--- a/NuKeeper.Gitlab/Model/MergeRequest.cs
+++ b/NuKeeper.Gitlab/Model/MergeRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace NuKeeper.Gitlab.Model
@@ -23,6 +24,6 @@ namespace NuKeeper.Gitlab.Model
         public bool RemoveSourceBranch { get; set; }
 
         [JsonProperty("labels")]
-        public string Labels { get; set; }
+        public IList<string> Labels { get; set; }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

#901 

### :new: What is the new behavior (if this is a feature change)?

Nukeeper completes successfully when creating merges against GitLab.com

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

I ran this against GitLab.com - feel free to do the same.

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
