### PR TITLE
Automatic update of LibGit2Sharp to 0.26.2

### DIFF
--- a/NuKeeper.Git/NuKeeper.Git.csproj
+++ b/NuKeeper.Git/NuKeeper.Git.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `LibGit2Sharp` to `0.26.2` from `0.26.1`
`LibGit2Sharp 0.26.2` was published at `2019-12-11T09:05:55Z`, 5 months ago

1 project update:
Updated `NuKeeper.Git\NuKeeper.Git.csproj` to `LibGit2Sharp` `0.26.2` from `0.26.1`

[LibGit2Sharp 0.26.2 on NuGet.org](https://www.nuget.org/packages/LibGit2Sharp/0.26.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
