### PR TITLE
Automatic update of Octokit to 0.47.0

### DIFF
--- a/NuKeeper.GitHub/NuKeeper.GitHub.csproj
+++ b/NuKeeper.GitHub/NuKeeper.GitHub.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Octokit" Version="0.47.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Octokit" Version="0.47.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Octokit` to `0.47.0` from `0.36.0`
`Octokit 0.47.0` was published at `2020-04-12T16:45:31Z`, 21 days ago

2 project updates:
Updated `NuKeeper.GitHub\NuKeeper.GitHub.csproj` to `Octokit` `0.47.0` from `0.36.0`
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `Octokit` `0.47.0` from `0.36.0`

[Octokit 0.47.0 on NuGet.org](https://www.nuget.org/packages/Octokit/0.47.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
