### PR TITLE
Automatic update of NuGet.Credentials to 5.6.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Credentials" Version="5.5.1" />
+    <PackageReference Include="NuGet.Credentials" Version="5.6.0" />
     <PackageReference Include="SimpleInjector" Version="4.10.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Credentials` to `5.6.0` from `5.5.1`
`NuGet.Credentials 5.6.0` was published at `2020-05-20T22:31:13Z`, 21 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.Credentials` `5.6.0` from `5.5.1`

[NuGet.Credentials 5.6.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Credentials/5.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
