### PR TITLE
Automatic update of LibGit2Sharp to 0.27.0-preview-0034

### DIFF
--- a/NuKeeper.Git/NuKeeper.Git.csproj
+++ b/NuKeeper.Git/NuKeeper.Git.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `LibGit2Sharp` to `0.27.0-preview-0034` from `0.26.2`
`LibGit2Sharp 0.27.0-preview-0034` was published at `2019-11-20T22:32:51Z`, 9 months ago

1 project update:
Updated `NuKeeper.Git\NuKeeper.Git.csproj` to `LibGit2Sharp` `0.27.0-preview-0034` from `0.26.2`

[LibGit2Sharp 0.27.0-preview-0034 on NuGet.org](https://www.nuget.org/packages/LibGit2Sharp/0.27.0-preview-0034)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
