### PR TITLE
Return non-zero exit code for unhandled exceptions

### DIFF
--- a/NuKeeper/ExitCodes.cs
+++ b/NuKeeper/ExitCodes.cs
@@ -6,7 +6,7 @@ namespace NuKeeper
     enum ExitCodes
     {
         Success = 0,
-        UnknownError = 1 << 1,
-        InvalidArguments = 1 << 2,
+        UnknownError = 1 << 0,
+        InvalidArguments = 1 << 1,
     }
 }

--- a/NuKeeper/ExitCodes.cs
+++ b/NuKeeper/ExitCodes.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NuKeeper
+{
+    [Flags]
+    enum ExitCodes
+    {
+        Success = 0,
+        UnknownError = 1 << 1,
+        InvalidArguments = 1 << 2,
+    }
+}

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -7,6 +7,7 @@ using NuKeeper.Commands;
 [assembly: InternalsVisibleTo("NuKeeper.Tests")]
 
 #pragma warning disable CA1822
+#pragma warning disable CA1031
 
 namespace NuKeeper
 {
@@ -31,12 +32,16 @@ namespace NuKeeper
             try
             {
                 return app.Execute(args);
-
             }
             catch (CommandParsingException cpe)
             {
                 Console.WriteLine(cpe.Message);
-                return -1;
+                return (int)ExitCodes.InvalidArguments;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                return (int)ExitCodes.UnknownError;
             }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

feature

### :arrow_heading_down: What is the current behavior?

Currently when an exception is thrown besides `CommandParsingException`, the exit code of the tool will be 0 (no error). This means that in CI builds on a schedule, you won't get build failures if something is wrong (#904).

```
C:\Program Files\dotnet\dotnet.exe (process 13168) exited with code 0.
```

### :new: What is the new behavior (if this is a feature change)?

With this change, a non-zero exit code is returned, which would then fail the build and cause alarm bells to ring.

```
C:\Program Files\dotnet\dotnet.exe (process 13168) exited with code 2.
```

### :boom: Does this PR introduce a breaking change?

Maybe. So other tools relying on a zero exit code even when errors happen, would need a change. I think this is desirable.

### :bug: Recommendations for testing

Nuget.config:
```
@@ -0,0 +1,9 @@
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <clear/>
  </packageSources>
</configuration>
```

### :memo: Links to relevant issues/docs

#904

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
