### PR TITLE
Automatic update of Microsoft.CodeAnalysis.FxCopAnalyzers to 3.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
@@ -13,7 +13,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
     [TestFixture]
     public class FileSettingsReaderTests
     {
-        private string _uniqueTemporaryFolder = null;
+        private string _uniqueTemporaryFolder;
 
         [SetUp]
         public void Setup()

--- a/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
+++ b/NuKeeper.Inspection.Tests/Sources/NugetSourcesReaderTests.cs
@@ -15,7 +15,7 @@ namespace NuKeeper.Inspection.Tests.Sources
 {
     public class NugetSourcesReaderTests
     {
-        private IFolder _uniqueTemporaryFolder = null;
+        private IFolder _uniqueTemporaryFolder;
 
         [SetUp] 
         public void Setup()

--- a/NuKeeper.Integration.Tests/LogHelpers/NuKeeperTestLogger.cs
+++ b/NuKeeper.Integration.Tests/LogHelpers/NuKeeperTestLogger.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Integration.Tests.LogHelpers
         {
             var test = TestContext.CurrentContext.Test.Name;
 
-            if (_buffer.Count > 0)
+            if (!_buffer.IsEmpty)
             {
                 TestContext.Error.WriteLine($"{test}: NuKeeper Log:");
                 while (_buffer.TryDequeue(out var line))

--- a/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
+++ b/NuKeeper.Integration.Tests/LogHelpers/NugetTestLogger.cs
@@ -26,7 +26,7 @@ namespace NuKeeper.Integration.Tests.LogHelpers
         {
             var test = TestContext.CurrentContext.Test.Name;
 
-            if (_buffer.Count > 0)
+            if (!_buffer.IsEmpty)
             {
                 TestContext.Error.WriteLine($"{test}: NuKeeper Log:");
                 while (_buffer.TryDequeue(out var line))

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -63,7 +63,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>";
 
-        private IFolder _uniqueTemporaryFolder = null;
+        private IFolder _uniqueTemporaryFolder;
 
         [SetUp]
         public void Setup()

--- a/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/NuGetUpdatePackageCommandTests.cs
@@ -31,7 +31,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
         private readonly string _nugetConfig =
             @"<configuration><config><add key=""repositoryPath"" value="".\packages"" /></config></configuration>";
 
-        private IFolder _uniqueTemporaryFolder = null;
+        private IFolder _uniqueTemporaryFolder;
 
         [SetUp]
         public void Setup()

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -48,7 +48,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
   </ItemGroup>
 </Project>";
 
-        private IFolder _uniqueTemporaryFolder = null;
+        private IFolder _uniqueTemporaryFolder;
 
         [SetUp]
         public void Setup()

--- a/NuKeeper.Update/Selection/UpdateSelection.cs
+++ b/NuKeeper.Update/Selection/UpdateSelection.cs
@@ -12,7 +12,7 @@ namespace NuKeeper.Update.Selection
     {
         private readonly INuKeeperLogger _logger;
         private FilterSettings _settings;
-        private DateTime? _maxPublishedDate = null;
+        private DateTime? _maxPublishedDate;
 
         public UpdateSelection(INuKeeperLogger logger)
         {


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0` was published at `2020-08-10T19:51:45Z`, 15 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
