### PR TITLE
feat(AD/TFS): Support reviewers in PRs

### DIFF
--- a/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class PullRequestRequest
@@ -19,5 +21,6 @@ namespace NuKeeper.Abstractions.CollaborationModels
         public string Body { get; set; }
         public bool DeleteBranchAfterMerge { get; set; }
         public bool SetAutoMerge { get; }
+        public List<Reviewer> Reviewers { get; } = new List<Reviewer>();
     }
 }

--- a/NuKeeper.Abstractions/CollaborationModels/Reviewer.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/Reviewer.cs
@@ -1,0 +1,8 @@
+namespace NuKeeper.Abstractions.CollaborationModels
+{
+    public class Reviewer
+    {
+        public string Name { get; set; }
+        public bool IsRequired { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/Concat.cs
+++ b/NuKeeper.Abstractions/Concat.cs
@@ -15,24 +15,9 @@ namespace NuKeeper.Abstractions
             return values.FirstOrDefault(i => i.HasValue) ?? default;
         }
 
-        public static IReadOnlyCollection<string> FirstPopulatedList(List<string> list1, List<string> list2, List<string> list3)
+        public static IReadOnlyCollection<string> FirstPopulatedList(params List<string>[] lists)
         {
-            if (HasElements(list1))
-            {
-                return list1;
-            }
-
-            if (HasElements(list2))
-            {
-                return list2;
-            }
-
-            if (HasElements(list3))
-            {
-                return list3;
-            }
-
-            return null;
+            return lists.FirstOrDefault(HasElements);
         }
 
         private static bool HasElements(List<string> strings)

--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -24,6 +24,7 @@ namespace NuKeeper.Abstractions.Configuration
         public string ExcludeRepos { get; set; }
 
         public List<string> Label { get; set; }
+        public List<string> Reviewers { get; set; }
 
         public string LogFile { get; set; }
 

--- a/NuKeeper.Abstractions/Configuration/SourceControlServerSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/SourceControlServerSettings.cs
@@ -9,6 +9,7 @@ namespace NuKeeper.Abstractions.Configuration
         public string OrganisationName { get; set; }
         public RepositorySettings Repository { get; set; }
         public IReadOnlyCollection<string> Labels { get; set; }
+        public IReadOnlyCollection<string> Reviewers { get; set; }
         public Regex IncludeRepos { get; set; }
         public Regex ExcludeRepos { get; set; }
     }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -117,37 +117,54 @@ namespace NuKeeper.AzureDevOps
 
         // documentation is confusing, I think this won't work without memberId or ownerId
         // https://docs.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-6.0
-        public Task<Resource<Account>> GetCurrentUser()
+        public virtual Task<Resource<Account>> GetCurrentUser()
         {
             return GetResource<Resource<Account>>("/_apis/accounts");
         }
 
-        public Task<Resource<Account>> GetUserByMail(string email)
+        public virtual Task<Resource<Account>> GetUserByMail(string email)
         {
             var encodedEmail = HttpUtility.UrlEncode(email);
             return GetResource<Resource<Account>>($"/_apis/identities?searchFilter=MailAddress&filterValue={encodedEmail}");
         }
 
-        public async Task<IEnumerable<Project>> GetProjects()
+        public async virtual Task<IEnumerable<Project>> GetProjects()
         {
             var response = await GetResource<ProjectResource>("/_apis/projects");
             return response?.value.AsEnumerable();
         }
 
-        public async Task<IEnumerable<AzureRepository>> GetGitRepositories(string projectName)
+        public async virtual Task<IEnumerable<WebApiTeam>> GetTeamsAsync(string projectName)
+        {
+            var response = await GetResource<Resource<WebApiTeam>>($"_apis/projects/{projectName}/teams");
+            return response?.value.AsEnumerable();
+        }
+
+        public async virtual Task<IEnumerable<TeamMember>> GetTeamMembersAsync(string projectName, string teamName)
+        {
+            var response = await GetResource<Resource<TeamMember>>($"_apis/projects/{projectName}/teams/{teamName}/members");
+            return response?.value.AsEnumerable();
+        }
+
+        public async virtual Task<Identity> GetUserAsync(string id)
+        {
+            return await GetResource<Identity>($"_apis/identities/{id}");
+        }
+
+        public async virtual Task<IEnumerable<AzureRepository>> GetGitRepositories(string projectName)
         {
             var response = await GetResource<GitRepositories>($"{projectName}/_apis/git/repositories");
             return response?.value.AsEnumerable();
         }
 
-        public async Task<IEnumerable<GitRefs>> GetRepositoryRefs(string projectName, string repositoryId)
+        public async virtual Task<IEnumerable<GitRefs>> GetRepositoryRefs(string projectName, string repositoryId)
         {
             var response = await GetResource<GitRefsResource>($"{projectName}/_apis/git/repositories/{repositoryId}/refs");
             return response?.value.AsEnumerable();
         }
 
         //https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/get%20pull%20requests?view=azure-devops-rest-5.0
-        public async Task<IEnumerable<PullRequest>> GetPullRequests(
+        public async virtual Task<IEnumerable<PullRequest>> GetPullRequests(
              string projectName,
              string azureRepositoryId,
              string headBranch,
@@ -170,25 +187,25 @@ namespace NuKeeper.AzureDevOps
             return response?.value.AsEnumerable();
         }
 
-        public async Task<PullRequest> CreatePullRequest(PRRequest request, string projectName, string azureRepositoryId)
+        public async virtual Task<PullRequest> CreatePullRequest(PRRequest request, string projectName, string azureRepositoryId)
         {
             var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PostResource<PullRequest>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullrequests", content);
         }
 
-        public async Task<LabelResource> CreatePullRequestLabel(LabelRequest request, string projectName, string azureRepositoryId, int pullRequestId)
+        public async virtual Task<LabelResource> CreatePullRequestLabel(LabelRequest request, string projectName, string azureRepositoryId, int pullRequestId)
         {
             var labelContent = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PostResource<LabelResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}/labels", labelContent, true);
         }
 
-        public async Task<PullRequest> SetAutoComplete(PRRequest request, string projectName, string azureRepositoryId, int pullRequestId)
+        public async virtual Task<PullRequest> SetAutoComplete(PRRequest request, string projectName, string azureRepositoryId, int pullRequestId)
         {
             var autoCompleteContent = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PatchResource<PullRequest>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}", autoCompleteContent);
         }
-        
-        public async Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string azureRepositoryId)
+
+        public async virtual Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string azureRepositoryId)
         {
             var response = await GetResource<GitItemResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/items?recursionLevel=Full");
             return response?.value.Select(v => v.path).AsEnumerable();

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -7,11 +7,13 @@ namespace NuKeeper.AzureDevOps
 #pragma warning disable CA1056 // Uri properties should not be strings
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CA2227 // Collection properties should be read only
+#pragma warning disable CA1819 // Properties should not return arrays
 
     public class Resource<T>
     {
         public int count { get; set; }
         public IEnumerable<T> value { get; set; }
+
     }
 
     public class Account
@@ -63,6 +65,34 @@ namespace NuKeeper.AzureDevOps
         public string uniqueName { get; set; }
         public string imageUrl { get; set; }
         public string descriptor { get; set; }
+    }
+
+    public class Identity
+    {
+        public string id { get; set; }
+        public Dictionary<string, object> properties { get; set; }
+        public string Mail
+        {
+            get
+            {
+                if (properties.ContainsKey("Mail"))
+                {
+                    switch (properties["Mail"])
+                    {
+                        case JObject mailObject:
+                            return mailObject.Property("$value").Value.ToString();
+
+                        case JProperty mailProp:
+                            return mailProp.Value.ToString();
+
+                        case string mailString:
+                            return mailString;
+                    }
+                }
+
+                return string.Empty;
+            }
+        }
     }
 
     public class GitRefs
@@ -134,6 +164,7 @@ namespace NuKeeper.AzureDevOps
         public int Count { get; set; }
         public IEnumerable<Project> value { get; set; }
     }
+
     public class Project
     {
         public string description { get; set; }
@@ -144,6 +175,39 @@ namespace NuKeeper.AzureDevOps
         public int revision { get; set; }
         public string visibility { get; set; }
     }
+
+    public class WebApiTeam
+    {
+        public string description { get; set; }
+
+        /// <summary>
+        ///     Team (Identity) Guid. A Team Foundation ID.
+        /// </summary>
+        public string id { get; set; }
+
+        /// <summary>
+        ///     Identity REST API Url to this team.
+        /// </summary>
+        public string identityUrl { get; set; }
+
+        public string name { get; set; }
+
+        public string projectId { get; set; }
+
+        public string projectName { get; set; }
+
+        /// <summary>
+        ///     Team REST API Url.
+        /// </summary>
+        public string url { get; set; }
+    }
+
+    public class TeamMember
+    {
+        public IdentityRef identity { get; set; }
+        public bool isTeamAdmin { get; set; }
+    }
+
     public class PRRequest
     {
         public string sourceRefName { get; set; }
@@ -152,7 +216,36 @@ namespace NuKeeper.AzureDevOps
         public string description { get; set; }
         public GitPullRequestCompletionOptions completionOptions { get; set; }
         public Creator autoCompleteSetBy { get; set; }
+        public IEnumerable<IdentityRefWithVote> reviewers { get; set; }
     }
+
+    public class IdentityRef
+    {
+        public string id { get; set; }
+
+        /// <summary>
+        ///     The descriptor is the primary way to reference the graph subject while the system is running.
+        ///     This field will uniquely identify the same graph subject across both Accounts and collections.
+        /// </summary>
+        public string descriptor { get; set; }
+
+        /// <summary>
+        ///     This is the non-unique display name of the graph subject.
+        ///     To change this field, you must alter its value in the source provider.
+        /// </summary>
+        public string displayName { get; set; }
+
+        /// <summary>
+        ///     Email address for Azure Devops. Domain name for Azure Devops Server. (??)
+        /// </summary>
+        public string uniqueName { get; set; }
+    }
+
+    public class IdentityRefWithVote : IdentityRef
+    {
+        public bool isRequired { get; set; }
+    }
+
     public class GitPullRequestCompletionOptions
     {
         public bool deleteSourceBranch { get; set; }

--- a/NuKeeper.Tests/Commands/CollaborationPlatformCommandTests.cs
+++ b/NuKeeper.Tests/Commands/CollaborationPlatformCommandTests.cs
@@ -1,0 +1,129 @@
+using NSubstitute;
+using NUnit.Framework;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Collaboration;
+using NuKeeper.Commands;
+using NuKeeper.Inspection.Logging;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System;
+
+namespace NuKeeper.Tests.Commands
+{
+    [TestFixture]
+    public class CollaborationPlatformCommandTests
+    {
+        private ICollaborationEngine _engine;
+        private IConfigureLogger _logger;
+        private IFileSettingsCache _fileSettingsCache;
+        private ICollaborationFactory _collaborationFactory;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _engine = Substitute.For<ICollaborationEngine>();
+            _logger = Substitute.For<IConfigureLogger>();
+            _fileSettingsCache = Substitute.For<IFileSettingsCache>();
+            _collaborationFactory = Substitute.For<ICollaborationFactory>();
+
+            _fileSettingsCache
+                .GetSettings()
+                .Returns(FileSettings.Empty());
+            _collaborationFactory
+                .Initialise(Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<ForkMode?>(), Arg.Any<Platform?>())
+                .Returns(ValidationResult.Success);
+        }
+
+
+        [Test]
+        public async Task OnExecute_ReviewersProvidedFromCli_CorrectlyPopulatesSettingsContainerWithReviewers()
+        {
+            var command = MakeCommand();
+            _collaborationFactory
+                .Settings
+                .Returns(new CollaborationPlatformSettings { Token = command.PersonalAccessToken });
+            command.Reviewers = new List<string> { "nukeeper@nukeeper.nukeeper" };
+
+            await command.OnExecute();
+
+            await _engine
+                .Received()
+                .Run(
+                    Arg.Is<SettingsContainer>(s =>
+                        s.SourceControlServerSettings.Reviewers.Contains("nukeeper@nukeeper.nukeeper")
+                    )
+                );
+        }
+
+        [Test]
+        public async Task OnExecute_ReviewersProvidedFromFile_CorrectlyPopulatesSettingsContainerWithReviewers()
+        {
+            var command = MakeCommand();
+            _fileSettingsCache
+                .GetSettings()
+                .Returns(new FileSettings { Reviewers = new List<string> { "nukeeper@nukeeper.nukeeper" } });
+            _collaborationFactory
+                .Settings
+                .Returns(new CollaborationPlatformSettings { Token = command.PersonalAccessToken });
+
+            await command.OnExecute();
+
+            await _engine
+                .Received()
+                .Run(
+                    Arg.Is<SettingsContainer>(s =>
+                        s.SourceControlServerSettings.Reviewers.Contains("nukeeper@nukeeper.nukeeper")
+                    )
+                );
+        }
+
+        [Test]
+        public async Task OnExecute_ReviewersProvidedFromCliAndFile_CorrectlyPopulatesSettingsContainerWithReviewersFromCli()
+        {
+            var command = MakeCommand();
+            command.Reviewers = new List<string> { "notnukeeper@nukeeper.nukeeper" };
+            _collaborationFactory
+                .Settings
+                .Returns(new CollaborationPlatformSettings { Token = command.PersonalAccessToken });
+            _fileSettingsCache
+                .GetSettings()
+                .Returns(new FileSettings { Reviewers = new List<string> { "nukeeper@nukeeper.nukeeper" } });
+
+            await command.OnExecute();
+
+            await _engine
+                .Received()
+                .Run(
+                    Arg.Is<SettingsContainer>(s =>
+                        s.SourceControlServerSettings.Reviewers.Contains("notnukeeper@nukeeper.nukeeper")
+                    )
+                );
+        }
+
+        CollaborationPlatformCommand MakeCommand()
+        {
+            return new CollaborationPlatformCommandStub(
+                _engine,
+                _logger,
+                _fileSettingsCache,
+                _collaborationFactory
+            )
+            {
+                ApiEndpoint = "http://tfs.myorganization.com/tfs/DefaultCollection/MyProject/_git/MyRepository",
+                PersonalAccessToken = "mytoken"
+            };
+        }
+
+        class CollaborationPlatformCommandStub : CollaborationPlatformCommand
+        {
+            public CollaborationPlatformCommandStub(
+                ICollaborationEngine engine,
+                IConfigureLogger logger,
+                IFileSettingsCache fileSettingsCache,
+                ICollaborationFactory collaborationFactory
+            ) : base(engine, logger, fileSettingsCache, collaborationFactory) { }
+        }
+    }
+}

--- a/NuKeeper/Commands/CollaborationPlatformCommand.cs
+++ b/NuKeeper/Commands/CollaborationPlatformCommand.cs
@@ -41,6 +41,11 @@ namespace NuKeeper.Commands
                 "Label to apply to GitHub pull requests. Defaults to 'nukeeper'. Multiple labels can be provided by specifying this option multiple times.")]
         public List<string> Label { get; set; }
 
+        [Option(CommandOptionType.MultipleValue, ShortName = "r", LongName = "reviewer",
+            Description =
+                "Email address of reviewer to add to pull requests. Multiple reviewers can be provided by specifying this option multiple times.")]
+        public List<string> Reviewers { get; set; }
+
         [Option(CommandOptionType.SingleValue, ShortName = "g", LongName = "api",
             Description =
                 "Api Base Url. If you are using an internal server and not a public one, you must set it to the api url of your server.")]
@@ -140,6 +145,10 @@ namespace NuKeeper.Commands
             {
                 return deleteBranchAfterMergeValid;
             }
+
+            settings.SourceControlServerSettings.Reviewers = Concat.FirstPopulatedList(
+                Reviewers, fileSettings.Reviewers
+            );
 
             return ValidationResult.Success;
         }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -24,7 +24,8 @@ namespace NuKeeper.Engine.Packages
             ICollaborationFactory collaborationFactory,
             IExistingCommitFilter existingCommitFilter,
             IUpdateRunner localUpdater,
-            INuKeeperLogger logger)
+            INuKeeperLogger logger
+        )
         {
             _collaborationFactory = collaborationFactory;
             _existingCommitFilter = existingCommitFilter;
@@ -155,6 +156,14 @@ namespace NuKeeper.Engine.Packages
                     var body = _collaborationFactory.CommitWorder.MakeCommitDetails(updates);
 
                     var pullRequestRequest = new PullRequestRequest(qualifiedBranch, title, repository.DefaultBranch, settings.BranchSettings.DeleteBranchAfterMerge, settings.SourceControlServerSettings.Repository.SetAutoMerge) { Body = body };
+
+                    foreach (var reviewer in settings.SourceControlServerSettings?.Reviewers ?? Enumerable.Empty<string>())
+                    {
+                        pullRequestRequest.Reviewers.Add(new Reviewer
+                        {
+                            Name = reviewer
+                        });
+                    }
 
                     await _collaborationFactory.CollaborationPlatform.OpenPullRequest(repository.Pull, pullRequestRequest, settings.SourceControlServerSettings.Labels);
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
@@ -1,23 +1,201 @@
-using System;
-using System.Net.Http;
-using NUnit.Framework;
 using NSubstitute;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.AzureDevOps;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Nukeeper.AzureDevOps.Tests
 {
     public class AzureDevOpsPlatformTests
     {
+        const string MyRepository = "MyRepository";
+        const string KnownUserId = "26238A59-0F9F-4E03-9BD2-DA419E003FB0";
+        const string KnownUser = "nukeeper@nukeeper.nukeeper";
+        private INuKeeperLogger _logger;
+
+        [SetUp]
+        public void Setup()
+        {
+            _logger = Substitute.For<INuKeeperLogger>();
+        }
+
         [Test]
-        public void Initialise()
+        public async Task OpenPullRequest_WithReviewers_CreatesPullRequestWithReviewers()
+        {
+            var platform = MakeAzureDevopsPlatform();
+            var forkData = MakeForkData();
+            var pullrequest = MakePullRequestRequest();
+            var client = platform.Client as AzureDevOpsRestClientMock;
+            pullrequest.Reviewers.Add(new Reviewer { Name = KnownUser });
+
+            await platform.OpenPullRequest(forkData, pullrequest, new List<string>());
+
+            Assert.AreEqual(1, client.AttemptedPullRequest.reviewers.Count());
+        }
+
+        [Test]
+        public async Task OpenPullRequest_WithReviewers_CreatesPullRequestWithoutReviewersIfIdentitiesCannotBeFetched()
+        {
+            var platform = MakeAzureDevopsPlatform();
+            var forkData = MakeForkData();
+            var pullrequest = MakePullRequestRequest();
+            var client = platform.Client as AzureDevOpsRestClientMock;
+            client.ThrowOnFetchIdentities = true;
+            pullrequest.Reviewers.Add(new Reviewer { Name = KnownUser });
+
+            await platform.OpenPullRequest(forkData, pullrequest, new List<string>());
+
+            Assert.AreEqual(0, client.AttemptedPullRequest.reviewers?.Count() ?? 0);
+        }
+
+        [Test]
+        public async Task OpenPullRequest_WithKnownAndUnknownReviewers_CreatesPullRequestForKnownReviewers()
+        {
+            var platform = MakeAzureDevopsPlatform();
+            var forkData = MakeForkData();
+            var pullrequest = MakePullRequestRequest();
+            pullrequest.Reviewers.Add(new Reviewer { Name = KnownUser });
+            pullrequest.Reviewers.Add(new Reviewer { Name = "unknown@nukeeper.nukeeper" });
+
+            await platform.OpenPullRequest(forkData, pullrequest, new List<string>());
+
+            var attemptedPr = (platform.Client as AzureDevOpsRestClientMock).AttemptedPullRequest;
+
+            Assert.AreEqual(1, attemptedPr.reviewers.Count());
+        }
+
+        private AzureDevOpsPlatformStub MakeAzureDevopsPlatform()
         {
             var httpClientFactory = Substitute.For<IHttpClientFactory>();
             httpClientFactory.CreateClient().Returns(new HttpClient());
 
-            var platform = new AzureDevOpsPlatform(Substitute.For<INuKeeperLogger>(), httpClientFactory);
-            platform.Initialise(new AuthSettings(new Uri("https://uri.com"), "token"));
+            var platform = new AzureDevOpsPlatformStub(_logger, httpClientFactory);
+            platform.Initialise(
+                new AuthSettings(
+                    new Uri("https://tfs.mycompany.com/tfs/DefaultCollection"),
+                    "PAT"
+                )
+            );
+            return platform;
+        }
+
+        private static ForkData MakeForkData()
+        {
+            return new ForkData(
+                new Uri("https://tfs.mycompany.com/tfs/DefaultCollection/MyProject/_git/MyRepository"),
+                "MyProject",
+                MyRepository
+            );
+        }
+
+        private static PullRequestRequest MakePullRequestRequest()
+        {
+            return new PullRequestRequest("", "", "", false, false);
+        }
+
+        class AzureDevOpsPlatformStub : AzureDevOpsPlatform
+        {
+            private INuKeeperLogger _logger;
+
+            public AzureDevOpsPlatformStub(
+                INuKeeperLogger logger,
+                IHttpClientFactory clientFactory
+            ) : base(logger, clientFactory)
+            {
+                _logger = logger;
+                ClientFactory = clientFactory;
+            }
+
+            public IHttpClientFactory ClientFactory { get; }
+            public AzureDevOpsRestClient Client { get; protected set; }
+
+            protected override AzureDevOpsRestClient GetClient(AuthSettings settings)
+            {
+                return Client = new AzureDevOpsRestClientMock(
+                    ClientFactory,
+                    _logger,
+                    settings.Token,
+                    settings.ApiBase
+                );
+            }
+        }
+
+        class AzureDevOpsRestClientMock : AzureDevOpsRestClient
+        {
+            public AzureDevOpsRestClientMock(
+                IHttpClientFactory clientFactory,
+                INuKeeperLogger logger,
+                string personalAccessToken,
+                Uri baseAddress
+            ) : base(clientFactory, logger, personalAccessToken, baseAddress) { }
+
+            public bool ThrowOnFetchIdentities { get; set; }
+
+            public PRRequest AttemptedPullRequest { get; private set; }
+
+            public override Task<IEnumerable<AzureRepository>> GetGitRepositories(string projectName)
+            {
+                return Task.FromResult(
+                    new List<AzureRepository>
+                    {
+                        new AzureRepository { name = MyRepository }
+                    }.AsEnumerable()
+                );
+            }
+
+            public override Task<IEnumerable<WebApiTeam>> GetTeamsAsync(string projectName)
+            {
+                return Task.FromResult(
+                    new List<WebApiTeam>
+                    {
+                        new WebApiTeam()
+                    }.AsEnumerable()
+                );
+            }
+
+            public override Task<IEnumerable<TeamMember>> GetTeamMembersAsync(string projectName, string teamName)
+            {
+                return Task.FromResult(
+                    new List<TeamMember>
+                    {
+                        new TeamMember { identity = new IdentityRef { id = KnownUserId } }
+                    }.AsEnumerable()
+                );
+            }
+
+            public override Task<Identity> GetUserAsync(string id)
+            {
+                if (ThrowOnFetchIdentities)
+                    throw new NuKeeperException("Could not fetch identity");
+
+                if (id == KnownUserId)
+                {
+                    return Task.FromResult(
+                        new Identity
+                        {
+                            properties = new Dictionary<string, object>
+                            {
+                                { "Mail", KnownUser }
+                            }
+                        }
+                   );
+                }
+
+                return Task.FromResult<Identity>(null);
+            }
+
+            public override Task<PullRequest> CreatePullRequest(PRRequest request, string projectName, string azureRepositoryId)
+            {
+                AttemptedPullRequest = request;
+                return Task.FromResult(new PullRequest());
+            }
         }
     }
 }

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -26,6 +26,7 @@ title: "Configuration"
 | fork             | f         | `repo`, `org`, `global`   | PreferFork (Github) <br/> SingleRepository (AzureDevOps) |
 | fork             | f         | `repo`, `org`, `global`   | PreferFork              |
 | label            | l         | `repo`, `org`, `global`   | 'nukeeper'              |
+| reviewer         | r         | `repo`, `org`, `global`   |                         |
 | maxpackageupdates| m         | `repo`, `org`, `global`, `update`| 3, or when the command is `update`, 1 |
 | maxopenpullrequests |           | `repo`, `org`, `global`| 1 if `consolidate`, else `maxpackageupdates` |
 | consolidate      | n         | `repo`, `org`, `global`   | false                   |
@@ -70,6 +71,7 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
 * *api* This is the api endpoint for the instance you're targeting. If you are using an internal server and not a public one, you must set it to the api url for your server. The value will be e.g. `https://github.mycompany.com/api/v3`.
 * *fork* Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below.
 * *label* Label to apply to GitHub pull requests. Can be specified multiple times.
+* *reviewer* Email address of the reviewer to add to the pull request. Can be specified multiple times. Currently only works for AzureDevops/TFS.
 * *maxpackageupdates* The maximum number of package updates to apply. In `repo`,`org` and `global` commands, this limits the number of updates per repository. If the `--consolidate` flag is used, these wll be consolidated into one Pull Request. If not, then there will be one Pull Request per update applied. In the `update` command, The default value is 1. When changed, multiple updates can be applied in a single `update` run, up to this number.
 * *maxopenpullrequests* The maximum number of pull requests that can be active in one repository at a time. If the `--consolidate` flag is used, the default value is 1. If not, then the default will be `maxpackageupdates`. This currently only works for AzureDevops/TFS.
 

--- a/site/content/platform/azure-devops.md
+++ b/site/content/platform/azure-devops.md
@@ -114,3 +114,15 @@ You can instruct nukeeper to not create more pull requests than allowed by speci
 nukeeper repo "https://dev.azure.com/{org}/{project}/_git/{repo}" <PAT> --maxopenpullrequests 10
 ```
 
+#### Adding reviewers to a pull request
+
+You can add reviewers to your pull request by specifying the `--reviewer` or `-r` option as many times as you like. It expects an email address. The user should be part of any of the teams that belong to the target project.
+
+```sh
+nukeeper repo "https://dev.azure.com/{org}/{project}/_git/{repo}" <PAT> -r nukeeper@company.com
+```
+
+The implementation currently depends on the [Teams](https://docs.microsoft.com/en-us/rest/api/azure/devops/core/teams?view=azure-devops-rest-6.0) and [Identities](https://docs.microsoft.com/en-us/rest/api/azure/devops/ims/?view=azure-devops-rest-6.0) APIs, and requires the following additional scopes:
+
++ `Team and Project`
++ `Profile`


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

None

### :new: What is the new behavior (if this is a feature change)?

You can now specify reviewers to be added to the pull requests created
for the Azure Devops (Server), and TFS or VSTS platforms.

You can do this by either specifying the `--reviewer` option on the
commandline, or by adding a `Reviewers` property to the
`nukeeper.settings.json` file.

As usual, CLI arguments take precedence over settings from the file
system.

The reviewer value should be an email address.

The current implementation uses the REST apis for teams, and team
members. However, I noticed there's also a users api that allows
querying based on the email address. I did not however see an easy way
to make sure that a particular user is part of a team by using that
API, as the `membersOf` property was empty in my case.

Somebody who is more familiar with these apis could probably improve
this implementation significantly but it is working for my azure devops
server instance.

### :boom: Does this PR introduce a breaking change?

No. When creating the pull request, reviewers are immediately added, however if for some reason reviewers cannot be resolved, the pull request is still created.

### :bug: Recommendations for testing

Azure Devops vs Azure Devops Server vs TFS vs VSTS. I only have access to a Azure Devops Server instance. I can confirm it's working there, but I haven't been able to test other cases.

### :memo: Links to relevant issues/docs

?

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
