### PR TITLE
Add subgroup support to GitLab repositories

### DIFF
--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -44,20 +44,20 @@ namespace NuKeeper.Gitlab
                     $"The provided uri was is not in the correct format. Provided null and format should be {UrlPattern}");
             }
 
-            // Assumption - url should look like https://gitlab.com/{username}/{projectname}.git";
+            // Assumption - url should look like https://gitlab.com/{username}/{projectname}.git" with infinite subgroups;
             var path = repositoryUri.AbsolutePath;
             var pathParts = path.Split('/')
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();
 
-            if (pathParts.Count != 2)
+            if (pathParts.Count < 2)
             {
                 throw new NuKeeperException(
                     $"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be {UrlPattern}");
             }
 
             var repoOwner = pathParts[0];
-            var repoName = pathParts[1].Replace(".git", string.Empty);
+            var repoName = pathParts[pathParts.Length].Replace(".git", string.Empty);
 
             var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -57,7 +57,7 @@ namespace NuKeeper.Gitlab
             }
 
             var repoOwner = pathParts[0];
-            var repoName = pathParts[pathParts.Count].Replace(".git", string.Empty);
+            var repoName = pathParts[pathParts.Count - 1].Replace(".git", string.Empty);
 
             var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -57,7 +57,7 @@ namespace NuKeeper.Gitlab
             }
 
             var repoOwner = pathParts[0];
-            var repoName = pathParts[pathParts.Count - 1].Replace(".git", string.Empty);
+            var repoName = string.Join("/", pathParts.Skip(1).ToArray()).Replace(".git", string.Empty);
 
             var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -57,7 +57,7 @@ namespace NuKeeper.Gitlab
             }
 
             var repoOwner = pathParts[0];
-            var repoName = pathParts[pathParts.Length].Replace(".git", string.Empty);
+            var repoName = pathParts[pathParts.Count].Replace(".git", string.Empty);
 
             var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Specifying a repository uri with a single or multiple subgroup(s) throws an exception.

### :new: What is the new behavior (if this is a feature change)?

Specifying a repository uri with a single or multiple subgroup(s) does not throw an exception.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Specify a repository with and without a subgroup or multiple subgroups.

### :memo: Links to relevant issues/docs

#905 
https://nukeeper.com/commands/repository/
https://nukeeper.com/platform/gitlab/

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
