### PR TITLE
Escape all sources when they need it

### DIFF
--- a/NuKeeper.Abstractions/NuGet/NuGetSources.cs
+++ b/NuKeeper.Abstractions/NuGet/NuGetSources.cs
@@ -45,7 +45,7 @@ namespace NuKeeper.Abstractions.NuGet
         public string CommandLine(string prefix)
         {
             return Items
-                .Select(s => $"{prefix} {EscapePathIfLocal(s)}")
+                .Select(s => $"{prefix} {EscapeSource(s)}")
                 .JoinWithSeparator(" ");
         }
 
@@ -54,9 +54,9 @@ namespace NuKeeper.Abstractions.NuGet
             return Items.Select(s => s.SourceUri.ToString()).JoinWithCommas();
         }
 
-        private static string EscapePathIfLocal(PackageSource source)
+        private static string EscapeSource(PackageSource source)
         {
-            return source.IsLocal ? ArgumentEscaper.EscapeAndConcatenate(new[] { source.Source }) : source.Source;
+            return ArgumentEscaper.EscapeAndConcatenate(new[] { source.Source });
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix potential bug with remote sources where the url contains a space
The need for escaping the source in an arg doesn't depend on if it's a local (file) or remote (http/s) uri. It depends only on if there is a space in it or not. This can be in either, although it's more likely in a file path with "C:\Program Files" etc
ArgumentEscaper will check for spaces and handle it when needed. [Code](https://github.com/natemcmaster/CommandLineUtils/blob/master/src/CommandLineUtils/Utilities/ArgumentEscaper.cs)

Follow-on from https://github.com/NuKeeperDotNet/NuKeeper/pull/943
particularly https://github.com/NuKeeperDotNet/NuKeeper/pull/943#issuecomment-621322856


### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
