### PR TITLE
Added support for PackageDownload and PackageVersion

### DIFF
--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageDownloadTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageDownloadTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NSubstitute;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class DirectoryBuildTargetsReaderPackageDownloadTests
+    {
+        const string PackagesFileWithSinglePackage =
+            @"<Project><ItemGroup><PackageDownload Include=""foo"" Version=""[1.2.3.4]"" /></ItemGroup></Project>";
+
+        private const string PackagesFileWithTwoPackages = @"<Project><ItemGroup>
+<PackageDownload Include=""foo"" Version=""[1.2.3.4]"" />
+<PackageDownload Update=""bar"" Version=""[2.3.4.5]"" /></ItemGroup></Project>";
+
+        [Test]
+        public void EmptyPackagesListShouldBeParsed()
+        {
+            const string emptyContents =
+                @"<Project/>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(emptyContents), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Not.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageFromVerboseFormatShouldBePopulated()
+        {
+            const string verboseFormatVersion =
+                @"<Project><ItemGroup><PackageDownload Include=""foo""><PrivateAssets>all</PrivateAssets><Version>1.2.3.4</Version></PackageDownload></ItemGroup></Project>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(verboseFormatVersion), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeCorrect()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Id, Is.EqualTo("foo"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
+        public void TwoPackagesShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            PackageAssert.IsPopulated(packages[0]);
+            PackageAssert.IsPopulated(packages[1]);
+        }
+
+        [Test]
+        public void TwoPackagesShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+
+            Assert.That(packages[1].Id, Is.EqualTo("bar"));
+            Assert.That(packages[1].Version, Is.EqualTo(new NuGetVersion("2.3.4.5")));
+        }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            var path = TempPath();
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), path);
+
+            foreach (var package in packages)
+            {
+                PackageAssert.IsPopulated(package);
+            }
+
+            Assert.That(packages.Select(p => p.Path), Is.All.EqualTo(path));
+        }
+
+        [Test]
+        public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
+        {
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(badVersion), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(1));
+            PackageAssert.IsPopulated(packages[0]);
+        }
+
+        private static PackagePath TempPath()
+        {
+            return new PackagePath(
+                OsSpecifics.GenerateBaseDirectory(),
+                Path.Combine("src", "Directory.Build.Props"),
+                PackageReferenceType.DirectoryBuildTargets);
+        }
+
+        private static DirectoryBuildTargetsReader MakeReader()
+        {
+            return new DirectoryBuildTargetsReader(Substitute.For<INuKeeperLogger>());
+        }
+
+        private static Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
+        }
+    }
+}

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageReferenceTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageReferenceTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace NuKeeper.Inspection.Tests.RepositoryInspection
 {
     [TestFixture]
-    public class DirectoryBuildTargetsReaderTests
+    public class DirectoryBuildTargetsReaderPackageReferenceTests
     {
         const string PackagesFileWithSinglePackage =
             @"<Project><ItemGroup><PackageReference Include=""foo"" Version=""1.2.3.4"" /></ItemGroup></Project>";

--- a/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageVersionTests.cs
+++ b/NuKeeper.Inspection.Tests/RepositoryInspection/DirectoryBuildTargetsReaderPackageVersionTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NSubstitute;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Inspection.RepositoryInspection;
+using NUnit.Framework;
+
+namespace NuKeeper.Inspection.Tests.RepositoryInspection
+{
+    [TestFixture]
+    public class DirectoryBuildTargetsReaderPackageVersionTests
+    {
+        const string PackagesFileWithSinglePackage =
+            @"<Project><ItemGroup><PackageVersion Include=""foo"" Version=""1.2.3.4"" /></ItemGroup></Project>";
+
+        private const string PackagesFileWithTwoPackages = @"<Project><ItemGroup>
+<PackageVersion Include=""foo"" Version=""1.2.3.4"" />
+<PackageVersion Update=""bar"" Version=""2.3.4.5"" /></ItemGroup></Project>";
+
+        [Test]
+        public void EmptyPackagesListShouldBeParsed()
+        {
+            const string emptyContents =
+                @"<Project/>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(emptyContents), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages, Is.Not.Empty);
+        }
+
+        [Test]
+        public void SinglePackageShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageFromVerboseFormatShouldBePopulated()
+        {
+            const string verboseFormatVersion =
+                @"<Project><ItemGroup><PackageVersion Include=""foo""><PrivateAssets>all</PrivateAssets><Version>1.2.3.4</Version></PackageVersion></ItemGroup></Project>";
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(verboseFormatVersion), TempPath());
+
+            var package = packages.FirstOrDefault();
+            PackageAssert.IsPopulated(package);
+        }
+
+        [Test]
+        public void SinglePackageShouldBeCorrect()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithSinglePackage), TempPath());
+
+            var package = packages.FirstOrDefault();
+
+            Assert.That(package, Is.Not.Null);
+            Assert.That(package.Id, Is.EqualTo("foo"));
+            Assert.That(package.Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+            Assert.That(package.Path.PackageReferenceType, Is.EqualTo(PackageReferenceType.DirectoryBuildTargets));
+        }
+
+        [Test]
+        public void TwoPackagesShouldBePopulated()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages, Is.Not.Null);
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            PackageAssert.IsPopulated(packages[0]);
+            PackageAssert.IsPopulated(packages[1]);
+        }
+
+        [Test]
+        public void TwoPackagesShouldBeRead()
+        {
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+
+            Assert.That(packages[0].Id, Is.EqualTo("foo"));
+            Assert.That(packages[0].Version, Is.EqualTo(new NuGetVersion("1.2.3.4")));
+
+            Assert.That(packages[1].Id, Is.EqualTo("bar"));
+            Assert.That(packages[1].Version, Is.EqualTo(new NuGetVersion("2.3.4.5")));
+        }
+
+        [Test]
+        public void ResultIsReiterable()
+        {
+            var path = TempPath();
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(PackagesFileWithTwoPackages), path);
+
+            foreach (var package in packages)
+            {
+                PackageAssert.IsPopulated(package);
+            }
+
+            Assert.That(packages.Select(p => p.Path), Is.All.EqualTo(path));
+        }
+
+        [Test]
+        public void WhenOnePackageCannotBeRead_TheOthersAreStillRead()
+        {
+            var badVersion = PackagesFileWithTwoPackages.Replace("1.2.3.4", "notaversion", StringComparison.OrdinalIgnoreCase);
+
+            var reader = MakeReader();
+            var packages = reader.Read(StreamFromString(badVersion), TempPath())
+                .ToList();
+
+            Assert.That(packages.Count, Is.EqualTo(1));
+            PackageAssert.IsPopulated(packages[0]);
+        }
+
+        private static PackagePath TempPath()
+        {
+            return new PackagePath(
+                OsSpecifics.GenerateBaseDirectory(),
+                Path.Combine("src", "Directory.Packages.Props"),
+                PackageReferenceType.DirectoryBuildTargets);
+        }
+
+        private static DirectoryBuildTargetsReader MakeReader()
+        {
+            return new DirectoryBuildTargetsReader(Substitute.For<INuKeeperLogger>());
+        }
+
+        private static Stream StreamFromString(string contents)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(contents));
+        }
+    }
+}

--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -70,18 +70,13 @@ namespace NuKeeper.Inspection.RepositoryInspection
             {
                 id = el.Attribute("Update")?.Value;
             }
-            var version = el.Name == "PackageDownload"
-                ? GetVersion(el)?.Trim('[', ']')
-                : GetVersion(el);
-
+            var version = GetVersion(el);
             return _packageInProjectReader.Read(id, version, path, null);
         }
 
-        private static string GetVersion(XElement el, XNamespace ns = null)
+        private static string GetVersion(XElement el)
         {
-            return ns == null
-                ? el.Attribute("Version")?.Value ?? el.Element("Version")?.Value
-                : el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
+            return el.Attribute("Version")?.Value ?? el.Element("Version")?.Value;
         }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -55,6 +55,8 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 return Array.Empty<PackageInProject>();
             }
 
+            var projectFileResults = new List<PackageInProject>();
+
             var itemGroups = project
                 .Elements(ns + "ItemGroup")
                 .ToList();
@@ -65,11 +67,27 @@ namespace NuKeeper.Inspection.RepositoryInspection
                 .ToList();
 
             var packageRefs = itemGroups.SelectMany(ig => ig.Elements(ns + "PackageReference"));
-
-            return packageRefs
+            projectFileResults.AddRange(
+                packageRefs
                 .Select(el => XmlToPackage(ns, el, path, projectRefs))
                 .Where(el => el != null)
-                .ToList();
+            );
+
+            projectFileResults.AddRange(
+                itemGroups
+                    .SelectMany(ig => ig.Elements(ns + "PackageDownloads"))
+                    .Select(el => XmlToPackage(ns, el, new PackagePath(baseDirectory, relativePath, PackageReferenceType.DirectoryBuildTargets), null))
+                    .Where(el => el != null)
+            );
+
+            projectFileResults.AddRange(
+                itemGroups
+                    .SelectMany(ig => ig.Elements(ns + "PackageVersion"))
+                    .Select(el => XmlToPackage(ns, el, new PackagePath(baseDirectory, relativePath, PackageReferenceType.DirectoryBuildTargets), null))
+                    .Where(el => el != null)
+            );
+
+            return projectFileResults;
         }
 
         private static string MakeProjectPath(XElement el, string currentPath)
@@ -94,9 +112,18 @@ namespace NuKeeper.Inspection.RepositoryInspection
             PackagePath path, IEnumerable<string> projectReferences)
         {
             var id = el.Attribute("Include")?.Value;
-            var version = el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
+            var version = el.Name == "PackageDownload"
+                ? GetVersion(el, ns)?.Trim('[', ']')
+                : GetVersion(el, ns);
 
             return _packageInProjectReader.Read(id, version, path, projectReferences);
+        }
+
+        private static string GetVersion(XElement el, XNamespace ns = null)
+        {
+            return ns == null
+                ? el.Attribute("Version")?.Value ?? el.Element("Version")?.Value
+                : el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
         }
     }
 }

--- a/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/ProjectFileReader.cs
@@ -75,7 +75,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
             projectFileResults.AddRange(
                 itemGroups
-                    .SelectMany(ig => ig.Elements(ns + "PackageDownloads"))
+                    .SelectMany(ig => ig.Elements(ns + "PackageDownload"))
                     .Select(el => XmlToPackage(ns, el, new PackagePath(baseDirectory, relativePath, PackageReferenceType.DirectoryBuildTargets), null))
                     .Where(el => el != null)
             );
@@ -112,18 +112,13 @@ namespace NuKeeper.Inspection.RepositoryInspection
             PackagePath path, IEnumerable<string> projectReferences)
         {
             var id = el.Attribute("Include")?.Value;
-            var version = el.Name == "PackageDownload"
-                ? GetVersion(el, ns)?.Trim('[', ']')
-                : GetVersion(el, ns);
-
+            var version = GetVersion(el, ns);
             return _packageInProjectReader.Read(id, version, path, projectReferences);
         }
 
-        private static string GetVersion(XElement el, XNamespace ns = null)
+        private static string GetVersion(XElement el, XNamespace ns)
         {
-            return ns == null
-                ? el.Attribute("Version")?.Value ?? el.Element("Version")?.Value
-                : el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
+            return el.Attribute("Version")?.Value ?? el.Element(ns + "Version")?.Value;
         }
     }
 }

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageDownloadTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageDownloadTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
+
+namespace NuKeeper.Integration.Tests.NuGet.Process
+{
+    [TestFixture]
+    public class UpdateDirectoryBuildTargetsCommandPackageDownloadTests : TestWithFailureLogging
+    {
+        private readonly string _testFileWithUpdate =
+            @"<Project><ItemGroup><PackageDownload Update=""foo"" Version=""[{packageVersion}]"" /></ItemGroup></Project>";
+
+        private readonly string _testFileWithInclude =
+            @"<Project><ItemGroup><PackageDownload Include=""foo"" Version=""[{packageVersion}]"" /></ItemGroup></Project>";
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithUpdateAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithUpdate, "<PackageDownload Update=\"foo\" Version=\"[{packageVersion}]\" />");
+        }
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithIncludeAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageDownload Include=\"foo\" Version=\"[{packageVersion}]\" />");
+        }
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithIncludeAndVerboseVersion()
+        {
+            await ExecuteValidUpdateTest(
+                @"<Project><ItemGroup><PackageDownload Include=""foo""><Version>[{packageVersion}]</Version></PackageDownload></ItemGroup></Project>",
+                @"<Version>[{packageVersion}]</Version>");
+        }
+
+        private async Task ExecuteValidUpdateTest(string testProjectContents, string expectedPackageString, [CallerMemberName] string memberName = "")
+        {
+            const string oldPackageVersion = "5.2.31";
+            const string newPackageVersion = "5.3.4";
+
+            var testFolder = memberName;
+            var testFile = "Directory.Build.props";
+            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            Directory.CreateDirectory(workDirectory);
+            var projectContents = testProjectContents.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase);
+            var projectPath = Path.Combine(workDirectory, testFile);
+            await File.WriteAllTextAsync(projectPath, projectContents);
+
+            var command = new UpdateDirectoryBuildTargetsCommand(NukeeperLogger);
+
+            var package = new PackageInProject("foo", oldPackageVersion,
+                new PackagePath(workDirectory, testFile, PackageReferenceType.DirectoryBuildTargets));
+
+            await command.Invoke(package, new NuGetVersion(newPackageVersion), null, NuGetSources.GlobalFeed);
+
+            var contents = await File.ReadAllTextAsync(projectPath);
+            Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion, StringComparison.OrdinalIgnoreCase)));
+            Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageReferenceTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageReferenceTests.cs
@@ -1,0 +1,67 @@
+using NuGet.Versioning;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Update.Process;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Integration.Tests.NuGet.Process
+{
+    [TestFixture]
+    public class UpdateDirectoryBuildTargetsCommandPackageReferenceTests : TestWithFailureLogging
+    {
+        private readonly string _testFileWithUpdate =
+@"<Project><ItemGroup><PackageReference Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+
+        private readonly string _testFileWithInclude =
+@"<Project><ItemGroup><PackageReference Include=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithUpdateAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithUpdate, "<PackageReference Update=\"foo\" Version=\"{packageVersion}\" />");
+        }
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithIncludeAttribute()
+        {
+            await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageReference Include=\"foo\" Version=\"{packageVersion}\" />");
+        }
+
+        [Test]
+        public async Task ShouldUpdateValidFileWithIncludeAndVerboseVersion()
+        {
+            await ExecuteValidUpdateTest(
+                @"<Project><ItemGroup><PackageReference Include=""foo""><Version>{packageVersion}</Version></PackageReference></ItemGroup></Project>",
+                @"<Version>{packageVersion}</Version>");
+        }
+
+        private async Task ExecuteValidUpdateTest(string testProjectContents, string expectedPackageString, [CallerMemberName] string memberName = "")
+        {
+            const string oldPackageVersion = "5.2.31";
+            const string newPackageVersion = "5.3.4";
+
+            var testFolder = memberName;
+            var testFile = "Directory.Build.props";
+            var workDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, testFolder);
+            Directory.CreateDirectory(workDirectory);
+            var projectContents = testProjectContents.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase);
+            var projectPath = Path.Combine(workDirectory, testFile);
+            await File.WriteAllTextAsync(projectPath, projectContents);
+
+            var command = new UpdateDirectoryBuildTargetsCommand(NukeeperLogger);
+
+            var package = new PackageInProject("foo", oldPackageVersion,
+                new PackagePath(workDirectory, testFile, PackageReferenceType.DirectoryBuildTargets));
+
+            await command.Invoke(package, new NuGetVersion(newPackageVersion), null, NuGetSources.GlobalFeed);
+
+            var contents = await File.ReadAllTextAsync(projectPath);
+            Assert.That(contents, Does.Contain(expectedPackageString.Replace("{packageVersion}", newPackageVersion, StringComparison.OrdinalIgnoreCase)));
+            Assert.That(contents, Does.Not.Contain(expectedPackageString.Replace("{packageVersion}", oldPackageVersion, StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+}

--- a/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageVersionTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/UpdateDirectoryBuildTargetsCommandPackageVersionTests.cs
@@ -1,41 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using NuGet.Versioning;
 using NuKeeper.Abstractions.NuGet;
 using NuKeeper.Abstractions.RepositoryInspection;
 using NuKeeper.Update.Process;
 using NUnit.Framework;
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 
 namespace NuKeeper.Integration.Tests.NuGet.Process
 {
     [TestFixture]
-    public class UpdateDirectoryBuildTargetsCommandTests : TestWithFailureLogging
+    public class UpdateDirectoryBuildTargetsCommandPackageVersionTests : TestWithFailureLogging
     {
         private readonly string _testFileWithUpdate =
-@"<Project><ItemGroup><PackageReference Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+            @"<Project><ItemGroup><PackageVersion Update=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
 
         private readonly string _testFileWithInclude =
-@"<Project><ItemGroup><PackageReference Include=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
+            @"<Project><ItemGroup><PackageVersion Include=""foo"" Version=""{packageVersion}"" /></ItemGroup></Project>";
 
         [Test]
         public async Task ShouldUpdateValidFileWithUpdateAttribute()
         {
-            await ExecuteValidUpdateTest(_testFileWithUpdate, "<PackageReference Update=\"foo\" Version=\"{packageVersion}\" />");
+            await ExecuteValidUpdateTest(_testFileWithUpdate, "<PackageVersion Update=\"foo\" Version=\"{packageVersion}\" />");
         }
 
         [Test]
         public async Task ShouldUpdateValidFileWithIncludeAttribute()
         {
-            await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageReference Include=\"foo\" Version=\"{packageVersion}\" />");
+            await ExecuteValidUpdateTest(_testFileWithInclude, "<PackageVersion Include=\"foo\" Version=\"{packageVersion}\" />");
         }
 
         [Test]
         public async Task ShouldUpdateValidFileWithIncludeAndVerboseVersion()
         {
             await ExecuteValidUpdateTest(
-                @"<Project><ItemGroup><PackageReference Include=""foo""><Version>{packageVersion}</Version></PackageReference></ItemGroup></Project>",
+                @"<Project><ItemGroup><PackageVersion Include=""foo""><Version>{packageVersion}</Version></PackageVersion></ItemGroup></Project>",
                 @"<Version>{packageVersion}</Version>");
         }
 

--- a/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
+++ b/NuKeeper.Update/Process/UpdateDirectoryBuildTargetsCommand.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,27 +58,40 @@ namespace NuKeeper.Update.Process
                 return;
             }
 
-            var packageNodeList = packagesNode.Elements("PackageReference")
-                .Where(x =>
-                    (x.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
-                  || x.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id,StringComparison.InvariantCultureIgnoreCase))));
+            var packageRefs = IncludesOrUpdates(currentPackage, packagesNode.Elements("PackageReference"));
+            UpdateVersionTo(currentPackage, packageRefs, newVersion.ToString());
+            var packageVersions = IncludesOrUpdates(currentPackage, packagesNode.Elements("PackageVersion"));
+            UpdateVersionTo(currentPackage, packageVersions, newVersion.ToString());
+            var packageDownloads = IncludesOrUpdates(currentPackage, packagesNode.Elements("PackageDownload"));
+            UpdateVersionTo(currentPackage, packageDownloads, $"[{newVersion}]");
 
-            foreach (var dependencyToUpdate in packageNodeList)
+            xml.Save(fileContents);
+        }
+
+        private void UpdateVersionTo(PackageInProject currentPackage, IEnumerable<XElement> elements, string newVersion)
+        {
+            foreach (var dependencyToUpdate in elements)
             {
                 _logger.Detailed(
                     $"Updating directory-level dependencies: {currentPackage.Id} in path {currentPackage.Path.FullName}");
                 var attribute = dependencyToUpdate.Attribute("Version");
                 if (attribute != null)
                 {
-                    attribute.Value = newVersion.ToString();
+                    attribute.Value = newVersion;
                 }
                 else
                 {
-                    dependencyToUpdate.Element("Version").Value = newVersion.ToString();
+                    dependencyToUpdate.Element("Version").Value = newVersion;
                 }
             }
+        }
 
-            xml.Save(fileContents);
+        private static IEnumerable<XElement> IncludesOrUpdates(PackageInProject currentPackage, IEnumerable<XElement> elements)
+        {
+            return elements.Where(el =>
+                el.Attributes("Include").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
+                || el.Attributes("Update").Any(a => a.Value.Equals(currentPackage.Id, StringComparison.InvariantCultureIgnoreCase))
+            );
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Testing with and without `PackageDownload` and `PackageVersion`.

### :new: What is the new behavior (if this is a feature change)?
`PackageDownload` - This is seriously a thing, today Nuke is using it ensure that packages are downloaded, but they are not implicitly referenced.  This is used in the Nuke context to ensure that the binaries exist.  I could not however find any specific documentation on this behavior, but it is a thing.
`PackageVersion` - This just shipped with the latest dotnet sdk `3.1.300` with support for centrally managed package versions.  While the building blocks will be the same this central managed solution will be supported inside VisualStudio at a future date.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Testing with and without `PackageDownload` and `PackageVersion`.

### :memo: Links to relevant issues/docs
I created a new PR using my older one as a reference so I merged the two together.  Hopefully the code is a little cleaner this time around, let me know.

Supersedes: #895
Relates: https://github.com/NuGet/Home/issues/7339
[Centrally managing NuGet package-versions](https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions)


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 

Let me know if you have any questions!  ❤️ Nukeeper ❤️ 