### PR TITLE
Show nukeeper command to get started easily

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -29,7 +29,9 @@ Integration with the following platforms is supported.
 
 NuKeeper has different commands and options which can be utilized. Below you'll find a summary of all the commands and what they do.
 
-```bash
+```
+$ nukeeper -h
+
 Options:
   --version     Show version information
   -?|-h|--help  Show help information


### PR DESCRIPTION
Currently the docs show an easily line to copy and paste to get the installer running. The next code block shows all available commands, but it hasn't told me (new user) what program I need to run these commands against. By showing the `nukeeper -h` command, I (new user) am given a hint on what the program name is so I can get started quickly.
