### PR TITLE
Automatic update of NuGet.CommandLine to 5.6.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
@@ -38,7 +38,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <TfmSpecificPackageFile Include="$(NuGetPackageRoot)\nuget.commandline\5.5.1\tools\NuGet.exe">
+    <TfmSpecificPackageFile Include="$(NuGetPackageRoot)\nuget.commandline\5.6.0\tools\NuGet.exe">
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\NuGet.exe</PackagePath>
     </TfmSpecificPackageFile>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.5.1">
+    <PackageReference Include="NuGet.CommandLine" Version="5.6.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.CommandLine` to `5.6.0` from `5.5.1`
`NuGet.CommandLine 5.6.0` was published at `2020-06-23T23:45:43Z`, 2 months ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.CommandLine` `5.6.0` from `5.5.1`

[NuGet.CommandLine 5.6.0 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/5.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
