### PR TITLE
Also run SetupDefaultCredentialService in GitRepositoryEngine so that…

### DIFF
--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -345,7 +345,7 @@ namespace NuKeeper.Tests.Commands
 
             var updater = Substitute.For<IRepositoryUpdater>();
             var gitEngine = new GitRepositoryEngine(updater, collaborationFactorySubstitute, folderFactorySubstitute,
-                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>());
+                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>(), Substitute.For<NuGet.Common.ILogger>());
 
             await gitEngine.Run(new RepositorySettings
             {
@@ -383,7 +383,7 @@ namespace NuKeeper.Tests.Commands
 
             var updater = Substitute.For<IRepositoryUpdater>();
             var gitEngine = new GitRepositoryEngine(updater, collaborationFactorySubstitute, Substitute.For<IFolderFactory>(),
-                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>());
+                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>(), Substitute.For<NuGet.Common.ILogger>());
 
             await gitEngine.Run(new RepositorySettings
             {
@@ -420,7 +420,7 @@ namespace NuKeeper.Tests.Commands
 
             var updater = Substitute.For<IRepositoryUpdater>();
             var gitEngine = new GitRepositoryEngine(updater, collaborationFactorySubstitute, Substitute.For<IFolderFactory>(),
-                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>());
+                Substitute.For<INuKeeperLogger>(), Substitute.For<IRepositoryFilter>(), Substitute.For<NuGet.Common.ILogger>());
 
             await gitEngine.Run(new RepositorySettings
             {

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -1,7 +1,8 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-
+using NuGet.Common;
+using NuGet.Credentials;
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -20,19 +21,22 @@ namespace NuKeeper.Engine
         private readonly INuKeeperLogger _logger;
         private readonly IRepositoryFilter _repositoryFilter;
         private readonly IRepositoryUpdater _repositoryUpdater;
+        private readonly ILogger _nugetLogger;
 
         public GitRepositoryEngine(
             IRepositoryUpdater repositoryUpdater,
             ICollaborationFactory collaborationFactory,
             IFolderFactory folderFactory,
             INuKeeperLogger logger,
-            IRepositoryFilter repositoryFilter)
+            IRepositoryFilter repositoryFilter,
+            ILogger nugetLogger)
         {
             _repositoryUpdater = repositoryUpdater;
             _collaborationFactory = collaborationFactory;
             _folderFactory = folderFactory;
             _logger = logger;
             _repositoryFilter = repositoryFilter;
+            _nugetLogger = nugetLogger;
         }
 
         public async Task<int> Run(RepositorySettings repository,
@@ -53,6 +57,8 @@ namespace NuKeeper.Engine
             {
                 throw new ArgumentNullException(nameof(settings));
             }
+
+            SetupDefaultCredentialService(_nugetLogger, true);
 
             try
             {

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -58,7 +58,7 @@ namespace NuKeeper.Engine
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            SetupDefaultCredentialService(_nugetLogger, true);
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(_nugetLogger, true);
 
             try
             {


### PR DESCRIPTION
… we can pick up the Azure DevOps feed credentials from the credential provider

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The PR fixes a bug when using nukeeper repo where we use a DevOps NuGet feed. Because of the --source the credentials are not used, so no packages could be found.

### :arrow_heading_down: What is the current behavior?
Azure DevOps credentials are not used, so no packages are found on the custom feed

### :new: What is the new behavior (if this is a feature change)?
Azure DevOps credentials are found and the correct packages are found on the custom feed

### :boom: Does this PR introduce a breaking change?
No breaking change

### :bug: Recommendations for testing
I had to set a few environment variables to get it working correctly
DOTNET_HOST_PATH -> "dotnet"
NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS -> "30"
NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS -> "30"

### :memo: Links to relevant issues/docs
https://github.com/NuKeeperDotNet/NuKeeper/pull/868

### :thinking: Checklist before submitting
- [✔ ] All projects build
- [✔ ] Relevant documentation was updated 
