### PR TITLE
Handle Azure DevOps repositories with mixed-case names

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             var repos = await _client.GetGitRepositories(target.Owner);
-            var repo = repos.Single(x => x.name == target.Name);
+            var repo = repos.Single(x => x.name.Equals(target.Name, StringComparison.OrdinalIgnoreCase));
 
             var result = await _client.GetPullRequests(
                 target.Owner,
@@ -76,7 +76,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             var repos = await _client.GetGitRepositories(target.Owner);
-            var repo = repos.Single(x => x.name == target.Name);
+            var repo = repos.Single(x => x.name.Equals(target.Name, StringComparison.OrdinalIgnoreCase));
 
             var req = new PRRequest
             {
@@ -120,7 +120,7 @@ namespace NuKeeper.AzureDevOps
         public async Task<Repository> GetUserRepository(string projectName, string repositoryName)
         {
             var repos = await GetRepositoriesForOrganisation(projectName);
-            return repos.Single(x => x.Name == repositoryName);
+            return repos.Single(x => x.Name.Equals(repositoryName, StringComparison.OrdinalIgnoreCase));
         }
 
         public Task<Repository> MakeUserFork(string owner, string repositoryName)
@@ -131,7 +131,7 @@ namespace NuKeeper.AzureDevOps
         public async Task<bool> RepositoryBranchExists(string projectName, string repositoryName, string branchName)
         {
             var repos = await _client.GetGitRepositories(projectName);
-            var repo = repos.Single(x => x.name == repositoryName);
+            var repo = repos.Single(x => x.name.Equals(repositoryName, StringComparison.OrdinalIgnoreCase));
             var refs = await _client.GetRepositoryRefs(projectName, repo.id);
             var count = refs.Count(x => x.name.EndsWith(branchName, StringComparison.OrdinalIgnoreCase));
             if (count > 0)


### PR DESCRIPTION
### Bug fix ###
> `nukeeper repo` command fails with Azure DevOps when the repository names have uppercase characters.

Command to reproduce:
`nukeeper repo -t origin/master -m 20 -n -c Major c:\Git\MyRepo [token]`

**The problem:**
Azure DevOps repositories can have mixed-case repository names.
NuKeeper uses Git lib to get remote repository URLs, and compute the repository name from this URL. Git always normalizes remote repos to all-lowercase.
When calling the Azure DevOps API to get a list of repositories for an organization, the names may be in mixed-case, and NuKeeper can't find the expected repository name based on the remote repo URL from Git.

**The fix:**
The change in the PR ensures that methods that attempts to match a repo in the Azure DevOps API response to the repo name is case insensitive so that the repository name can correctly be computed from Git's remote repository information.

The PR should not introduce any breaking changes, but rather resolve a bug.

Recommendations for testing:
Test it with a Azure DevOps repository with a mixed-case repository name, and see that it fails before my PR, but works after.
All existing tests runs successfully after the changes.

**_PS! When (if) this PR is approved, I would really appreciate if you could also update the Azure DevOps extension with the latest version._**