### PR TITLE
Allow creating GitHub pull requests with private emails

### DIFF
--- a/NuKeeper.GitHub/NuKeeper.GitHub.csproj
+++ b/NuKeeper.GitHub/NuKeeper.GitHub.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -64,8 +64,12 @@ namespace NuKeeper.GitHub
             return await ExceptionHandler(async () =>
             {
                 var user = await _client.User.Current();
+
+                var emails = await _client.User.Email.GetAll();
+                var primaryEmail = emails.FirstOrDefault(e => e.Primary);
+
                 _logger.Detailed($"Read github user '{user?.Login}'");
-                return new User(user?.Login, user?.Name, user?.Email);
+                return new User(user?.Login, user?.Name, primaryEmail?.Email ?? user?.Email);
             });
         }
 

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.GitHub
     public class OctokitClient : ICollaborationPlatform
     {
         private readonly INuKeeperLogger _logger;
-        private bool _initialised = false;
+        private bool _initialised;
 
         private IGitHubClient _client;
         private Uri _apiBase;
@@ -247,8 +247,7 @@ namespace NuKeeper.GitHub
         {
             try
             {
-                T retval = await funcToCheck();
-                return retval;
+                return await funcToCheck();
             }
             catch (ApiException ex)
             {
@@ -260,6 +259,7 @@ namespace NuKeeper.GitHub
                         throw new NuKeeperException(response.errors.First.message.ToString(), ex);
                     }
                 }
+
                 throw new NuKeeperException(ex.Message, ex);
             }
         }

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Does 2 things:
* Updates Octokit client to the latest version
* Fixes an issue with Github integration, when user has a private email configured. Instead of users API (https://developer.github.com/v3/users/#get-a-user) we're now using emails api to retrieve the primary email (https://developer.github.com/v3/users/emails/).

Note: This is a suggested way to retrieve user's email. Quote from the API docs:
> The email key in the following response is the publicly visible email address from your GitHub profile page. When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for email, then it will have a value of null. You only see publicly visible email addresses when authenticated with GitHub. For more information, see Authentication.

> The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "Emails API".   

### :arrow_heading_down: What is the current behavior?

As documentation states:
>  If you do not set a public email address for email, then it will have a value of `null`.

Stumbled upon it, when working on our github action. When email address is `null` you can't create GitHub MRs.

### :new: What is the new behavior (if this is a feature change)?

Now you can create MRs with a private email address.

### :boom: Does this PR introduce a breaking change?

Nope.

### :bug: Recommendations for testing

Make your email private and see that it still works.

### :memo: Links to relevant issues/docs
https://developer.github.com/v3/users/#get-a-user
https://developer.github.com/v3/users/emails/

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
