### PR TITLE
[Bitbucket Local] Add new API call to get the current BitBucket Server user details

### DIFF
--- a/NuKeeper.Git.Tests/TestDirectoryHelper.cs
+++ b/NuKeeper.Git.Tests/TestDirectoryHelper.cs
@@ -74,7 +74,16 @@ namespace NuKeeper.Git.Tests
 
             foreach (var subdirectory in subdirectories)
             {
-                NormalizeAttributes(subdirectory);
+                // This checks the directory exists and is valid.
+                // This is to workaround it failing to normalise some subdirectories on Azure DevOps
+                if (Directory.Exists(subdirectory.FullName))
+                {
+                    NormalizeAttributes(subdirectory);
+                }
+                else
+                {
+                    Console.WriteLine("Cannot normalize attributes for directory '{0}' since does not exist or is not valid", subdirectory.FullName);
+                }
             }
 
             File.SetAttributes(toNormalize.FullName, FileAttributes.Normal);

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Repository = NuKeeper.Abstractions.CollaborationModels.Repository;
-
+using User = NuKeeper.Abstractions.CollaborationModels.User;
 
 namespace NuKeeper.BitBucketLocal
 {
@@ -35,9 +35,10 @@ namespace NuKeeper.BitBucketLocal
             _client = new BitbucketLocalRestClient(httpClient, _logger, settings.Username, settings.Token);
         }
 
-        public Task<User> GetCurrentUser()
+        public async Task<User> GetCurrentUser()
         {
-            return Task.FromResult(new User(_settings.Username, "", ""));
+            var bitBucketUser = await _client.GetCurrentUser(_settings.Username);
+            return bitBucketUser != null ? new User(_settings.Username, bitBucketUser.DisplayName, bitBucketUser.EmailAddress) : new User(_settings.Username, "", "");
         }
 
         public async Task<bool> PullRequestExists(ForkData target, string headBranch, string baseBranch)

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -86,12 +86,18 @@ namespace NuKeeper.BitBucketLocal
             }
         }
 
+        public async Task<User> GetCurrentUser(string username, [CallerMemberName] string caller = null)
+        {
+            var users = await GetResourceOrEmpty<IteratorBasedPage<User>>($@"{ApiPath}/users?filter={username}", caller);
+            var user = users.Values.FirstOrDefault(x => x.Name.Equals(username, StringComparison.InvariantCultureIgnoreCase));
+            return user;
+        }
+
         public async Task<IEnumerable<Repository>> GetProjects([CallerMemberName] string caller = null)
         {
             var response = await GetResourceOrEmpty<IteratorBasedPage<Repository>>($@"{ApiPath}/projects?limit=999", caller);
             return response.Values;
         }
-
 
         public async Task<IEnumerable<Repository>> GetGitRepositories(string projectName, [CallerMemberName] string caller = null)
         {

--- a/Nukeeper.BitBucketLocal/Models/User.cs
+++ b/Nukeeper.BitBucketLocal/Models/User.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace NuKeeper.BitBucketLocal.Models
+{
+    public class User
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("emailAddress")]
+        public string EmailAddress { get; set; }
+
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("active")]
+        public string Active { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}


### PR DESCRIPTION
This adds a new API call for BitBucket Server (local) to get the user details from the username provided to use in creating a valid git user for the platform if possible.

Changed GetCurrentUser to use the actual user details if they can be read out instead of username and empty email which was causing it to always revert to using the git config

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Enhancement to use the user details from the user provided for BitBucket Server integration.

### :arrow_heading_down: What is the current behavior?

Currently only provides the username when creating a user for a commit signature, but this fails (since no name or email) and falls back to using the git config.

### :new: What is the new behavior (if this is a feature change)?

It will now attempt to lookup the user in BitBucket to get the name and email. If it cannot find the user, it will still fallback to the existing behaviour.

### :boom: Does this PR introduce a breaking change?

This will break any integrations which rely on it using the git config for the user that creates the commits and if this user is different to the username provided in the command line.

No impact on any other integrations or BitBucket Cloud.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
