### PR TITLE
Resolve CA1062 for NuKeeper.Abstractions

### DIFF
--- a/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Abstractions.CollaborationModels
             DeleteBranchAfterMerge = deleteBranchAfterMerge;
 
             //This can be a remote that has been passed in, this happens when run locally against a targetbranch that is remote
-            BaseRef = baseRef.Replace("origin/", string.Empty);
+            BaseRef = baseRef?.Replace("origin/", string.Empty);
         }
 
         public string Head { get; }

--- a/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
+++ b/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
@@ -11,6 +11,11 @@ namespace NuKeeper.Abstractions.Configuration
 
         public RepositorySettings(Repository repository)
         {
+            if (repository == null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
             RepositoryUri = repository.CloneUrl;
             RepositoryOwner = repository.Owner.Login;
             RepositoryName = repository.Name;

--- a/NuKeeper.Abstractions/Formats/StringExtensions.cs
+++ b/NuKeeper.Abstractions/Formats/StringExtensions.cs
@@ -21,6 +21,11 @@ namespace NuKeeper.Abstractions.Formats
             string value,
             StringComparison comparisonType)
         {
+            if (subject == null)
+            {
+                throw new ArgumentNullException(nameof(subject));
+            }
+
             return subject.IndexOf(value, 0, subject.Length, comparisonType) >= 0;
         }
     }

--- a/NuKeeper.Abstractions/Formats/UriFormats.cs
+++ b/NuKeeper.Abstractions/Formats/UriFormats.cs
@@ -26,6 +26,11 @@ namespace NuKeeper.Abstractions.Formats
 
         public static async Task<Uri> GetRemoteUriFromLocalRepo(this Uri repositoryUri, IGitDiscoveryDriver discoveryDriver, string shouldMatchTo)
         {
+            if (discoveryDriver == null)
+            {
+                throw new ArgumentNullException(nameof(discoveryDriver));
+            }
+
             if (await discoveryDriver.IsGitRepo(repositoryUri))
             {
                 // Check the origin remotes

--- a/NuKeeper.Abstractions/NuGet/VersionRanges.cs
+++ b/NuKeeper.Abstractions/NuGet/VersionRanges.cs
@@ -6,7 +6,7 @@ namespace NuKeeper.Abstractions.NuGet
     {
         public static NuGetVersion SingleVersion(VersionRange range)
         {
-            if (range.IsFloating || range.HasLowerAndUpperBounds)
+            if (range == null || range.IsFloating || range.HasLowerAndUpperBounds)
             {
                 return null;
             }


### PR DESCRIPTION
This removes a workaround from StringExtensions, which requires bumping the target SDK on several projects - which in turn requires temporarily disabling CA2234, in order to limit the scope of the change.