### PR TITLE
Fix for bitbucket local dashes in repo names

### DIFF
--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -88,7 +88,8 @@ namespace NuKeeper.BitBucketLocal
         public async Task<Repository> GetUserRepository(string projectName, string repositoryName)
         {
             var repos = await GetRepositoriesForOrganisation(projectName);
-            return repos.Single(x => x.Name.Equals(repositoryName, StringComparison.OrdinalIgnoreCase));
+            var fullName = repositoryName.Replace("-", " ");
+            return repos.Single(x => x.Name.Equals(fullName, StringComparison.OrdinalIgnoreCase));
         }
 
         public Task<Repository> MakeUserFork(string owner, string repositoryName)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for BitBucket Local - by default, repos with spaces in are presented as dashes in the url. E.g.
"My Special Repo" in BitBucket Server is http://my-bitbucket/scm/myproject/my-special-repo

### :arrow_heading_down: What is the current behavior?

```
C:\>nukeeper repo http://my-bitbucket/scm/myproject/my-special-project ACCESSTOKEN --maxpackageupdates 15 --consolidate --change Minor --include "Something.*" -v d
Matched uri 'http://my-bitbucket:7990/' to collaboration platform 'BitbucketLocal'
FindPushFork. Fork Mode is SingleRepositoryOnly
2020-02-08T18:03:25Z: Started
Getting from BitBucketLocal url rest/api/1.0/projects/myproject/repos?limit=999
Failed on repo my-special-project InvalidOperationException : Sequence contains no matching element
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at NuKeeper.BitBucketLocal.BitBucketLocalPlatform.GetUserRepository(String projectName, String repositoryName) in d:\a\r1\a\_NuKeeper PR Build\drop\Nukeeper.BitBucketLocal\BitBucketLocalPlatform.cs:line 91
   at NuKeeper.BitBucket.BitbucketForkFinder.IsPushableRepo(ForkData originFork) in d:\a\r1\a\_NuKeeper PR Build\drop\NuKeeper.BitBucket\BitbucketForkFinder.cs:line 56
   at NuKeeper.BitBucket.BitbucketForkFinder.FindUpstreamRepoOnly(ForkData pullFork) in d:\a\r1\a\_NuKeeper PR Build\drop\NuKeeper.BitBucket\BitbucketForkFinder.cs:line 38
   at NuKeeper.BitBucket.BitbucketForkFinder.FindPushFork(String userName, ForkData fallbackFork) in d:\a\r1\a\_NuKeeper PR Build\drop\NuKeeper.BitBucket\BitbucketForkFinder.cs:line 32
   at NuKeeper.Engine.GitRepositoryEngine.BuildGitRepositorySpec(RepositorySettings repository, String userName) in d:\a\r1\a\_NuKeeper PR Build\drop\NuKeeper\Engine\GitRepositoryEngine.cs:line 113
   at NuKeeper.Engine.GitRepositoryEngine.Run(RepositorySettings repository, GitUsernamePasswordCredentials credentials, SettingsContainer settings, User user) in d:\a\r1\a\_NuKeeper PR Build\drop\NuKeeper\Engine\GitRepositoryEngine.cs:line 43
Done at 2020-02-08T18:03:25Z
```

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
