### PR TITLE
Automatic update of SimpleInjector to 5.0.3

### DIFF
--- a/NuKeeper.Abstractions/Configuration/FileSettingsCache.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettingsCache.cs
@@ -4,10 +4,10 @@ namespace NuKeeper.Abstractions.Configuration
 {
     public class FileSettingsCache : IFileSettingsCache
     {
-        private readonly FileSettingsReader _reader;
+        private readonly IFileSettingsReader _reader;
         private FileSettings _settings;
 
-        public FileSettingsCache(FileSettingsReader reader)
+        public FileSettingsCache(IFileSettingsReader reader)
         {
             _reader = reader;
         }

--- a/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettingsReader.cs
@@ -4,7 +4,7 @@ using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Abstractions.Configuration
 {
-    public class FileSettingsReader
+    public class FileSettingsReader : IFileSettingsReader
     {
         private readonly INuKeeperLogger _logger;
 

--- a/NuKeeper.Abstractions/Configuration/IFileSettingsReader.cs
+++ b/NuKeeper.Abstractions/Configuration/IFileSettingsReader.cs
@@ -1,0 +1,7 @@
+namespace NuKeeper.Abstractions.Configuration
+{
+    public interface IFileSettingsReader
+    {
+        FileSettings Read(string folder);
+    }
+}

--- a/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/BulkPackageLookup.cs
@@ -12,11 +12,11 @@ namespace NuKeeper.Inspection.NuGetApi
     public class BulkPackageLookup : IBulkPackageLookup
     {
         private readonly IApiPackageLookup _packageLookup;
-        private readonly PackageLookupResultReporter _lookupReporter;
+        private readonly IPackageLookupResultReporter _lookupReporter;
 
         public BulkPackageLookup(
             IApiPackageLookup packageLookup,
-            PackageLookupResultReporter lookupReporter)
+            IPackageLookupResultReporter lookupReporter)
         {
             _packageLookup = packageLookup;
             _lookupReporter = lookupReporter;

--- a/NuKeeper.Inspection/NuGetApi/IPackageLookupResultReporter.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageLookupResultReporter.cs
@@ -1,0 +1,9 @@
+using NuKeeper.Abstractions.NuGetApi;
+
+namespace NuKeeper.Inspection.NuGetApi
+{
+    public interface IPackageLookupResultReporter
+    {
+        void Report(PackageLookupResult lookupResult);
+    }
+}

--- a/NuKeeper.Inspection/NuGetApi/PackageLookupResultReporter.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageLookupResultReporter.cs
@@ -4,7 +4,7 @@ using NuKeeper.Abstractions.NuGetApi;
 
 namespace NuKeeper.Inspection.NuGetApi
 {
-    public class PackageLookupResultReporter
+    public class PackageLookupResultReporter : IPackageLookupResultReporter
     {
         private readonly INuKeeperLogger _logger;
 

--- a/NuKeeper.Inspection/Sources/INuGetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/INuGetConfigFileReader.cs
@@ -1,0 +1,10 @@
+using NuKeeper.Abstractions.Inspections.Files;
+using NuKeeper.Abstractions.NuGet;
+
+namespace NuKeeper.Inspection.Sources
+{
+    public interface INuGetConfigFileReader
+    {
+        NuGetSources ReadNugetSources(IFolder workingFolder);
+    }
+}

--- a/NuKeeper.Inspection/Sources/NuGetConfigFileReader.cs
+++ b/NuKeeper.Inspection/Sources/NuGetConfigFileReader.cs
@@ -8,7 +8,7 @@ using NuKeeper.Abstractions.NuGet;
 
 namespace NuKeeper.Inspection.Sources
 {
-    public class NuGetConfigFileReader
+    public class NuGetConfigFileReader : INuGetConfigFileReader
     {
         private readonly INuKeeperLogger _logger;
 

--- a/NuKeeper.Inspection/Sources/NuGetSourcesReader.cs
+++ b/NuKeeper.Inspection/Sources/NuGetSourcesReader.cs
@@ -6,11 +6,11 @@ namespace NuKeeper.Inspection.Sources
 {
     public class NuGetSourcesReader : INuGetSourcesReader
     {
-        private readonly NuGetConfigFileReader _reader;
+        private readonly INuGetConfigFileReader _reader;
         private readonly INuKeeperLogger _logger;
 
         public NuGetSourcesReader(
-            NuGetConfigFileReader reader,
+            INuGetConfigFileReader reader,
             INuKeeperLogger logger)
         {
             _reader = reader;

--- a/NuKeeper.Tests/ContainerRegistrationTests.cs
+++ b/NuKeeper.Tests/ContainerRegistrationTests.cs
@@ -14,9 +14,10 @@ namespace NuKeeper.Tests
         {
             var container = ContainerRegistration.Init();
 
-            var engine = container.GetInstance<CollaborationEngine>();
+            var engine = container.GetInstance<ICollaborationEngine>();
 
             Assert.That(engine, Is.Not.Null);
+            Assert.That(engine, Is.TypeOf<CollaborationEngine>());
         }
 
         [Test]
@@ -24,9 +25,10 @@ namespace NuKeeper.Tests
         {
             var container = ContainerRegistration.Init();
 
-            var inspector = container.GetInstance<LocalEngine>();
+            var inspector = container.GetInstance<ILocalEngine>();
 
             Assert.That(inspector, Is.Not.Null);
+            Assert.That(inspector, Is.TypeOf<LocalEngine>());
         }
 
         [TestCase(typeof(InspectCommand))]

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -248,7 +248,7 @@ namespace NuKeeper.Tests.Engine
 
             var repoUpdater = new RepositoryUpdater(
                 sources, updateFinder, updateSelection, packageUpdater,
-                Substitute.For<INuKeeperLogger>(), new SolutionsRestore(fileRestore),
+                Substitute.For<INuKeeperLogger>(), new SolutionRestore(fileRestore),
                 reporter);
 
             return (repoUpdater, packageUpdater);

--- a/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/SolutionsRestoreTests.cs
@@ -22,7 +22,7 @@ namespace NuKeeper.Tests.Engine
 
             var packages = new List<PackageUpdateSet>();
 
-            var solutionRestore = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionRestore(cmd);
 
             await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
@@ -42,7 +42,7 @@ namespace NuKeeper.Tests.Engine
             var folder = Substitute.For<IFolder>();
             folder.Find(Arg.Any<string>()).Returns(new[] { sln });
 
-            var solutionRestore = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionRestore(cmd);
 
             await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
@@ -62,7 +62,7 @@ namespace NuKeeper.Tests.Engine
             var folder = Substitute.For<IFolder>();
             folder.Find(Arg.Any<string>()).Returns(new[] { sln });
 
-            var solutionRestore = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionRestore(cmd);
 
             await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 
@@ -83,7 +83,7 @@ namespace NuKeeper.Tests.Engine
             var folder = Substitute.For<IFolder>();
             folder.Find(Arg.Any<string>()).Returns(new[] { sln1, sln2 });
 
-            var solutionRestore = new SolutionsRestore(cmd);
+            var solutionRestore = new SolutionRestore(cmd);
 
             await solutionRestore.CheckRestore(packages, folder, NuGetSources.GlobalFeed);
 

--- a/NuKeeper.Tests/Local/LocalUpdaterTests.cs
+++ b/NuKeeper.Tests/Local/LocalUpdaterTests.cs
@@ -25,7 +25,7 @@ namespace NuKeeper.Tests.Local
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
             var folder = Substitute.For<IFolder>();
-            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
+            var restorer = new SolutionRestore(Substitute.For<IFileRestoreCommand>());
 
             var updater = new LocalUpdater(selection, runner, restorer, logger);
 
@@ -50,7 +50,7 @@ namespace NuKeeper.Tests.Local
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
             var folder = Substitute.For<IFolder>();
-            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
+            var restorer = new SolutionRestore(Substitute.For<IFileRestoreCommand>());
 
             var updater = new LocalUpdater(selection, runner, restorer, logger);
 
@@ -76,7 +76,7 @@ namespace NuKeeper.Tests.Local
             var runner = Substitute.For<IUpdateRunner>();
             var logger = Substitute.For<INuKeeperLogger>();
             var folder = Substitute.For<IFolder>();
-            var restorer = new SolutionsRestore(Substitute.For<IFileRestoreCommand>());
+            var restorer = new SolutionRestore(Substitute.For<IFileRestoreCommand>());
 
             var updater = new LocalUpdater(selection, runner, restorer, logger);
 

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="4.10.2" />
+    <PackageReference Include="SimpleInjector" Version="5.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/NuKeeper.Update/Process/ISolutionRestore.cs
+++ b/NuKeeper.Update/Process/ISolutionRestore.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuKeeper.Abstractions.Inspections.Files;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.RepositoryInspection;
+
+namespace NuKeeper.Update.Process
+{
+    public interface ISolutionRestore
+    {
+        Task CheckRestore(IEnumerable<PackageUpdateSet> targetUpdates, IFolder workingFolder, NuGetSources sources);
+    }
+}

--- a/NuKeeper.Update/Process/SolutionRestore.cs
+++ b/NuKeeper.Update/Process/SolutionRestore.cs
@@ -8,11 +8,11 @@ using NuKeeper.Abstractions.RepositoryInspection;
 
 namespace NuKeeper.Update.Process
 {
-    public class SolutionsRestore
+    public class SolutionRestore : ISolutionRestore
     {
         private readonly IFileRestoreCommand _fileRestoreCommand;
 
-        public SolutionsRestore(IFileRestoreCommand fileRestoreCommand)
+        public SolutionRestore(IFileRestoreCommand fileRestoreCommand)
         {
             _fileRestoreCommand = fileRestoreCommand;
         }

--- a/NuKeeper/ContainerInspectionRegistration.cs
+++ b/NuKeeper/ContainerInspectionRegistration.cs
@@ -24,17 +24,23 @@ namespace NuKeeper
             container.Register<ILogger, NuGetLogger>();
 
             container.Register<IDirectoryExclusions, DirectoryExclusions>();
-            container.Register<IFolder, Folder>();
             container.Register<IFolderFactory, FolderFactory>();
 
             container.Register<IPackageUpdatesLookup, PackageUpdatesLookup>();
             container.Register<IBulkPackageLookup, BulkPackageLookup>();
+            container.Register<IPackageLookupResultReporter, PackageLookupResultReporter>();
             container.Register<IPackageVersionsLookup, PackageVersionsLookup>();
             container.Register<IApiPackageLookup, ApiPackageLookup>();
             container.Register<IRepositoryScanner, RepositoryScanner>();
 
+            container.Register<ProjectFileReader>();
+            container.Register<PackagesFileReader>();
+            container.Register<NuspecFileReader>();
+            container.Register<DirectoryBuildTargetsReader>();
+
             container.Register<IUpdateFinder, UpdateFinder>();
             container.Register<INuGetSourcesReader, NuGetSourcesReader>();
+            container.Register<INuGetConfigFileReader, NuGetConfigFileReader>();
 
             container.Register<IReporter, Reporter>();
             container.Register<IPackageUpdateSetSort, PackageUpdateSetSort>();

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -16,6 +16,8 @@ using NuKeeper.Update.Selection;
 using SimpleInjector;
 using System.Linq;
 using System.Reflection;
+using NuKeeper.Commands;
+using NuKeeper.Update.Process;
 
 namespace NuKeeper
 {
@@ -26,10 +28,20 @@ namespace NuKeeper
             var container = new Container();
 
             Register(container);
+            RegisterCommands(container);
             ContainerInspectionRegistration.Register(container);
             ContainerUpdateRegistration.Register(container);
 
             return container;
+        }
+
+        private static void RegisterCommands(Container container)
+        {
+            container.Register<GlobalCommand>();
+            container.Register<InspectCommand>();
+            container.Register<OrganisationCommand>();
+            container.Register<RepositoryCommand>();
+            container.Register<UpdateCommand>();
         }
 
         private static void Register(Container container)
@@ -42,10 +54,12 @@ namespace NuKeeper
             container.Register<IExistingCommitFilter, ExistingCommitFilter>();
             container.Register<IPackageUpdater, PackageUpdater>();
             container.Register<IRepositoryFilter, RepositoryFilter>();
+            container.Register<ISolutionRestore, SolutionRestore>();
 
             container.Register<ILocalUpdater, LocalUpdater>();
             container.Register<IUpdateSelection, UpdateSelection>();
             container.Register<IFileSettingsCache, FileSettingsCache>();
+            container.Register<IFileSettingsReader, FileSettingsReader>();
 
             container.RegisterSingleton<IEnvironmentVariablesProvider, EnvironmentVariablesProvider>();
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Engine
         private readonly IPackageUpdateSelection _updateSelection;
         private readonly IPackageUpdater _packageUpdater;
         private readonly INuKeeperLogger _logger;
-        private readonly SolutionsRestore _solutionsRestore;
+        private readonly ISolutionRestore _solutionRestore;
         private readonly IReporter _reporter;
 
         public RepositoryUpdater(
@@ -30,7 +30,7 @@ namespace NuKeeper.Engine
             IPackageUpdateSelection updateSelection,
             IPackageUpdater packageUpdater,
             INuKeeperLogger logger,
-            SolutionsRestore solutionsRestore,
+            ISolutionRestore solutionRestore,
             IReporter reporter)
         {
             _nugetSourcesReader = nugetSourcesReader;
@@ -38,7 +38,7 @@ namespace NuKeeper.Engine
             _updateSelection = updateSelection;
             _packageUpdater = packageUpdater;
             _logger = logger;
-            _solutionsRestore = solutionsRestore;
+            _solutionRestore = solutionRestore;
             _reporter = reporter;
         }
 
@@ -113,7 +113,7 @@ namespace NuKeeper.Engine
                 return 0;
             }
 
-            await _solutionsRestore.CheckRestore(targetUpdates, settings.WorkingFolder ?? git.WorkingFolder, sources);
+            await _solutionRestore.CheckRestore(targetUpdates, settings.WorkingFolder ?? git.WorkingFolder, sources);
 
             var updatesDone = await _packageUpdater.MakeUpdatePullRequests(git, repository, targetUpdates, sources, settings);
 

--- a/NuKeeper/Local/LocalUpdater.cs
+++ b/NuKeeper/Local/LocalUpdater.cs
@@ -18,18 +18,18 @@ namespace NuKeeper.Local
     {
         private readonly IUpdateSelection _selection;
         private readonly IUpdateRunner _updateRunner;
-        private readonly SolutionsRestore _solutionsRestore;
+        private readonly ISolutionRestore _solutionRestore;
         private readonly INuKeeperLogger _logger;
 
         public LocalUpdater(
             IUpdateSelection selection,
             IUpdateRunner updateRunner,
-            SolutionsRestore solutionsRestore,
+            ISolutionRestore solutionRestore,
             INuKeeperLogger logger)
         {
             _selection = selection;
             _updateRunner = updateRunner;
-            _solutionsRestore = solutionsRestore;
+            _solutionRestore = solutionRestore;
             _logger = logger;
         }
 
@@ -63,7 +63,7 @@ namespace NuKeeper.Local
 
         private async Task ApplyUpdates(IReadOnlyCollection<PackageUpdateSet> updates, IFolder workingFolder, NuGetSources sources)
         {
-            await _solutionsRestore.CheckRestore(updates, workingFolder, sources);
+            await _solutionRestore.CheckRestore(updates, workingFolder, sources);
 
             foreach (var update in updates)
             {

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.6.0" />
-    <PackageReference Include="SimpleInjector" Version="4.10.2" />
+    <PackageReference Include="SimpleInjector" Version="5.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a major update of `SimpleInjector` to `5.0.3` from `4.10.2`
`SimpleInjector 5.0.3` was published at `2020-07-13T14:53:58Z`, 1 month ago

2 project updates:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector` `5.0.3` from `4.10.2`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `SimpleInjector` `5.0.3` from `4.10.2`

[SimpleInjector 5.0.3 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/5.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
