### PR TITLE
Added checkout directory parameter to repo command

### DIFF
--- a/NuKeeper.Inspection/Files/FolderFactory.cs
+++ b/NuKeeper.Inspection/Files/FolderFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
 
@@ -10,30 +11,12 @@ namespace NuKeeper.Inspection.Files
 {
     public class FolderFactory : IFolderFactory
     {
-        private readonly INuKeeperLogger _logger;
         private const string FolderPrefix = "repo-";
+        private readonly INuKeeperLogger _logger;
 
         public FolderFactory(INuKeeperLogger logger)
         {
             _logger = logger;
-        }
-
-        public IFolder UniqueTemporaryFolder()
-        {
-            var tempDir = new DirectoryInfo(GetUniqueTemporaryPath());
-            tempDir.Create();
-            return new Folder(_logger, tempDir);
-        }
-
-        public static string NuKeeperTempFilesPath()
-        {
-            return Path.Combine(Path.GetTempPath(), "NuKeeper");
-        }
-
-        private static string GetUniqueTemporaryPath()
-        {
-            var uniqueName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-            return Path.Combine(NuKeeperTempFilesPath(), $"{FolderPrefix}{uniqueName}");
         }
 
         /// <summary>
@@ -50,6 +33,11 @@ namespace NuKeeper.Inspection.Files
                 d.LastWriteTime < filterDatetime);
         }
 
+        public static string NuKeeperTempFilesPath()
+        {
+            return Path.Combine(Path.GetTempPath(), "NuKeeper");
+        }
+
         /// <summary>
         /// Cleanup folders that are not automatically have been cleaned.
         /// </summary>
@@ -61,6 +49,24 @@ namespace NuKeeper.Inspection.Files
                 var folder = new Folder(_logger, dir);
                 folder.TryDelete();
             }
+        }
+
+        public IFolder FolderFromPath(string folderPath)
+        {
+            return new Folder(_logger, new DirectoryInfo(folderPath));
+        }
+
+        public IFolder UniqueTemporaryFolder()
+        {
+            var tempDir = new DirectoryInfo(GetUniqueTemporaryPath());
+            tempDir.Create();
+            return new Folder(_logger, tempDir);
+        }
+
+        private static string GetUniqueTemporaryPath()
+        {
+            var uniqueName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+            return Path.Combine(NuKeeperTempFilesPath(), $"{FolderPrefix}{uniqueName}");
         }
     }
 }

--- a/NuKeeper.Inspection/Files/IFolderFactory.cs
+++ b/NuKeeper.Inspection/Files/IFolderFactory.cs
@@ -5,6 +5,9 @@ namespace NuKeeper.Inspection.Files
     public interface IFolderFactory
     {
         void DeleteExistingTempDirs();
+
+        IFolder FolderFromPath(string folderPath);
+
         IFolder UniqueTemporaryFolder();
     }
 }

--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
 using NSubstitute;
+
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -12,11 +18,8 @@ using NuKeeper.Engine;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
+
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Threading.Tasks;
 
 namespace NuKeeper.Tests.Commands
 {
@@ -24,6 +27,105 @@ namespace NuKeeper.Tests.Commands
     public class RepositoryCommandTests
     {
         private IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        public static async Task<(SettingsContainer settingsContainer, CollaborationPlatformSettings platformSettings)> CaptureSettings(
+            FileSettings settingsIn,
+            bool addLabels = false,
+            int? maxPackageUpdates = null)
+        {
+            var logger = Substitute.For<IConfigureLogger>();
+            var fileSettings = Substitute.For<IFileSettingsCache>();
+            var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
+            fileSettings.GetSettings().Returns(settingsIn);
+
+            var settingReader = new GitHubSettingsReader(new MockedGitDiscoveryDriver(), environmentVariablesProvider);
+            var settingsReaders = new List<ISettingsReader> { settingReader };
+            var collaborationFactory = GetCollaborationFactory(environmentVariablesProvider, settingsReaders);
+
+            SettingsContainer settingsOut = null;
+            var engine = Substitute.For<ICollaborationEngine>();
+            await engine.Run(Arg.Do<SettingsContainer>(x => settingsOut = x));
+
+            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
+            command.PersonalAccessToken = "testToken";
+            command.RepositoryUri = "http://github.com/test/test";
+
+            if (addLabels)
+            {
+                command.Label = new List<string> { "runLabel1", "runLabel2" };
+            }
+
+            command.MaxPackageUpdates = maxPackageUpdates;
+
+            await command.OnExecute();
+
+            return (settingsOut, collaborationFactory.Settings);
+        }
+
+        [Test]
+        public async Task EmptyFileResultsInDefaultSettings()
+        {
+            var fileSettings = FileSettings.Empty();
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.PackageFilters.MinimumAge, Is.EqualTo(TimeSpan.FromDays(7)));
+            Assert.That(settings.PackageFilters.Excludes, Is.Null);
+            Assert.That(settings.PackageFilters.Includes, Is.Null);
+            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(3));
+
+            Assert.That(settings.UserSettings, Is.Not.Null);
+            Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
+            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
+            Assert.That(settings.UserSettings.OutputDestination, Is.EqualTo(OutputDestination.Console));
+            Assert.That(settings.UserSettings.OutputFormat, Is.EqualTo(OutputFormat.Text));
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
+            Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.False);
+
+            Assert.That(settings.BranchSettings, Is.Not.Null);
+            Assert.That(settings.BranchSettings.BranchNameTemplate, Is.Null);
+            Assert.That(settings.BranchSettings.DeleteBranchAfterMerge, Is.EqualTo(true));
+
+            Assert.That(settings.SourceControlServerSettings.IncludeRepos, Is.Null);
+            Assert.That(settings.SourceControlServerSettings.ExcludeRepos, Is.Null);
+        }
+
+        [Test]
+        public async Task LabelsOnCommandLineWillReplaceFileLabels()
+        {
+            var fileSettings = new FileSettings
+            {
+                Label = new List<string> { "testLabel" }
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings, true);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings.Labels, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings.Labels, Has.Count.EqualTo(2));
+            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("runLabel1"));
+            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("runLabel2"));
+            Assert.That(settings.SourceControlServerSettings.Labels, Does.Not.Contain("testLabel"));
+        }
+
+        [Test]
+        public async Task MaxPackageUpdatesFromCommandLineOverridesFiles()
+        {
+            var fileSettings = new FileSettings
+            {
+                MaxPackageUpdates = 42
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings, false, 101);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(101));
+        }
 
         [SetUp]
         public void Setup()
@@ -190,7 +292,7 @@ namespace NuKeeper.Tests.Commands
             fileSettings.GetSettings().Returns(new FileSettings());
 
             var gitHubSettingReader = new GitHubSettingsReader(new MockedGitDiscoveryDriver(), _environmentVariablesProvider);
-            var bitbucketLocalSettingReader = new BitBucketLocalSettingsReader( _environmentVariablesProvider);
+            var bitbucketLocalSettingReader = new BitBucketLocalSettingsReader(_environmentVariablesProvider);
             var settingsReaders = new List<ISettingsReader> { gitHubSettingReader, bitbucketLocalSettingReader };
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
@@ -231,195 +333,44 @@ namespace NuKeeper.Tests.Commands
         }
 
         [Test]
-        public async Task EmptyFileResultsInDefaultSettings()
+        public async Task UseCustomCheckoutDirectoryIfParameterIsProvidedForRemote()
         {
-            var fileSettings = FileSettings.Empty();
+            var testUri = new Uri("https://github.com");
 
-            var (settings, _) = await CaptureSettings(fileSettings);
+            var collaborationFactorySubstitute = Substitute.For<ICollaborationFactory>();
+            collaborationFactorySubstitute.ForkFinder.FindPushFork(Arg.Any<string>(), Arg.Any<ForkData>()).Returns(Task.FromResult(new ForkData(testUri, "nukeeper", "nukeeper")));
+            var folderFactorySubstitute = Substitute.For<IFolderFactory>();
+            folderFactorySubstitute.FolderFromPath(Arg.Any<string>())
+                .Returns(ci => new Folder(null, new System.IO.DirectoryInfo(ci.Arg<string>())));
 
-            Assert.That(settings, Is.Not.Null);
+            var updater = Substitute.For<IRepositoryUpdater>();
+            var gitEngine = new GitRepositoryEngine(updater, collaborationFactorySubstitute, folderFactorySubstitute,
+                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>());
 
-            Assert.That(settings.PackageFilters, Is.Not.Null);
-            Assert.That(settings.PackageFilters.MinimumAge, Is.EqualTo(TimeSpan.FromDays(7)));
-            Assert.That(settings.PackageFilters.Excludes, Is.Null);
-            Assert.That(settings.PackageFilters.Includes, Is.Null);
-            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(3));
-
-            Assert.That(settings.UserSettings, Is.Not.Null);
-            Assert.That(settings.UserSettings.AllowedChange, Is.EqualTo(VersionChange.Major));
-            Assert.That(settings.UserSettings.NuGetSources, Is.Null);
-            Assert.That(settings.UserSettings.OutputDestination, Is.EqualTo(OutputDestination.Console));
-            Assert.That(settings.UserSettings.OutputFormat, Is.EqualTo(OutputFormat.Text));
-            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
-            Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.False);
-
-            Assert.That(settings.BranchSettings, Is.Not.Null);
-            Assert.That(settings.BranchSettings.BranchNameTemplate, Is.Null);
-            Assert.That(settings.BranchSettings.DeleteBranchAfterMerge, Is.EqualTo(true));
-
-            Assert.That(settings.SourceControlServerSettings.IncludeRepos, Is.Null);
-            Assert.That(settings.SourceControlServerSettings.ExcludeRepos, Is.Null);
-        }
-
-        [Test]
-        public async Task WillReadApiFromFile()
-        {
-            var fileSettings = new FileSettings
+            await gitEngine.Run(new RepositorySettings
             {
-                Api = "http://github.contoso.com/"
-            };
-
-            var (_, platformSettings) = await CaptureSettings(fileSettings);
-
-            Assert.That(platformSettings, Is.Not.Null);
-            Assert.That(platformSettings.BaseApiUrl, Is.Not.Null);
-            Assert.That(platformSettings.BaseApiUrl, Is.EqualTo(new Uri("http://github.contoso.com/")));
-        }
-
-        [Test]
-        public async Task WillReadLabelFromFile()
-        {
-            var fileSettings = new FileSettings
+                RepositoryUri = testUri,
+                RepositoryOwner = "nukeeper",
+                RepositoryName = "nukeeper"
+            }, new GitUsernamePasswordCredentials()
             {
-                Label = new List<string> { "testLabel" }
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Labels, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Labels, Has.Count.EqualTo(1));
-            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("testLabel"));
-        }
-
-        [Test]
-        public async Task WillReadMaxPackageUpdatesFromFile()
-        {
-            var fileSettings = new FileSettings
+                Password = "..",
+                Username = "nukeeper"
+            }, new SettingsContainer()
             {
-                MaxPackageUpdates = 42
-            };
+                SourceControlServerSettings = new SourceControlServerSettings()
+                {
+                    Scope = ServerScope.Repository
+                },
+                UserSettings = new UserSettings()
+                {
+                    Directory = "testdirectory"
+                }
+            }, null);
 
-            var (settings, _) = await CaptureSettings(fileSettings);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.PackageFilters, Is.Not.Null);
-            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(42));
-        }
-
-        [Test]
-        public async Task WillReadConsolidateFromFile()
-        {
-            var fileSettings = new FileSettings
-            {
-                Consolidate = true
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.True);
-        }
-
-        [Test]
-        public async Task WillReadBranchNamePrefixFromFile()
-        {
-            var testTemplate = "nukeeper/MyBranch";
-
-            var fileSettings = new FileSettings
-            {
-                BranchNameTemplate = testTemplate
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.BranchSettings, Is.Not.Null);
-            Assert.That(settings.BranchSettings.BranchNameTemplate, Is.EqualTo(testTemplate));
-        }
-
-        [Test]
-        public async Task WillNotReadMaxRepoFromFile()
-        {
-            var fileSettings = new FileSettings
-            {
-                MaxRepo = 42
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.PackageFilters, Is.Not.Null);
-            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task MaxPackageUpdatesFromCommandLineOverridesFiles()
-        {
-            var fileSettings = new FileSettings
-            {
-                MaxPackageUpdates = 42
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings, false, 101);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.PackageFilters, Is.Not.Null);
-            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(101));
-        }
-
-        [Test]
-        public async Task LabelsOnCommandLineWillReplaceFileLabels()
-        {
-            var fileSettings = new FileSettings
-            {
-                Label = new List<string> { "testLabel" }
-            };
-
-            var (settings, _) = await CaptureSettings(fileSettings, true);
-
-            Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Labels, Is.Not.Null);
-            Assert.That(settings.SourceControlServerSettings.Labels, Has.Count.EqualTo(2));
-            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("runLabel1"));
-            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("runLabel2"));
-            Assert.That(settings.SourceControlServerSettings.Labels, Does.Not.Contain("testLabel"));
-        }
-
-        public static async Task<(SettingsContainer settingsContainer, CollaborationPlatformSettings platformSettings)> CaptureSettings(
-            FileSettings settingsIn,
-            bool addLabels = false,
-            int? maxPackageUpdates = null)
-        {
-            var logger = Substitute.For<IConfigureLogger>();
-            var fileSettings = Substitute.For<IFileSettingsCache>();
-            var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
-            fileSettings.GetSettings().Returns(settingsIn);
-
-            var settingReader = new GitHubSettingsReader(new MockedGitDiscoveryDriver(), environmentVariablesProvider);
-            var settingsReaders = new List<ISettingsReader> { settingReader };
-            var collaborationFactory = GetCollaborationFactory(environmentVariablesProvider, settingsReaders);
-
-            SettingsContainer settingsOut = null;
-            var engine = Substitute.For<ICollaborationEngine>();
-            await engine.Run(Arg.Do<SettingsContainer>(x => settingsOut = x));
-
-            var command = new RepositoryCommand(engine, logger, fileSettings, collaborationFactory, settingsReaders);
-            command.PersonalAccessToken = "testToken";
-            command.RepositoryUri = "http://github.com/test/test";
-
-            if (addLabels)
-            {
-                command.Label = new List<string> { "runLabel1", "runLabel2" };
-            }
-
-            command.MaxPackageUpdates = maxPackageUpdates;
-
-            await command.OnExecute();
-
-            return (settingsOut, collaborationFactory.Settings);
+            await updater.Received().Run(Arg.Any<IGitDriver>(),
+                Arg.Any<RepositoryData>(),
+                Arg.Is<SettingsContainer>(c => c.WorkingFolder.FullPath.EndsWith("testdirectory", StringComparison.Ordinal)));
         }
 
         [Test]
@@ -454,7 +405,6 @@ namespace NuKeeper.Tests.Commands
                     Scope = ServerScope.Repository
                 }
             }, null);
-
 
             await updater.Received().Run(Arg.Any<IGitDriver>(),
                 Arg.Is<RepositoryData>(r => r.DefaultBranch == "custombranch"), Arg.Any<SettingsContainer>());
@@ -496,9 +446,101 @@ namespace NuKeeper.Tests.Commands
                 }
             }, null);
 
-
             await updater.Received().Run(Arg.Any<IGitDriver>(),
                 Arg.Is<RepositoryData>(r => r.DefaultBranch == "custombranch"), Arg.Any<SettingsContainer>());
+        }
+
+        [Test]
+        public async Task WillNotReadMaxRepoFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                MaxRepo = 42
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.UserSettings.MaxRepositoriesChanged, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task WillReadApiFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                Api = "http://github.contoso.com/"
+            };
+
+            var (_, platformSettings) = await CaptureSettings(fileSettings);
+
+            Assert.That(platformSettings, Is.Not.Null);
+            Assert.That(platformSettings.BaseApiUrl, Is.Not.Null);
+            Assert.That(platformSettings.BaseApiUrl, Is.EqualTo(new Uri("http://github.contoso.com/")));
+        }
+
+        [Test]
+        public async Task WillReadBranchNamePrefixFromFile()
+        {
+            var testTemplate = "nukeeper/MyBranch";
+
+            var fileSettings = new FileSettings
+            {
+                BranchNameTemplate = testTemplate
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.BranchSettings, Is.Not.Null);
+            Assert.That(settings.BranchSettings.BranchNameTemplate, Is.EqualTo(testTemplate));
+        }
+
+        [Test]
+        public async Task WillReadConsolidateFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                Consolidate = true
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.UserSettings.ConsolidateUpdatesInSinglePullRequest, Is.True);
+        }
+
+        [Test]
+        public async Task WillReadLabelFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                Label = new List<string> { "testLabel" }
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings.Labels, Is.Not.Null);
+            Assert.That(settings.SourceControlServerSettings.Labels, Has.Count.EqualTo(1));
+            Assert.That(settings.SourceControlServerSettings.Labels, Does.Contain("testLabel"));
+        }
+
+        [Test]
+        public async Task WillReadMaxPackageUpdatesFromFile()
+        {
+            var fileSettings = new FileSettings
+            {
+                MaxPackageUpdates = 42
+            };
+
+            var (settings, _) = await CaptureSettings(fileSettings);
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.PackageFilters, Is.Not.Null);
+            Assert.That(settings.PackageFilters.MaxPackageUpdates, Is.EqualTo(42));
         }
 
         private static ICollaborationFactory GetCollaborationFactory(IEnvironmentVariablesProvider environmentVariablesProvider,

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -1,26 +1,21 @@
-using McMaster.Extensions.CommandLineUtils;
-using NuKeeper.Abstractions.CollaborationPlatform;
-using NuKeeper.Abstractions.Configuration;
-using NuKeeper.Inspection.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+
+using McMaster.Extensions.CommandLineUtils;
+
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Formats;
 using NuKeeper.Collaboration;
-using System.Threading.Tasks;
+using NuKeeper.Inspection.Logging;
 
 namespace NuKeeper.Commands
 {
     [Command("repo", "r", "repository", Description = "Performs version checks and generates pull requests for a single repository.")]
     internal class RepositoryCommand : CollaborationPlatformCommand
     {
-        [Argument(0, Name = "Repository URI", Description = "The URI of the repository to scan.")]
-        public string RepositoryUri { get; set; }
-
-        [Option(CommandOptionType.SingleValue, LongName = "targetBranch",
-            Description = "If the target branch is another branch than that you are currently on, set this to the target")]
-        public string TargetBranch { get; set; }
-
         private readonly IEnumerable<ISettingsReader> _settingsReaders;
 
         public RepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory, IEnumerable<ISettingsReader> settingsReaders)
@@ -28,6 +23,16 @@ namespace NuKeeper.Commands
         {
             _settingsReaders = settingsReaders;
         }
+
+        [Argument(0, Name = "Repository URI", Description = "The URI of the repository to scan.")]
+        public string RepositoryUri { get; set; }
+
+        [Option(CommandOptionType.SingleValue, LongName = "targetBranch",
+            Description = "If the target branch is another branch than that you are currently on, set this to the target")]
+        public string TargetBranch { get; set; }
+
+        [Option(CommandOptionType.SingleValue, ShortName = "cdir", Description = "If you want NuKeeper to check out the repository to an alternate path, set it here (by default, a temporary directory is used).")]
+        protected string CheckoutDirectory { get; set; }
 
         protected override async Task<ValidationResult> PopulateSettings(SettingsContainer settings)
         {
@@ -69,6 +74,8 @@ namespace NuKeeper.Commands
 
             settings.SourceControlServerSettings.Scope = ServerScope.Repository;
             settings.UserSettings.MaxRepositoriesChanged = 1;
+            settings.UserSettings.Directory = CheckoutDirectory;
+
             return ValidationResult.Success;
         }
 

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -74,7 +74,7 @@ namespace NuKeeper.Engine
                 }
                 else
                 {
-                    folder = !string.IsNullOrWhiteSpace(settings.UserSettings.Directory)
+                    folder = !string.IsNullOrWhiteSpace(settings?.UserSettings?.Directory)
                         ? _folderFactory.FolderFromPath(settings.UserSettings.Directory)
                         : _folderFactory.UniqueTemporaryFolder();
                     settings.WorkingFolder = folder;

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -14,11 +15,11 @@ namespace NuKeeper.Engine
 {
     public class GitRepositoryEngine : IGitRepositoryEngine
     {
-        private readonly IRepositoryUpdater _repositoryUpdater;
         private readonly ICollaborationFactory _collaborationFactory;
         private readonly IFolderFactory _folderFactory;
         private readonly INuKeeperLogger _logger;
         private readonly IRepositoryFilter _repositoryFilter;
+        private readonly IRepositoryUpdater _repositoryUpdater;
 
         public GitRepositoryEngine(
             IRepositoryUpdater repositoryUpdater,
@@ -73,7 +74,9 @@ namespace NuKeeper.Engine
                 }
                 else
                 {
-                    folder = _folderFactory.UniqueTemporaryFolder();
+                    folder = !string.IsNullOrWhiteSpace(settings.UserSettings.Directory)
+                        ? _folderFactory.FolderFromPath(settings.UserSettings.Directory)
+                        : _folderFactory.UniqueTemporaryFolder();
                     settings.WorkingFolder = folder;
                 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
A feature for setting the directory to check out to via a command line parameter in the `repo` command.

### :arrow_heading_down: What is the current behavior?
Currently, the `repo` command creates a temporary folder below %APPDATA% to check out the repository to.

### :new: What is the new behavior (if this is a feature change)?
The default is still the same. However, via the optional command line parameter `--checkoutdirectory` (or `-cdir`) a custom directory can be provided, e.g. `nukeeper repo <url> <token> -cdir "C:\Git"`.

### :boom: Does this PR introduce a breaking change?
I don't think so, since the default behaviour is not changed and the command line switch is optional.

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
This solves the original request from #683 (though not the updated intention).
Although I tried setting the TMP-Variable as mentioned in the issue, the path with auto-generated temp folder names is still too long for óur project (I know, that is a discussion for itself), which is why I implemented this.

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
-> Please point me to the right documentation, I will be glad to update it 😃

This is my first PR here, so feel free to highlight any changes I should make (e.g. code style) and I will try to adjust them shortly...
