### PR TITLE
Quote package sources that contain spaces

### DIFF
--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -49,7 +49,7 @@ namespace NuKeeper.Update.Process
 
             if (result.IndexOf(" ", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                return Uri.EscapeUriString(result);
+                return "\"" + result + "\"";
             }
 
             return result;

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Versioning;
@@ -21,7 +22,7 @@ namespace NuKeeper.Update.Process
         {
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
-            var sourceUrl = packageSource.SourceUri.ToString();
+            var sourceUrl = EscapedUri(packageSource.SourceUri);
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";
@@ -35,6 +36,23 @@ namespace NuKeeper.Update.Process
 
             var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
+        }
+
+        private static string EscapedUri(Uri uri)
+        {
+            if (uri == null)
+            {
+                return string.Empty;
+            }
+
+            var result = uri.ToString();
+
+            if (result.IndexOf(" ", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return Uri.EscapeUriString(result);
+            }
+
+            return result;
         }
     }
 }

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
 using NuGet.Configuration;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.NuGet;
@@ -22,7 +23,7 @@ namespace NuKeeper.Update.Process
         {
             var projectPath = currentPackage.Path.Info.DirectoryName;
             var projectFileName = currentPackage.Path.Info.Name;
-            var sourceUrl = EscapedUri(packageSource.SourceUri);
+            var sourceUrl = UriEscapedForArgument(packageSource.SourceUri);
             var sources = allSources.CommandLine("-s");
 
             var restoreCommand = $"restore {projectFileName} {sources}";
@@ -38,21 +39,14 @@ namespace NuKeeper.Update.Process
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
 
-        private static string EscapedUri(Uri uri)
+        private static string UriEscapedForArgument(Uri uri)
         {
             if (uri == null)
             {
                 return string.Empty;
             }
 
-            var result = uri.ToString();
-
-            if (result.IndexOf(" ", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return "\"" + result + "\"";
-            }
-
-            return result;
+            return ArgumentEscaper.EscapeAndConcatenate(new string[] { uri.ToString() });
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix for space in url, issue For https://github.com/NuKeeperDotNet/NuKeeper/issues/942


### :arrow_heading_down: What is the current behavior?

`DotNetUpdatePackageCommand` fails at the "dotnet add" step when the package source is a url containing a space, as this is not correctly handled by the commandline unless it is escaped.

### :new: What is the new behavior (if this is a feature change)?

Should not fail any more, the url should be passed to `dotnet add`
We could also escape the url with turning spaces to `%20` via `Uri.EscapeUriString`
Some of these uris will be local folder paths, not `http://` uris, so those also need quoting.
So I think that `" "` quoting is preferred - the issue is really with a command-line param containing a space, so quoting it with `" "` seems a more accurate fix.

### :boom: Does this PR introduce a breaking change?

No, it only happens on package sources with spaces in the uri.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
