### PR TITLE
Automatic update of SimpleInjector to 5.0.3

### DIFF
--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="4.10.2" />
+    <PackageReference Include="SimpleInjector" Version="5.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.6.0" />
-    <PackageReference Include="SimpleInjector" Version="4.10.2" />
+    <PackageReference Include="SimpleInjector" Version="5.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a major update of `SimpleInjector` to `5.0.3` from `4.10.2`
`SimpleInjector 5.0.3` was published at `2020-07-13T14:53:58Z`, 1 month ago

2 project updates:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector` `5.0.3` from `4.10.2`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `SimpleInjector` `5.0.3` from `4.10.2`

[SimpleInjector 5.0.3 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/5.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
