### PR TITLE
Update Microsoft.CodeAnalysis.FxCopAnalyzers to 3.0

### DIFF
--- a/CodeAnalysisRules.ruleset
+++ b/CodeAnalysisRules.ruleset
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="CodeProjects" Description="Code analysis rules for NuKeeper Code." ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
   </Rules>
 </RuleSet>

--- a/CodeAnalysisRulesForTests.ruleset
+++ b/CodeAnalysisRulesForTests.ruleset
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="TestProjects" Description="Code analysis rules for NuKeeper Tests." ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
   </Rules>
 </RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -57,7 +57,7 @@ namespace NuKeeper.AzureDevOps
             return settings;
         }
 
-        private RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
         {
             // URL pattern is 
             // https://dev.azure.com/{org}/{project}/_git/{repo}/

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -49,13 +49,13 @@ namespace NuKeeper.AzureDevOps
                 : CreateSettingsFromRemote(repositoryUri);
             if (settings == null)
             {
-                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
+                throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be {UrlPattern}");
             }
 
             return settings;
         }
 
-        private RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
         {
             // URL pattern is
             // https://{org}.visualstudio.com/{project}/_git/{repo} or

--- a/NuKeeper.Git.Tests/GitCmdDiscoveryDriverTest.cs
+++ b/NuKeeper.Git.Tests/GitCmdDiscoveryDriverTest.cs
@@ -63,9 +63,9 @@ namespace NuKeeper.Git.Tests
             Assert.IsNotNull(remotesArray, "GitCmdDiscoveryDriver returned null for GetRemotes");
             Assert.IsNotNull(classicRemotesArray, "LibGit2SharpDiscoveryDriver returned null for GetRemotes");
 
-            Assert.AreEqual(remotesArray?.Count(), classicRemotesArray?.Count(), "Lib2Sharp and GitCmd should have the same number of results");
+            Assert.AreEqual(remotesArray?.Length, classicRemotesArray?.Length, "Lib2Sharp and GitCmd should have the same number of results");
 
-            for(var count=0; count< classicRemotesArray.Count(); count++)
+            for(var count=0; count< classicRemotesArray.Length; count++)
             {
                 var classicRemote = classicRemotesArray[count];
                 var remote = remotesArray.Where(r => r.Name.Equals(classicRemote.Name, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();

--- a/NuKeeper.Git.Tests/GitCmdDriverTest.cs
+++ b/NuKeeper.Git.Tests/GitCmdDriverTest.cs
@@ -79,7 +79,7 @@ namespace NuKeeper.Git.Tests
                     .Select(b=>b.Trim()).ToArray();
 
                 var master = branchNames.Where(b => b.EndsWith("/master", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
-                if(master != null && branchNames.Count() > 1)
+                if(master != null && branchNames.Length > 1)
                 {
                     var headBranch = branchNames.First(b => !b.Equals(master,StringComparison.InvariantCultureIgnoreCase));
                     var localHeadBranch = Regex.Replace(headBranch, "^origin/", "");

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -45,7 +45,7 @@ namespace NuKeeper.GitHub
         {
             var envToken = _environmentVariablesProvider.GetEnvironmentVariable("NuKeeper_github_token");
             settings.Token = Concat.FirstValue(envToken, settings.Token);
-            settings.ForkMode = settings.ForkMode ?? ForkMode.PreferFork;
+            settings.ForkMode ??= ForkMode.PreferFork;
         }
 
         public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, string targetBranch = null)
@@ -108,7 +108,7 @@ namespace NuKeeper.GitHub
             };
         }
 
-        private RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -234,7 +234,7 @@ namespace NuKeeper.GitHub
             }
         }
 
-        private async Task<T> ExceptionHandler<T>(Func<Task<T>> funcToCheck)
+        private static async Task<T> ExceptionHandler<T>(Func<Task<T>> funcToCheck)
         {
             try
             {

--- a/NuKeeper.Gitea/GiteaPlatform.cs
+++ b/NuKeeper.Gitea/GiteaPlatform.cs
@@ -115,7 +115,7 @@ namespace NuKeeper.Gitea
             throw new NotImplementedException();
         }
 
-        private Organization MapOrganization(Gitea.Model.Organization x)
+        private static Organization MapOrganization(Gitea.Model.Organization x)
         {
             return new Organization(x.FullName);
         }

--- a/NuKeeper.Gitea/GiteaSettingsReader.cs
+++ b/NuKeeper.Gitea/GiteaSettingsReader.cs
@@ -99,11 +99,13 @@ namespace NuKeeper.Gitea
             });
         }
 
-        private Uri GetBaseAddress(Uri repoUri)
+        private static Uri GetBaseAddress(Uri repoUri)
         {
             var newSegments = repoUri.Segments.Take(repoUri.Segments.Length - 2).ToArray();
-            var ub = new UriBuilder(repoUri);
-            ub.Path = string.Concat(newSegments);
+            var ub = new UriBuilder(repoUri)
+            {
+                Path = string.Concat(newSegments)
+            };
 
             return ub.Uri;
         }

--- a/NuKeeper.Integration.Tests/Engine/ExistingCommitFilterTest.cs
+++ b/NuKeeper.Integration.Tests/Engine/ExistingCommitFilterTest.cs
@@ -40,7 +40,7 @@ namespace NuKeeper.Integration.Tests.Engine
 
             var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head");
 
-            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual(1, result.Count);
             Assert.AreEqual("First.Nuget", result.FirstOrDefault()?.SelectedId);
         }
 
@@ -66,7 +66,7 @@ namespace NuKeeper.Integration.Tests.Engine
 
             var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head");
 
-            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(2, result.Count);
         }
 
         private IExistingCommitFilter MakeExistingCommitFilter()
@@ -87,13 +87,13 @@ namespace NuKeeper.Integration.Tests.Engine
         {
             return Task.Run(() =>
             {
-                return (IReadOnlyCollection<string>)ids.Select(id => createCommitMessage(id, new NuGetVersion("3.0.0"))).ToList().AsReadOnly();
+                return (IReadOnlyCollection<string>)ids.Select(id => CreateCommitMessage(id, new NuGetVersion("3.0.0"))).ToList().AsReadOnly();
             });
         }
 
         private static IGitDriver MakeGitDriver(string[] ids)
         {
-            var l = ids.Select(id => createCommitMessage(id, new NuGetVersion("3.0.0"))).ToArray();
+            var l = ids.Select(id => CreateCommitMessage(id, new NuGetVersion("3.0.0"))).ToArray();
 
             var git = Substitute.For<IGitDriver>();
             git.GetNewCommitMessages(Arg.Any<string>(), Arg.Any<string>())
@@ -102,7 +102,7 @@ namespace NuKeeper.Integration.Tests.Engine
             return git;
         }
 
-        private static string createCommitMessage(string id, NuGetVersion version)
+        private static string CreateCommitMessage(string id, NuGetVersion version)
         {
             return $"Automatic update of {id} to {version}";
         }

--- a/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
+++ b/NuKeeper.Tests/Engine/PackageUpdateSelectionTests.cs
@@ -87,18 +87,13 @@ namespace NuKeeper.Tests.Engine
             return new PackageUpdateSelection(MakeSort(), updateSelection, logger);
         }
 
-        private FilterSettings NoFilter()
+        private static FilterSettings NoFilter()
         {
             return new FilterSettings
             {
-                MaxPackageUpdates = Int32.MaxValue,
+                MaxPackageUpdates = int.MaxValue,
                 MinimumAge = TimeSpan.Zero
             };
-        }
-
-        private BranchSettings DefaultBranchSettings()
-        {
-            return new BranchSettings();
         }
 
         private static ForkData PushFork()

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -203,7 +203,7 @@ namespace NuKeeper.Tests.Engine
                 .Returns(new List<PackageUpdateSet>());
         }
 
-        private SettingsContainer MakeSettings(bool consolidateUpdates = false)
+        private static SettingsContainer MakeSettings(bool consolidateUpdates = false)
         {
             return new SettingsContainer
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Update `Microsoft.CodeAnalysis.FxCopAnalyzers` to 3.0 in `Directory.Build.props`
and make minimum changes to get it building without warning again

Warnings disabled:

Null checks ( https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1062 ) - we need more null checks and/or more internal methods before turning that rule on
Disposing (CA2000) looks like we can't, for reasons given here https://jmarcher.io/ca2000-welcome-to-hell/



### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
