### PR TITLE
Fix allowed change to work per version

### DIFF
--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -59,7 +59,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Not.Empty);
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.ContainsKey("foo"), Is.True);
+            Assert.That(results.ElementAt(0).Key.Id, Is.EqualTo("foo"));
         }
 
         [Test]
@@ -106,10 +106,11 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 VersionChange.Major,
                 UsePrerelease.FromPrerelease);
 
+            var packages = results.Select(kvp => kvp.Key);
             Assert.That(results.Count, Is.EqualTo(2));
-            Assert.That(results.ContainsKey("foo"), Is.True);
-            Assert.That(results.ContainsKey("bar"), Is.True);
-            Assert.That(results.ContainsKey("fish"), Is.False);
+            Assert.That(packages, Has.Some.Matches<PackageIdentity>(pi => pi.Id == "foo"));
+            Assert.That(packages, Has.Some.Matches<PackageIdentity>(pi => pi.Id == "bar"));
+            Assert.That(packages, Has.None.Matches<PackageIdentity>(pi => pi.Id == "fish"));
         }
 
         [Test]
@@ -163,9 +164,10 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)),
                 Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
 
+            var packages = results.Select(kvp => kvp.Key);
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.ContainsKey("foo"), Is.True);
-            Assert.That(results.ContainsKey("bar"), Is.False);
+            Assert.That(packages, Has.Some.Matches<PackageIdentity>(pi => pi.Id == "foo"));
+            Assert.That(packages, Has.None.Matches<PackageIdentity>(pi => pi.Id == "bar"));
         }
 
         private static void ApiHasNewVersionForPackage(IApiPackageLookup lookup, string packageName)

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
@@ -1,0 +1,129 @@
+using NSubstitute;
+using NUnit.Framework;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.NuGetApi;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Inspection.NuGetApi;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Inspection.Tests.NuGetApi
+{
+    [TestFixture]
+    public class PackageUpdatesLookupTests
+    {
+        IApiPackageLookup _apiPackageLookup;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _apiPackageLookup = Substitute.For<IApiPackageLookup>();
+
+            _apiPackageLookup
+                .FindVersionUpdate(
+                    Arg.Any<PackageIdentity>(),
+                    Arg.Any<NuGetSources>(),
+                    VersionChange.Minor,
+                    Arg.Any<UsePrerelease>()
+                )
+                .Returns(ci =>
+                    GetPackageLookupResult(
+                        (PackageIdentity)ci[0],
+                        (VersionChange)ci[2]
+                    )
+                );
+        }
+
+        [Test]
+        public async Task FindUpdatesForPackages_OnePackageDifferentVersionsInDifferentProjects_RespectsAllowedChangeForEachVersionIndependently()
+        {
+            var packagesInProjects = new List<PackageInProject>
+            {
+                MakePackageInProject("foo.bar", "6.0.1", "root", "myprojectA"),
+                MakePackageInProject("foo.bar", "10.2.1", "root", "myprojectB")
+            };
+            var sut = MakePackageUpdatesLookup();
+
+            var result = await sut.FindUpdatesForPackages(
+                packagesInProjects,
+                new NuGetSources("https://api.nuget.com/"),
+                VersionChange.Minor,
+                UsePrerelease.Never
+            );
+
+            var versionUpdates = result.Select(p => p.SelectedVersion.ToNormalizedString());
+#pragma warning disable CA1307 // Specify StringComparison
+            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("6.")));
+            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("10.")));
+#pragma warning restore CA1307 // Specify StringComparison
+        }
+
+        private static PackageLookupResult GetPackageLookupResult(
+            PackageIdentity package,
+            VersionChange versionChange
+        )
+        {
+            var packageName = package.Id;
+            var major = package.Version.Major;
+            var minor = package.Version.Minor;
+            var patch = package.Version.Patch;
+
+            return new PackageLookupResult(
+                versionChange,
+                MakePackageSearchMetadata(packageName, $"{major + 1}.0.0"),
+                MakePackageSearchMetadata(packageName, $"{major}.{minor+1}.0"),
+                MakePackageSearchMetadata(packageName, $"{major}.{minor}.{patch+1}")
+            );
+        }
+
+        private static PackageSearchMetadata MakePackageSearchMetadata(
+            string packageName,
+            string version,
+            string source = "https://api.nuget.com/"
+        )
+        {
+            return new PackageSearchMetadata(
+                new PackageIdentity(
+                    packageName,
+                    new NuGetVersion(version)
+                ),
+                new PackageSource(source),
+                null,
+                null
+            );
+        }
+
+        private static PackageInProject MakePackageInProject(
+            string packageName,
+            string version,
+            string rootDir,
+            string relativeDir
+        )
+        {
+            return new PackageInProject(
+                packageName,
+                version,
+                new PackagePath(
+                    rootDir,
+                    relativeDir,
+                    PackageReferenceType.PackagesConfig
+                )
+            );
+        }
+
+        private PackageUpdatesLookup MakePackageUpdatesLookup()
+        {
+            return new PackageUpdatesLookup(
+                new BulkPackageLookup(
+                    _apiPackageLookup,
+                    Substitute.For<IPackageLookupResultReporter>()
+                )
+            );
+        }
+    }
+}

--- a/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
@@ -9,7 +9,7 @@ namespace NuKeeper.Inspection.NuGetApi
 {
     public interface IBulkPackageLookup
     {
-        Task<IDictionary<string, PackageLookupResult>> FindVersionUpdates(
+        Task<IDictionary<PackageIdentity, PackageLookupResult>> FindVersionUpdates(
             IEnumerable<PackageIdentity> packages,
             NuGetSources sources,
             VersionChange allowedChange,

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.Inspection.NuGetApi
                 var matchVersion = latestPackage.Selected().Identity.Version;
 
                 var updatesForThisPackage = packages
-                    .Where(p => p.Id.Equals(packageId,StringComparison.InvariantCultureIgnoreCase) && p.Version < matchVersion)
+                    .Where(p => p.Identity.Equals(packageId) && p.Version < matchVersion)
                     .ToList();
 
                 if (updatesForThisPackage.Count > 0)

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -25,9 +25,10 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
                 UsePrerelease.FromPrerelease);
 
+            var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results, Does.ContainKey("Moq"));
+            Assert.That(updatedPackages, Has.Some.Matches<PackageIdentity>(p => p.Id == "Moq"));
         }
 
         [Test]
@@ -45,10 +46,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
                 UsePrerelease.FromPrerelease);
 
+            var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
-            Assert.That(results, Does.ContainKey("Moq"));
-            Assert.That(results, Does.ContainKey("Newtonsoft.Json"));
+            Assert.That(updatedPackages, Has.Some.Matches<PackageIdentity>(p => p.Id == "Moq"));
+            Assert.That(updatedPackages, Has.Some.Matches<PackageIdentity>(p => p.Id == "Newtonsoft.Json"));
         }
 
         [Test]
@@ -68,8 +70,6 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results.ContainsKey("NUnit"), "results.ContainsKey('NUnit')");
-            Assert.That(results.ContainsKey("nunit"), "results.ContainsKey('nunit')");
         }
 
         [Test]
@@ -120,10 +120,11 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
                 UsePrerelease.FromPrerelease);
 
+            var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(2));
-            Assert.That(results, Does.ContainKey("Moq"));
-            Assert.That(results, Does.ContainKey("Newtonsoft.Json"));
+            Assert.That(updatedPackages, Has.Some.Matches<PackageIdentity>(p => p.Id == "Moq"));
+            Assert.That(updatedPackages, Has.Some.Matches<PackageIdentity>(p => p.Id == "Newtonsoft.Json"));
         }
 
         private BulkPackageLookup BuildBulkPackageLookup()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

In case a package is installed in multiple projects, allowed change will only consider the highest installed version instead of looking at each version independently. This results in unexpected updates for packages outside of the allowed change range. For example, if one project has version 12.0.3 for `Newtonsoft.Json` but another one is still working with version 6.0.3, even when specifying `--change Minor`, it will try to update the 6.0.3 to `12.X.X`. 

We cannot make assumptions about other projects as we don't know if they will end up being loaded into the same process.

This fix ensures that different versions of the same package are only grouped, if that doesn't result in allowed change being ignored.

### :new: What is the new behavior (if this is a feature change)?

N/A

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Test whether the correct updates are being applied when there are multiple versions of the same package across different projects that are outside of the allowed change range for each other.

Test whether the correct updates are being applied if there are multiple versions of the same package across different projects that are inside the allowed change range of each other.

### :memo: Links to relevant issues/docs

+ https://github.com/NuKeeperDotNet/NuKeeper/issues/913
+ https://github.com/NuKeeperDotNet/NuKeeper/issues/912

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated (no relevant documentation)
