### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection to 3.1.8

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.CommandLine" Version="5.7.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.DependencyInjection 3.1.8` was published at `2020-09-08T14:11:06Z`, 20 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Microsoft.Extensions.DependencyInjection` `3.1.8` from `3.1.7`

[Microsoft.Extensions.DependencyInjection 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/3.1.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
