### PR TITLE
Fix issue 866

### DIFF
--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -43,8 +43,7 @@ namespace NuKeeper.Update.Process
                 throw new ArgumentNullException(nameof(sources));
             }
 
-            var fileNameArg = ArgumentEscaper.EscapeAndConcatenate(new[] { file.Name });
-            _logger.Normal($"Nuget restore on {file.DirectoryName} {fileNameArg}");
+            _logger.Normal($"Nuget restore on {file.DirectoryName} {file.Name}");
 
             var nuget = _nuGetPath.Executable;
 
@@ -54,9 +53,10 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
+            var fileNameCommandLine = ArgumentEscaper.EscapeAndConcatenate(new[] { file.Name });
             var sourcesCommandLine = sources.CommandLine("-Source");
 
-            var restoreCommand = $"restore {fileNameArg} {sourcesCommandLine}  -NonInteractive";
+            var restoreCommand = $"restore {fileNameCommandLine} {sourcesCommandLine}  -NonInteractive";
 
             ProcessOutput processOutput;
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -84,12 +84,12 @@ namespace NuKeeper.Update.Process
 
             if (processOutput.Success)
             {
-                _logger.Detailed($"Nuget restore on {fileNameArg} complete");
+                _logger.Detailed($"Nuget restore on {file.Name} complete");
             }
             else
             {
                 _logger.Detailed(
-                    $"Nuget restore failed on {file.DirectoryName} {fileNameArg}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
+                    $"Nuget restore failed on {file.DirectoryName} {file.Name}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
             }
         }
 

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
 using NuGet.Configuration;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.Logging;
@@ -42,7 +43,8 @@ namespace NuKeeper.Update.Process
                 throw new ArgumentNullException(nameof(sources));
             }
 
-            _logger.Normal($"Nuget restore on {file.DirectoryName} {file.Name}");
+            var fileNameArg = ArgumentEscaper.EscapeAndConcatenate(new[] { file.Name });
+            _logger.Normal($"Nuget restore on {file.DirectoryName} {fileNameArg}");
 
             var nuget = _nuGetPath.Executable;
 
@@ -54,7 +56,7 @@ namespace NuKeeper.Update.Process
 
             var sourcesCommandLine = sources.CommandLine("-Source");
 
-            var restoreCommand = $"restore {file.Name} {sourcesCommandLine}  -NonInteractive";
+            var restoreCommand = $"restore {fileNameArg} {sourcesCommandLine}  -NonInteractive";
 
             ProcessOutput processOutput;
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -82,12 +84,12 @@ namespace NuKeeper.Update.Process
 
             if (processOutput.Success)
             {
-                _logger.Detailed($"Nuget restore on {file.Name} complete");
+                _logger.Detailed($"Nuget restore on {fileNameArg} complete");
             }
             else
             {
                 _logger.Detailed(
-                    $"Nuget restore failed on {file.DirectoryName} {file.Name}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
+                    $"Nuget restore failed on {file.DirectoryName} {fileNameArg}:\n{processOutput.Output}\n{processOutput.ErrorOutput}");
             }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix for https://github.com/NuKeeperDotNet/NuKeeper/issues/866

When there is a space in the file name, e.g. "My Solution.sln", it needs to be quoted on the command line
As before, `ArgumentEscaper.EscapeAndConcatenate` handles this

### :arrow_heading_down: What is the current behavior?

restore fails when the project name contains a space

### :new: What is the new behavior (if this is a feature change)?

restore does not fail

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
