### PR TITLE
Automatic update of NuGet.Credentials to 5.5.1

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Credentials" Version="5.2.0" />
+    <PackageReference Include="NuGet.Credentials" Version="5.5.1" />
     <PackageReference Include="SimpleInjector" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Credentials` to `5.5.1` from `5.2.0`
`NuGet.Credentials 5.5.1` was published at `2020-04-03T21:21:06Z`, 1 month ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.Credentials` `5.5.1` from `5.2.0`

[NuGet.Credentials 5.5.1 on NuGet.org](https://www.nuget.org/packages/NuGet.Credentials/5.5.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
