### PR TITLE
Automatic update of System.Text.Encoding.CodePages to 4.7.1

### DIFF
--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.Text.Encoding.CodePages` to `4.7.1` from `4.7.0`
`System.Text.Encoding.CodePages 4.7.1` was published at `2020-05-12T14:56:47Z`, 1 month ago

1 project update:
Updated `NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `System.Text.Encoding.CodePages` `4.7.1` from `4.7.0`

[System.Text.Encoding.CodePages 4.7.1 on NuGet.org](https://www.nuget.org/packages/System.Text.Encoding.CodePages/4.7.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
