### PR TITLE
Adding user:email to personal token scopes

### DIFF
--- a/site/content/platform/github.md
+++ b/site/content/platform/github.md
@@ -14,6 +14,7 @@ To get a token for your *account* go to [**settings -> developer settings -> per
 1. Give it the following access rights:
   - Repo command: 
     - [x] Repo
+    - [x] user:email
   - Organisation command and Global command:
     - [x] Admin:org (read)
     - [x] Admin:public_key (read)  


### PR DESCRIPTION
Adding user:email to personal token scopes

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Website update

### :arrow_heading_down: What is the current behavior?
When adding only the recommended scopes and then running NuKeeper, I get the error "NuKeeper.Abstractions.NuKeeperException: user/emails was not found."

### :new: What is the new behavior (if this is a feature change)?
NuKeeper succeeds

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
N/A - documentation only

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [N/A] All projects build
- [Y] Relevant documentation was updated 
