### PR TITLE
Feature/azuredevops org global

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
@@ -5,38 +5,104 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.CollaborationModels;
 
 namespace NuKeeper.AzureDevOps
 {
     public class AzureDevOpsRepositoryDiscovery : IRepositoryDiscovery
     {
         private readonly INuKeeperLogger _logger;
+        private readonly ICollaborationPlatform _collaborationPlatform;
         private readonly string _token;
 
-        public AzureDevOpsRepositoryDiscovery(INuKeeperLogger logger, string token)
+        public AzureDevOpsRepositoryDiscovery(INuKeeperLogger logger, ICollaborationPlatform collaborationPlatform, string token)
         {
             _logger = logger;
+            _collaborationPlatform = collaborationPlatform;
             _token = token;
         }
 
-        public Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings)
+        public async Task<IEnumerable<RepositorySettings>> GetRepositories(SourceControlServerSettings settings)
         {
             switch (settings.Scope)
             {
                 case ServerScope.Global:
+                    return await ForAllOrgs(settings);
+
                 case ServerScope.Organisation:
-                    _logger.Error($"{settings.Scope} not yet implemented");
-                    throw new NotImplementedException();
+                    return await FromOrganisation(settings.OrganisationName, settings);
 
                 case ServerScope.Repository:
-                    //Workaround for https://github.com/libgit2/libgit2sharp/issues/1596
-                    settings.Repository.RepositoryUri = new Uri(settings.Repository.RepositoryUri.ToString().Replace("--PasswordToReplace--", _token));
-                    return Task.FromResult(new List<RepositorySettings> { settings.Repository }.AsEnumerable());
+                    
+                    settings.Repository.RepositoryUri = PasswordReplacedRepositoryUri(settings.Repository.RepositoryUri);
+                    return new List<RepositorySettings> { settings.Repository }.AsEnumerable();
 
                 default:
                     _logger.Error($"Unknown Server Scope {settings.Scope}");
-                    return Task.FromResult(Enumerable.Empty<RepositorySettings>());
+                    return Enumerable.Empty<RepositorySettings>();
             }
+        }
+
+        private async Task<IReadOnlyCollection<RepositorySettings>> ForAllOrgs(SourceControlServerSettings settings)
+        {
+            var allOrgs = await _collaborationPlatform.GetOrganizations();
+
+            var allRepos = new List<RepositorySettings>();
+
+            foreach (var org in allOrgs)
+            {
+                var repos = await FromOrganisation(org.Name, settings);
+                allRepos.AddRange(repos);
+            }
+
+            return allRepos;
+        }
+
+        private async Task<IReadOnlyCollection<RepositorySettings>> FromOrganisation(string organisationName, SourceControlServerSettings settings)
+        {
+            var allOrgRepos = await _collaborationPlatform.GetRepositoriesForOrganisation(organisationName);
+
+            var usableRepos = allOrgRepos
+                .Where(r => MatchesIncludeExclude(r, settings))
+                .Where(RepoIsModifiable)
+                .ToList();
+
+            if (allOrgRepos.Count > usableRepos.Count)
+            {
+                _logger.Detailed($"Can pull from {usableRepos.Count} repos out of {allOrgRepos.Count}");
+            }
+
+            return usableRepos
+                .Select(r => CreateRepositorySettings(organisationName, r.CloneUrl, organisationName, r.Name))
+                .ToList();
+        }
+
+        private static bool MatchesIncludeExclude(Repository repo, SourceControlServerSettings settings)
+        {
+            return RegexMatch.IncludeExclude(repo.Name, settings.IncludeRepos, settings.ExcludeRepos);
+        }
+
+        private static bool RepoIsModifiable(Repository repo)
+        {
+            return
+                !repo.Archived &&
+                repo.UserPermissions.Pull;
+        }
+
+        private RepositorySettings CreateRepositorySettings(string org, Uri repositoryUri, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
+        {
+            ApiUri = string.IsNullOrWhiteSpace(org) ? new Uri($"https://dev.azure.com/") : new Uri($"https://dev.azure.com/{org}/"),
+            RepositoryUri = PasswordReplacedRepositoryUri(repositoryUri),
+            RepositoryName = repoName,
+            RepositoryOwner = project,
+            RemoteInfo = remoteInfo
+        };
+
+        private Uri PasswordReplacedRepositoryUri(Uri repositoryUri)
+        {
+            //Workaround for https://github.com/libgit2/libgit2sharp/issues/1596
+            return new Uri(repositoryUri.ToString().Replace("--PasswordToReplace--", _token));
         }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -139,5 +139,11 @@ namespace NuKeeper.AzureDevOps
             var labelContent = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PostResource<LabelResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}/labels", labelContent, true);
         }
+
+        public async Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string azureRepositoryId)
+        {
+            var response = await GetResource<GitItemResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/items?recursionLevel=Full");
+            return response?.value.Select(v => v.path).AsEnumerable();
+        }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -119,9 +119,25 @@ namespace NuKeeper.AzureDevOps
             return false;
         }
 
-        public Task<SearchCodeResult> Search(SearchCodeRequest search)
+        public async Task<SearchCodeResult> Search(SearchCodeRequest searchRequest)
         {
-            throw new NotImplementedException();
+            var totalCount = 0;
+            var repositoryFileNames = new List<string>();
+            foreach (var repo in searchRequest.Repos)
+            {
+                repositoryFileNames.AddRange(await _client.GetGitRepositoryFileNames(repo.Owner, repo.Name));
+            }
+
+            var searchStrings = searchRequest.Term
+                .Replace("\"", string.Empty)
+                .Split(new[] { "OR" }, StringSplitOptions.None);
+
+            foreach (var searchString in searchStrings)
+            {
+                totalCount += repositoryFileNames.FindAll(x => x.EndsWith(searchString.Trim(), StringComparison.InvariantCultureIgnoreCase)).Count;
+            }
+
+            return new SearchCodeResult(totalCount);
         }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -145,4 +145,15 @@ namespace NuKeeper.AzureDevOps
         public int count { get; set; }
         public IEnumerable<Label> value { get; set; }
     }
+
+    public class GitItemResource
+    {
+        public int count { get; set; }
+        public IEnumerable<GitItem> value { get; set; }
+    }
+
+    public class GitItem
+    {
+        public string path { get; set; }
+    }
 }

--- a/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
+++ b/NuKeeper.Tests/Commands/OrganisationCommandTests.cs
@@ -11,18 +11,20 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuKeeper.Abstractions.Git;
+using NuKeeper.AzureDevOps;
 
 namespace NuKeeper.Tests.Commands
 {
     [TestFixture]
     public class OrganisationCommandTests
     {
-        private static CollaborationFactory GetCollaborationFactory()
+        private static CollaborationFactory GetCollaborationFactory(Func<IGitDiscoveryDriver, IEnvironmentVariablesProvider, ISettingsReader> createSettingsReader)
         {
             var environmentVariablesProvider = Substitute.For<IEnvironmentVariablesProvider>();
 
             return new CollaborationFactory(
-                new ISettingsReader[] { new GitHubSettingsReader(new MockedGitDiscoveryDriver(), environmentVariablesProvider) },
+                new ISettingsReader[] { createSettingsReader(new MockedGitDiscoveryDriver(), environmentVariablesProvider) },
                 Substitute.For<INuKeeperLogger>()
             );
         }
@@ -34,7 +36,7 @@ namespace NuKeeper.Tests.Commands
             var logger = Substitute.For<IConfigureLogger>();
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
-            var collaborationFactory = GetCollaborationFactory();
+            var collaborationFactory = GetCollaborationFactory((d, e) => new GitHubSettingsReader(d, e));
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
 
@@ -54,11 +56,11 @@ namespace NuKeeper.Tests.Commands
             var fileSettings = Substitute.For<IFileSettingsCache>();
             fileSettings.GetSettings().Returns(FileSettings.Empty());
 
-            var collaborationFactory = GetCollaborationFactory();
+            var collaborationFactory = GetCollaborationFactory((d, e) => new GitHubSettingsReader(d, e));
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
             command.PersonalAccessToken = "abc";
-            command.GithubOrganisationName = "testOrg";
+            command.OrganisationName = "testOrg";
 
             var status = await command.OnExecute();
 
@@ -69,7 +71,30 @@ namespace NuKeeper.Tests.Commands
         }
 
         [Test]
-        public async Task ShouldPopulateGithubSettings()
+        public async Task ShouldCallEngineAndSucceedWithRequiredAzureDevOpsParams()
+        {
+            var engine = Substitute.For<ICollaborationEngine>();
+            var logger = Substitute.For<IConfigureLogger>();
+            var fileSettings = Substitute.For<IFileSettingsCache>();
+            fileSettings.GetSettings().Returns(FileSettings.Empty());
+
+            var collaborationFactory = GetCollaborationFactory((d, e) => new AzureDevOpsSettingsReader(d, e));
+
+            var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
+            command.PersonalAccessToken = "abc";
+            command.OrganisationName = "testOrg";
+            command.ApiEndpoint = "https://dev.azure.com/org";
+
+            var status = await command.OnExecute();
+
+            Assert.That(status, Is.EqualTo(0));
+            await engine
+                .Received(1)
+                .Run(Arg.Any<SettingsContainer>());
+        }
+
+        [Test]
+        public async Task ShouldPopulateSettings()
         {
             var fileSettings = FileSettings.Empty();
 
@@ -295,11 +320,11 @@ namespace NuKeeper.Tests.Commands
 
             fileSettings.GetSettings().Returns(settingsIn);
 
-            var collaborationFactory = GetCollaborationFactory();
+            var collaborationFactory = GetCollaborationFactory((d, e) => new GitHubSettingsReader(d, e));
 
             var command = new OrganisationCommand(engine, logger, fileSettings, collaborationFactory);
             command.PersonalAccessToken = "testToken";
-            command.GithubOrganisationName = "testOrg";
+            command.OrganisationName = "testOrg";
 
             if (addCommandRepoInclude)
             {

--- a/NuKeeper/Collaboration/CollaborationFactory.cs
+++ b/NuKeeper/Collaboration/CollaborationFactory.cs
@@ -134,7 +134,7 @@ namespace NuKeeper.Collaboration
             {
                 case Platform.AzureDevOps:
                     CollaborationPlatform = new AzureDevOpsPlatform(_nuKeeperLogger);
-                    RepositoryDiscovery = new AzureDevOpsRepositoryDiscovery(_nuKeeperLogger, Settings.Token);
+                    RepositoryDiscovery = new AzureDevOpsRepositoryDiscovery(_nuKeeperLogger, CollaborationPlatform, Settings.Token);
                     ForkFinder = new AzureDevOpsForkFinder(CollaborationPlatform, _nuKeeperLogger, forkMode);
 
                     // We go for the specific platform version of ICommitWorder

--- a/NuKeeper/Commands/OrganisationCommand.cs
+++ b/NuKeeper/Commands/OrganisationCommand.cs
@@ -8,11 +8,11 @@ using System.Threading.Tasks;
 
 namespace NuKeeper.Commands
 {
-    [Command("org", "o", "organization", "organisation", Description = "Performs version checks and generates pull requests for all repositories in a github organisation.")]
+    [Command("org", "o", "organization", "organisation", Description = "Performs version checks and generates pull requests for all repositories in a github organisation or an Azure DevOps project.")]
     internal class OrganisationCommand : MultipleRepositoryCommand
     {
-        [Argument(0, Name = "GitHub organisation name", Description = "The organisation to scan.")]
-        public string GithubOrganisationName { get; set; }
+        [Argument(0, Name = "Organisation name", Description = "The organisation to scan.")]
+        public string OrganisationName { get; set; }
 
         public OrganisationCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory)
             : base(engine, logger, fileSettingsCache, collaborationFactory)
@@ -31,7 +31,7 @@ namespace NuKeeper.Commands
             }
 
             settings.SourceControlServerSettings.Scope = ServerScope.Organisation;
-            settings.SourceControlServerSettings.OrganisationName = GithubOrganisationName;
+            settings.SourceControlServerSettings.OrganisationName = OrganisationName;
             return ValidationResult.Success;
         }
     }

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsRestClientTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsRestClientTests.cs
@@ -339,6 +339,27 @@ namespace Nukeeper.AzureDevOps.Tests
         }
 
         [Test]
+        public async Task RetrievesFileNames()
+        {
+            var gitItemResource = new GitItemResource()
+            {
+                value = new List<GitItem>
+                {
+                    new GitItem { path = "/src/file.cs"},
+                    new GitItem { path = "/src/project.csproj"},
+                    new GitItem { path = "/README.md"},
+                    
+                },
+                count = 3
+            };
+
+            var restClient = GetFakeClient(gitItemResource);
+            var request = new LabelRequest { name = "nukeeper" };
+            var fileNames = await restClient.GetGitRepositoryFileNames("ProjectName", "RepoId");
+            Assert.IsNotNull(fileNames);
+            Assert.That(fileNames, Is.EquivalentTo(new [] { "/src/file.cs", "/src/project.csproj", "/README.md"}));
+        }
+        
         [TestCase("proj/_apis/git/repositories/Id/pullrequests", false, "proj/_apis/git/repositories/Id/pullrequests?api-version=4.1")]
         [TestCase("proj/_apis/git/repositories/Id/pullrequests", true, "proj/_apis/git/repositories/Id/pullrequests?api-version=4.1-preview.1")]
         [TestCase("proj/_apis/git/repositories/Id/pullrequests?searchCriteria.sourceRefName=head", false, "proj/_apis/git/repositories/Id/pullrequests?searchCriteria.sourceRefName=head&api-version=4.1")]

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -39,7 +39,7 @@ Options:
 Commands:
   global        Performs version checks and generates pull requests for all repositories the provided token can access.
   inspect       Checks projects existing locally for possible updates.
-  org           Performs version checks and generates pull requests for all repositories in a github organisation.
+  org           Performs version checks and generates pull requests for all repositories in a github organisation or an Azure DevOps project.
   repo          Performs version checks and generates pull requests for a single repository.
   update        Applies relevant updates to a local project.
 ```

--- a/site/content/commands/global.md
+++ b/site/content/commands/global.md
@@ -3,11 +3,17 @@ title: "Global"
 ---
 
 {{% notice info %}}
-This command is only available for github
+This command is only available for github and Azure DevOps
 {{% /notice %}}
 
-Use the global command to update a particular package across your entire github server.
+Use the global command to update a particular package across your entire github server or Azure DevOps organization.
 
+[Github](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
 ```sh
-nukeeper global mygithubtoken --include PackageToUpdate --api https://github.mycompany.com/api/v3
+nukeeper global token --include PackageToUpdate --api https://github.mycompany.com/api/v3
+```
+
+[Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts)
+```sh
+nukeeper global token --include PackageToUpdate --api https://dev.azure.com/organization
 ```

--- a/site/content/commands/organisation.md
+++ b/site/content/commands/organisation.md
@@ -3,12 +3,18 @@ title: "Organisation"
 ---
 
 {{% notice info %}}
-This command is only available for github
+This command is only available for github and Azure DevOps
 {{% /notice %}}
 
-Use the organisation command to raise multiple pull requests against multiple GitHub repositories within the same [GitHub Organisation](https://help.github.com/articles/about-organizations/).
+Use the organisation command to raise multiple pull requests against multiple GitHub repositories within the same [GitHub Organisation](https://help.github.com/articles/about-organizations/) or within the same Azure DevOps project.
 
+[Github](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
 ```sh
-nukeeper org myteam mygithubtoken
+nukeeper org myteam token
+```
+
+[Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts)
+```sh
+nukeeper org project token --include PackageToUpdate --api https://dev.azure.com/organization
 ```
 

--- a/site/content/platform/azure-devops.md
+++ b/site/content/platform/azure-devops.md
@@ -6,7 +6,7 @@ title: "Azure Devops"
 NuKeeper supports Azure Devops, VSTS and TFS on premise. The same instruction apply for all these platforms!
 {{% /notice %}}
 
-NuKeeper supports integration with Azure Devops in two ways. One of them is to use the **repo** command and the other one is through the **extension**. The benefit of the extension is that you can make a build pipeline with the extension and schedule your pipeline. This way you can automate your updating flow.
+NuKeeper supports integration with Azure Devops in two ways. One of them is to use the **repo**, **org** or **global** commands and the other one is through the **extension**. The benefit of the extension is that you can make a build pipeline with the extension and schedule your pipeline. This way you can automate your updating flow.
 
 ## Extension
 
@@ -80,6 +80,22 @@ The repo command works for azure-devops & vsts they same as for the other platfo
 
 ```sh
 nukeeper repo "https://dev.azure.com/{org}/{project}/_git/{repo}/" <PAT>
+```
+
+## Organisation command
+
+Use the organisation command to raise multiple pull requests against multiple git repositories within the same Azure DevOps project.
+
+```sh
+nukeeper org project <PAT> --api https://dev.azure.com/myAzureDevOpsorganization
+```
+
+## Global command
+
+Use the global command to update a particular package across your entire Azure DevOps organization.
+
+```sh
+nukeeper global <PAT> --api https://dev.azure.com/myAzureDevOpsorganization --include PackageToUpdate
 ```
 
 ### Additional arguments


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature & Docs update

### :arrow_heading_down: What is the current behavior?
**org** and **global** commands are not working with Azure DevOps

### :new: What is the new behavior (if this is a feature change)?
**org** and **global** commands are supported with Azure DevOps.
You will need to provide the **api** parameter the **Azure DevOps organization uri** for these commands to work, as it will direct NuKeeper to Azure DevOps platform.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run org and global commands against Azure DevOps organizations and projects.
Note that 
- Azure DevOps **organization** are similar to NuKeeper **global** concept
- Azure DevOps **projects** are similar to NuKeeper **organisation** concept

### :memo: Links to relevant issues/docs
#864 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
