### PR TITLE
Automatic update of Newtonsoft.Json to 12.0.3

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.CommandLine" Version="5.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Newtonsoft.Json` to `12.0.3` from `12.0.2`
`Newtonsoft.Json 12.0.3` was published at `2019-11-09T01:27:30Z`, 6 months ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Newtonsoft.Json` `12.0.3` from `12.0.2`

[Newtonsoft.Json 12.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
