### PR TITLE
Fix for bitbucket local dashes in repo names

### DIFF
--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -10,7 +10,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Repository = NuKeeper.Abstractions.CollaborationModels.Repository;
 
-
 namespace NuKeeper.BitBucketLocal
 {
     public class BitBucketLocalPlatform : ICollaborationPlatform
@@ -112,8 +111,19 @@ namespace NuKeeper.BitBucketLocal
 
         public async Task<Repository> GetUserRepository(string projectName, string repositoryName)
         {
+            var sanitisedRepositoryName = SanitizeRepositoryName(repositoryName);
             var repos = await GetRepositoriesForOrganisation(projectName);
-            return repos.Single(x => x.Name.Equals(repositoryName, StringComparison.OrdinalIgnoreCase));
+            return repos.Single(x => string.Equals(SanitizeRepositoryName(x.Name), sanitisedRepositoryName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string SanitizeRepositoryName(string repositoryName)
+        {
+            if (string.IsNullOrWhiteSpace(repositoryName))
+            {
+                return string.Empty;
+            }
+
+            return repositoryName.Replace("-", " ");
         }
 
         public Task<Repository> MakeUserFork(string owner, string repositoryName)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Same as #920 but hopefully safer "Bug fix for BitBucket Local - by default, repos with spaces in are presented as dashes in the url. "
You have to apply the same "sanitisation" to both strings being compared, or you can potentially introduce differences between them, as well as remove differences.

### :arrow_heading_down: What is the current behavior?

See #920

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
