### PR TITLE
Automatic update of NuGet.Credentials to 5.7.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Credentials" Version="5.6.0" />
+    <PackageReference Include="NuGet.Credentials" Version="5.7.0" />
     <PackageReference Include="SimpleInjector" Version="4.10.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Credentials` to `5.7.0` from `5.6.0`
`NuGet.Credentials 5.7.0` was published at `2020-08-13T18:24:19Z`, 12 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.Credentials` `5.7.0` from `5.6.0`

[NuGet.Credentials 5.7.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Credentials/5.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
