### PR TITLE
Automatic update of McMaster.Extensions.CommandLineUtils to 3.0.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.5.1" />
   </ItemGroup>
 

--- a/NuKeeper/Program.cs
+++ b/NuKeeper/Program.cs
@@ -26,7 +26,7 @@ namespace NuKeeper
         {
             var container = ContainerRegistration.Init();
 
-            var app = new CommandLineApplication<Program> { ThrowOnUnexpectedArgument = false };
+            var app = new CommandLineApplication<Program> { UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect };
             app.Conventions.UseDefaultConventions().UseConstructorInjection(container);
 
             try


### PR DESCRIPTION
NuKeeper has generated a major update of `McMaster.Extensions.CommandLineUtils` to `3.0.0` from `2.4.2`
`McMaster.Extensions.CommandLineUtils 3.0.0` was published at `2020-03-29T22:11:16Z`, 2 months ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `McMaster.Extensions.CommandLineUtils` `3.0.0` from `2.4.2`

[McMaster.Extensions.CommandLineUtils 3.0.0 on NuGet.org](https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils/3.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
