### PR TITLE
Fix UriFormatException

### DIFF
--- a/NuKeeper.Git/GitCmdDriver.cs
+++ b/NuKeeper.Git/GitCmdDriver.cs
@@ -100,7 +100,7 @@ namespace NuKeeper.Git
                 return pullEndpoint;
             }
 
-            return new UriBuilder(pullEndpoint) { UserName = gitCredentials.Username, Password = gitCredentials.Password }.Uri;
+            return new UriBuilder(pullEndpoint) { UserName = Uri.EscapeDataString(gitCredentials.Username), Password = gitCredentials.Password }.Uri;
         }
     }
 }

--- a/NuKeeper.Git/GitCmdDriver.cs
+++ b/NuKeeper.Git/GitCmdDriver.cs
@@ -95,7 +95,7 @@ namespace NuKeeper.Git
 
         private Uri CreateCredentialsUri(Uri pullEndpoint, GitUsernamePasswordCredentials gitCredentials)
         {
-            if (_gitCredentials == null)
+            if (_gitCredentials?.Username == null)
             {
                 return pullEndpoint;
             }


### PR DESCRIPTION
Fix UriFormatException with message "Invalid URI: Invalid port specified." when Username contains '@'

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
When Username contains '@'  throws UriFormatException  with message "Invalid URI: Invalid port specified."

### :arrow_heading_down: What is the current behavior?
UriFormatException 

### :new: What is the new behavior (if this is a feature change)?
Replace '@' by "%40"

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
