### PR TITLE
Automatic update of NuGet.CommandLine to 5.5.1

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.2.0">
+    <PackageReference Include="NuGet.CommandLine" Version="5.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.CommandLine` to `5.5.1` from `5.2.0`
`NuGet.CommandLine 5.5.1` was published at `2020-04-16T00:02:16Z`, 18 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.CommandLine` `5.5.1` from `5.2.0`

[NuGet.CommandLine 5.5.1 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/5.5.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
