### PR TITLE
Automatic update of System.Text.Encoding.CodePages to 4.7.0

### DIFF
--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="5.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.Text.Encoding.CodePages` to `4.7.0` from `4.6.0`
`System.Text.Encoding.CodePages 4.7.0` was published at `2019-12-03T16:41:49Z`, 5 months ago

1 project update:
Updated `NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `System.Text.Encoding.CodePages` `4.7.0` from `4.6.0`

[System.Text.Encoding.CodePages 4.7.0 on NuGet.org](https://www.nuget.org/packages/System.Text.Encoding.CodePages/4.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
