### PR TITLE
AD: Support custom limit on number of open pull requests

### DIFF
--- a/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
+++ b/NuKeeper.Abstractions.Tests/Configuration/FileSettingsReaderTests.cs
@@ -46,6 +46,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
             Assert.That(data.MaxPackageUpdates, Is.Null);
+            Assert.That(data.MaxOpenPullRequests, Is.Null);
             Assert.That(data.MaxRepo, Is.Null);
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
@@ -77,6 +78,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Exclude, Is.Null);
             Assert.That(data.Label, Is.Null);
             Assert.That(data.MaxPackageUpdates, Is.Null);
+            Assert.That(data.MaxOpenPullRequests, Is.Null);
             Assert.That(data.MaxRepo, Is.Null);
             Assert.That(data.Verbosity, Is.Null);
             Assert.That(data.Change, Is.Null);
@@ -103,6 +105,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
                ""logFile"":""somefile.log"",
                ""branchNameTemplate"": ""nukeeper/MyBranch"",
                ""maxPackageUpdates"": 42,
+               ""maxOpenPullRequests"": 10,
                ""maxRepo"": 12,
                ""verbosity"": ""Detailed"",
                ""Change"": ""Minor"",
@@ -162,6 +165,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             var data = fsr.Read(path);
 
             Assert.That(data.MaxPackageUpdates, Is.EqualTo(42));
+            Assert.That(data.MaxOpenPullRequests, Is.EqualTo(10));
             Assert.That(data.MaxRepo, Is.EqualTo(12));
         }
 
@@ -197,6 +201,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
                ""IncluDeRepoS"":""repo2"",
                ""label"": [""mark"" ],
                ""MaxPackageUpdates"":4,
+               ""MaxOpenPUllrequests"":10,
                ""MAXrepo"":3,
                ""vErBoSiTy"": ""Q"",
                ""CHANGE"": ""PATCH"",
@@ -219,6 +224,7 @@ namespace NuKeeper.Abstractions.Tests.Configuration
             Assert.That(data.Label.Count, Is.EqualTo(1));
             Assert.That(data.Label, Does.Contain("mark"));
             Assert.That(data.MaxPackageUpdates, Is.EqualTo(4));
+            Assert.That(data.MaxOpenPullRequests, Is.EqualTo(10));
             Assert.That(data.MaxRepo, Is.EqualTo(3));
             Assert.That(data.Verbosity, Is.EqualTo(LogLevel.Quiet));
             Assert.That(data.Change, Is.EqualTo(VersionChange.Patch));

--- a/NuKeeper.Abstractions/CollaborationModels/User.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/User.cs
@@ -2,6 +2,8 @@ namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class User
     {
+        public static readonly User Default = new User("user@email.com", "", "");
+
         public User(string login, string name, string email)
         {
             Login = login;

--- a/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationPlatform.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICollaborationPlatform.cs
@@ -26,5 +26,6 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
         Task<bool> RepositoryBranchExists(string userName, string repositoryName, string branchName);
 
         Task<SearchCodeResult> Search(SearchCodeRequest search);
+        Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName);
     }
 }

--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -43,6 +43,7 @@ namespace NuKeeper.Abstractions.Configuration
         public bool? DeleteBranchAfterMerge { get; set; }
 
         public string GitCliPath { get; set; }
+        public int? MaxOpenPullRequests { get; set; }
 
         public static FileSettings Empty()
         {

--- a/NuKeeper.Abstractions/Configuration/UserSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/UserSettings.cs
@@ -8,6 +8,7 @@ namespace NuKeeper.Abstractions.Configuration
         public NuGetSources NuGetSources { get; set; }
 
         public int MaxRepositoriesChanged { get; set; }
+        public int MaxOpenPullRequests { get; set; }
 
         public bool ConsolidateUpdatesInSinglePullRequest { get; set; }
 

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -115,6 +115,19 @@ namespace NuKeeper.AzureDevOps
                 : new Uri($"{relativePath}{separator}api-version=4.1", UriKind.Relative);
         }
 
+        // documentation is confusing, I think this won't work without memberId or ownerId
+        // https://docs.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-6.0
+        public Task<Resource<Account>> GetCurrentUser()
+        {
+            return GetResource<Resource<Account>>("/_apis/accounts");
+        }
+
+        public Task<Resource<Account>> GetUserByMail(string email)
+        {
+            var encodedEmail = HttpUtility.UrlEncode(email);
+            return GetResource<Resource<Account>>($"/_apis/identities?searchFilter=MailAddress&filterValue={encodedEmail}");
+        }
+
         public async Task<IEnumerable<Project>> GetProjects()
         {
             var response = await GetResource<ProjectResource>("/_apis/projects");
@@ -144,6 +157,15 @@ namespace NuKeeper.AzureDevOps
             var encodedHeadBranch = HttpUtility.UrlEncode(headBranch);
 
             var response = await GetResource<PullRequestResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullrequests?searchCriteria.sourceRefName={encodedHeadBranch}&searchCriteria.targetRefName={encodedBaseBranch}");
+
+            return response?.value.AsEnumerable();
+        }
+
+        public async Task<IEnumerable<PullRequest>> GetPullRequests(string projectName, string repositoryName, string user)
+        {
+            var response = await GetResource<PullRequestResource>(
+                $"{projectName}/_apis/git/repositories/{repositoryName}/pullrequests?searchCriteria.creatorId={user}"
+            );
 
             return response?.value.AsEnumerable();
         }

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +7,42 @@ namespace NuKeeper.AzureDevOps
 #pragma warning disable CA1056 // Uri properties should not be strings
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CA2227 // Collection properties should be read only
+
+    public class Resource<T>
+    {
+        public int count { get; set; }
+        public IEnumerable<T> value { get; set; }
+    }
+
+    public class Account
+    {
+        public string accountId { get; set; }
+        public string accountName { get; set; }
+        public string accountOwner { get; set; }
+        public Dictionary<string, object> properties { get; set; }
+        public string Mail
+        {
+            get
+            {
+                if (properties.ContainsKey("Mail"))
+                {
+                    switch (properties["Mail"])
+                    {
+                        case JObject mailObject:
+                            return mailObject.Property("$value").Value.ToString();
+
+                        case JProperty mailProp:
+                            return mailProp.Value.ToString();
+
+                        case string mailString:
+                            return mailString;
+                    }
+                }
+
+                return string.Empty;
+            }
+        }
+    }
 
     public class Avatar
     {
@@ -75,6 +112,7 @@ namespace NuKeeper.AzureDevOps
         public string Url { get; set; }
         public bool SupportsIterations { get; set; }
         public Creator CreatedBy { get; set; }
+        public IEnumerable<WebApiTagDefinition> labels { get; set; }
 
         // public CreatedBy CreatedBy { get; set; }
         // public Lastmergesourcecommit LastMergeSourceCommit { get; set; }
@@ -82,6 +120,15 @@ namespace NuKeeper.AzureDevOps
         // public Lastmergecommit LastMergeCommit { get; set; }
         // public IEnumerable<Reviewer> Reviewers { get; set; }
     }
+
+    public class WebApiTagDefinition
+    {
+        public bool active { get; set; }
+        public string id { get; set; }
+        public string name { get; set; }
+        public string url { get; set; }
+    }
+
     public class ProjectResource
     {
         public int Count { get; set; }

--- a/NuKeeper.BitBucket/BitbucketPlatform.cs
+++ b/NuKeeper.BitBucket/BitbucketPlatform.cs
@@ -139,5 +139,10 @@ namespace NuKeeper.BitBucket
                     new Uri(repo.links.html.href),
                     null, false, null);
         }
+
+        public Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -263,5 +263,10 @@ namespace NuKeeper.GitHub
                 throw new NuKeeperException(ex.Message, ex);
             }
         }
+
+        public Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/NuKeeper.Gitea/GiteaPlatform.cs
+++ b/NuKeeper.Gitea/GiteaPlatform.cs
@@ -148,5 +148,10 @@ namespace NuKeeper.Gitea
                 repo.IsFork,
                 repo.Parent != null ? MapRepository(repo.Parent) : null);
         }
+
+        public Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/NuKeeper.Gitlab/GitlabPlatform.cs
+++ b/NuKeeper.Gitlab/GitlabPlatform.cs
@@ -126,5 +126,10 @@ namespace NuKeeper.Gitlab
             _logger.Error($"Search has not yet been implemented for GitLab.");
             throw new NotImplementedException();
         }
+
+        public Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdaterTests.cs
@@ -1,0 +1,280 @@
+using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuKeeper.Abstractions.CollaborationModels;
+using NuKeeper.Abstractions.CollaborationPlatform;
+using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Git;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Abstractions.NuGetApi;
+using NuKeeper.Abstractions.RepositoryInspection;
+using NuKeeper.Engine;
+using NuKeeper.Engine.Packages;
+using NuKeeper.Update;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Tests.Engine.Packages
+{
+    [TestFixture]
+    public class PackageUpdaterTests
+    {
+        private ICollaborationFactory _collaborationFactory;
+        private IExistingCommitFilter _existingCommitFilter;
+        private IUpdateRunner _updateRunner;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _collaborationFactory = Substitute.For<ICollaborationFactory>();
+            _existingCommitFilter = Substitute.For<IExistingCommitFilter>();
+            _updateRunner = Substitute.For<IUpdateRunner>();
+
+            _existingCommitFilter
+                .Filter(
+                    Arg.Any<IGitDriver>(),
+                    Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>()
+                )
+                .Returns(ci => ((IReadOnlyCollection<PackageUpdateSet>)ci[1]));
+        }
+
+        [Test]
+        public async Task MakeUpdatePullRequests_TwoUpdatesOneExistingPrAndMaxOpenPrIsTwo_CreatesOnlyOnePr()
+        {
+            _collaborationFactory
+                .CollaborationPlatform
+                .GetNumberOfOpenPullRequests(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(1);
+            var packages = new List<PackageUpdateSet>
+            {
+                MakePackageUpdateSet("foo.bar", "1.0.0"),
+                MakePackageUpdateSet("notfoo.bar", "2.0.0")
+            };
+            var repoData = MakeRepositoryData();
+            var settings = MakeSettings();
+            settings.UserSettings.MaxOpenPullRequests = 2;
+            var sut = MakePackageUpdater();
+
+            var (updatesDone, thresholdReached) = await sut.MakeUpdatePullRequests(
+                Substitute.For<IGitDriver>(),
+                repoData,
+                packages,
+                new NuGetSources(""),
+                settings
+            );
+
+            Assert.That(updatesDone, Is.EqualTo(1));
+            Assert.That(thresholdReached, Is.True);
+        }
+
+        [Test]
+        public async Task MakeUpdatePullRequest_OpenPrsEqualsMaxOpenPrs_DoesNotCreateNewPr()
+        {
+            _collaborationFactory
+                .CollaborationPlatform
+                .GetNumberOfOpenPullRequests(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(2);
+            var packages = new List<PackageUpdateSet>
+            {
+                MakePackageUpdateSet("foo.bar", "1.0.0")
+            };
+            var repoData = MakeRepositoryData();
+            var settings = MakeSettings();
+            settings.UserSettings.MaxOpenPullRequests = 2;
+            var sut = MakePackageUpdater();
+
+            var (updatesDone, thresHoldReached) = await sut.MakeUpdatePullRequests(
+                Substitute.For<IGitDriver>(),
+                repoData,
+                packages,
+                new NuGetSources(""),
+                settings
+            );
+
+            Assert.That(updatesDone, Is.EqualTo(0));
+            Assert.That(thresHoldReached, Is.True);
+        }
+
+        [Test]
+        public async Task MakeUpdatePullRequest_UpdateDoesNotCreatePrDueToExistingCommits_DoesNotPreventNewUpdates()
+        {
+            var packageSetOne = MakePackageUpdateSet("foo.bar", "1.0.0");
+            var packageSetTwo = MakePackageUpdateSet("notfoo.bar", "2.0.0");
+            _collaborationFactory
+                .CollaborationPlatform
+                .GetNumberOfOpenPullRequests(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(1);
+            _existingCommitFilter
+                .Filter(
+                    Arg.Any<IGitDriver>(),
+                    Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>()
+                )
+                .Returns(new List<PackageUpdateSet>(), new List<PackageUpdateSet> { packageSetTwo });
+            var packages = new List<PackageUpdateSet> { packageSetOne, packageSetTwo };
+            var repoData = MakeRepositoryData();
+            var settings = MakeSettings();
+            settings.UserSettings.MaxOpenPullRequests = 2;
+            var sut = MakePackageUpdater();
+
+            var (updatesDone, _) = await sut.MakeUpdatePullRequests(
+                Substitute.For<IGitDriver>(),
+                repoData,
+                packages,
+                new NuGetSources(""),
+                settings
+            );
+
+            Assert.That(updatesDone, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task MakeUpdatePullRequest_UpdateDoesNotCreatePrDueToExistingPr_DoesNotPreventNewUpdates()
+        {
+            var packageSetOne = MakePackageUpdateSet("foo.bar", "1.0.0");
+            var packageSetTwo = MakePackageUpdateSet("notfoo.bar", "2.0.0");
+            _collaborationFactory
+                .CollaborationPlatform
+                .GetNumberOfOpenPullRequests(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(1);
+            _collaborationFactory
+                .CollaborationPlatform
+                .PullRequestExists(Arg.Any<ForkData>(), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(true, false);
+            var packages = new List<PackageUpdateSet> { packageSetOne, packageSetTwo };
+            var repoData = MakeRepositoryData();
+            var settings = MakeSettings();
+            settings.UserSettings.MaxOpenPullRequests = 2;
+            var sut = MakePackageUpdater();
+
+            var (updatesDone, _) = await sut.MakeUpdatePullRequests(
+                Substitute.For<IGitDriver>(),
+                repoData,
+                packages,
+                new NuGetSources(""),
+                settings
+            );
+
+            Assert.That(updatesDone, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task MakeUpdatePullRequests_LessPrsThanMaxOpenPrs_ReturnsNotThresholdReached()
+        {
+            _collaborationFactory
+                .CollaborationPlatform
+                .GetNumberOfOpenPullRequests(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(1);
+            var packages = new List<PackageUpdateSet>
+            {
+                MakePackageUpdateSet("foo.bar", "1.0.0"),
+                MakePackageUpdateSet("notfoo.bar", "2.0.0")
+            };
+            var repoData = MakeRepositoryData();
+            var settings = MakeSettings();
+            settings.UserSettings.MaxOpenPullRequests = 10;
+            var sut = MakePackageUpdater();
+
+            var (updatesDone, thresholdReached) = await sut.MakeUpdatePullRequests(
+                Substitute.For<IGitDriver>(),
+                repoData,
+                packages,
+                new NuGetSources(""),
+                settings
+            );
+
+            Assert.That(thresholdReached, Is.False);
+        }
+
+        private PackageUpdater MakePackageUpdater()
+        {
+            return new PackageUpdater(
+                _collaborationFactory,
+                _existingCommitFilter,
+                _updateRunner,
+                Substitute.For<INuKeeperLogger>()
+            );
+        }
+
+        private static RepositoryData MakeRepositoryData()
+        {
+            return new RepositoryData(
+                new ForkData(new Uri("http://foo.com"), "me", "test"),
+                new ForkData(new Uri("http://foo.com"), "me", "test"));
+        }
+
+        private static PackageUpdateSet MakePackageUpdateSet(string packageName, string version)
+        {
+            return new PackageUpdateSet(
+                new PackageLookupResult(
+                    VersionChange.Major,
+                    MakePackageSearchMetadata(packageName, version),
+                    null,
+                    null
+                ),
+                new List<PackageInProject>
+                {
+                    MakePackageInProject(packageName, version)
+                }
+            );
+        }
+
+        private static SettingsContainer MakeSettings(
+            bool consolidateUpdates = false
+        )
+        {
+            return new SettingsContainer
+            {
+                SourceControlServerSettings = new SourceControlServerSettings
+                {
+                    Repository = new RepositorySettings()
+                },
+                UserSettings = new UserSettings
+                {
+                    ConsolidateUpdatesInSinglePullRequest = consolidateUpdates
+                },
+                BranchSettings = new BranchSettings(),
+                PackageFilters = new FilterSettings
+                {
+                    MaxPackageUpdates = 3,
+                    MinimumAge = new TimeSpan(7, 0, 0, 0),
+                }
+            };
+        }
+
+        private static PackageInProject MakePackageInProject(string packageName, string version)
+        {
+            return new PackageInProject(
+                new PackageVersionRange(
+                    packageName,
+                    VersionRange.Parse(version)
+                ),
+                new PackagePath(
+                    "projectA",
+                    "MyFolder",
+                    PackageReferenceType.PackagesConfig
+                )
+            );
+        }
+
+        private static PackageSearchMetadata MakePackageSearchMetadata(string packageName, string version)
+        {
+            return new PackageSearchMetadata(
+                new PackageIdentity(
+                    packageName,
+                    NuGetVersion.Parse(version)
+                ),
+                new PackageSource("https://api.nuget.com/v3/"),
+                new DateTimeOffset(2019, 1, 12, 0, 0, 0, TimeSpan.Zero),
+                null
+            );
+        }
+    }
+}

--- a/NuKeeper/Engine/Packages/IPackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/IPackageUpdater.cs
@@ -9,11 +9,12 @@ namespace NuKeeper.Engine.Packages
 {
     public interface IPackageUpdater
     {
-        Task<int> MakeUpdatePullRequests(
+        Task<(int UpdatesMade, bool ThresholdReached)> MakeUpdatePullRequests(
             IGitDriver git,
             RepositoryData repository,
             IReadOnlyCollection<PackageUpdateSet> updates,
             NuGetSources sources,
-            SettingsContainer settings);
+            SettingsContainer settings
+        );
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -32,12 +32,13 @@ namespace NuKeeper.Engine.Packages
             _logger = logger;
         }
 
-        public async Task<int> MakeUpdatePullRequests(
+        public async Task<(int UpdatesMade, bool ThresholdReached)> MakeUpdatePullRequests(
             IGitDriver git,
             RepositoryData repository,
             IReadOnlyCollection<PackageUpdateSet> updates,
             NuGetSources sources,
-            SettingsContainer settings)
+            SettingsContainer settings
+        )
         {
             if (settings == null)
             {
@@ -54,6 +55,19 @@ namespace NuKeeper.Engine.Packages
                 throw new ArgumentNullException(nameof(repository));
             }
 
+            var openPrs = await _collaborationFactory.CollaborationPlatform.GetNumberOfOpenPullRequests(
+                repository.Pull.Owner,
+                repository.Pull.Name
+            );
+
+            var allowedPrs = settings.UserSettings.MaxOpenPullRequests;
+
+            if (openPrs >= allowedPrs)
+            {
+                _logger.Normal("Number of open pull requests equals or exceeds allowed number of open pull requests.");
+                return (0, true);
+            }
+
             int totalCount = 0;
 
             var groups = UpdateConsolidator.Consolidate(updates,
@@ -61,17 +75,25 @@ namespace NuKeeper.Engine.Packages
 
             foreach (var updateSets in groups)
             {
-                var updatesMade = await MakeUpdatePullRequests(
+                var (updatesMade, pullRequestCreated) = await MakeUpdatePullRequests(
                     git, repository,
                     sources, settings, updateSets);
 
                 totalCount += updatesMade;
+
+                if (pullRequestCreated)
+                    openPrs++;
+
+                if (openPrs == allowedPrs)
+                {
+                    return (totalCount, true);
+                }
             }
 
-            return totalCount;
+            return (totalCount, false);
         }
 
-        private async Task<int> MakeUpdatePullRequests(
+        private async Task<(int UpdatesMade, bool PullRequestCreated)> MakeUpdatePullRequests(
             IGitDriver git, RepositoryData repository,
             NuGetSources sources, SettingsContainer settings,
             IReadOnlyCollection<PackageUpdateSet> updates)
@@ -108,6 +130,9 @@ namespace NuKeeper.Engine.Packages
                 await git.Commit(commitMessage);
             }
 
+            bool pullRequestCreated = false;
+
+            // bug: pr might not have been created yet
             if (haveUpdates)
             {
                 await git.Push(repository.Remote, branchWithChanges);
@@ -132,6 +157,8 @@ namespace NuKeeper.Engine.Packages
                     var pullRequestRequest = new PullRequestRequest(qualifiedBranch, title, repository.DefaultBranch, settings.BranchSettings.DeleteBranchAfterMerge, settings.SourceControlServerSettings.Repository.SetAutoMerge) { Body = body };
 
                     await _collaborationFactory.CollaborationPlatform.OpenPullRequest(repository.Pull, pullRequestRequest, settings.SourceControlServerSettings.Labels);
+
+                    pullRequestCreated = true;
                 }
                 else
                 {
@@ -139,7 +166,7 @@ namespace NuKeeper.Engine.Packages
                 }
             }
             await git.Checkout(repository.DefaultBranch);
-            return filteredUpdates.Count;
+            return (filteredUpdates.Count, pullRequestCreated);
         }
     }
 }

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -167,5 +167,10 @@ namespace NuKeeper.BitBucketLocal
 
             return new SearchCodeResult(totalCount);
         }
+
+        public Task<int> GetNumberOfOpenPullRequests(string projectName, string repositoryName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -27,6 +27,7 @@ title: "Configuration"
 | fork             | f         | `repo`, `org`, `global`   | PreferFork              |
 | label            | l         | `repo`, `org`, `global`   | 'nukeeper'              |
 | maxpackageupdates| m         | `repo`, `org`, `global`, `update`| 3, or when the command is `update`, 1 |
+| maxopenpullrequests |           | `repo`, `org`, `global`| 1 if `consolidate`, else `maxpackageupdates` |
 | consolidate      | n         | `repo`, `org`, `global`   | false                   |
 | platform         |           | `repo`, `org`, `global`   | _null_                  |
 | gitclipath       | git       | `repo`, `org`, `global`   | _null_ (use default Lib2Git-Implementation)                  |
@@ -70,6 +71,14 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
 * *fork* Values are `PreferFork`, `PreferSingleRepository` and `SingleRepositoryOnly`. Prefer to make branches on a fork of the target repository, or on that repository itself. See the section "Branches, forks and pull requests" below.
 * *label* Label to apply to GitHub pull requests. Can be specified multiple times.
 * *maxpackageupdates* The maximum number of package updates to apply. In `repo`,`org` and `global` commands, this limits the number of updates per repository. If the `--consolidate` flag is used, these wll be consolidated into one Pull Request. If not, then there will be one Pull Request per update applied. In the `update` command, The default value is 1. When changed, multiple updates can be applied in a single `update` run, up to this number.
+* *maxopenpullrequests* The maximum number of pull requests that can be active in one repository at a time. If the `--consolidate` flag is used, the default value is 1. If not, then the default will be `maxpackageupdates`. This currently only works for AzureDevops/TFS.
+
+  To be able to figure out the number of active pull requests, different strategies are used:
+
+  1. First, only pull requests created by the identity linked to the PAT are considered, however this is only possible for Azure Devops Services, and not the on-premise version, as it does not provide any (straightforward) API to be able to figure this out. The cloud version does provide an API that should allow us to figure out the current account, but this requires a token with a scope that can read identities/account information.
+  2. If no account or identity can be determined based on the PAT. Then, currently a hardcoded, user `nukeeper@bot.com` is considered. Again this requires a broader scope.
+  3. If no user identity was able to be fetched, then it will fetch all active PRs and consider only those with labels `nukeeper` attached to it.
+
 * *maxrepo* The maximum number of repositories to change. Used in Organisation and Global mode.
 * *consolidate* Consolidate updates into a single pull request, instead of the default of 1 pull request per package update applied.
 * *platform* One of `GitHub`, `AzureDevOps`, `Bitbucket`, `BitbucketLocal`, `Gitlab`, `Gitea`. Determines which kind of source control api will be used. This is typicaly infered from the api url structure, but since this does not always work, it can be specified here if neccessary.

--- a/site/content/commands/repository.md
+++ b/site/content/commands/repository.md
@@ -93,3 +93,5 @@ NuKeeper sorts the pull requests, using heuristics so that more impactful update
 `--change minor` Do not allow major version changes.
 
 `--age 10d` Do not apply any version change until it has been available for 10 days. The default is 7 days. You can also specify this value in weeks with e.g. `age=6w` or hours with e.g. `age=12h`.
+
+`--maxopenpullrequests 10` will ensure that no more than 10 pull requests can be active in a single repository at the same time. The default value is 1 if `consolidate` is specified, otherwise `maxpackageupdates`.

--- a/site/content/platform/azure-devops.md
+++ b/site/content/platform/azure-devops.md
@@ -105,3 +105,12 @@ Add any additional arguments that are available for the repo command
 nukeeper repo "https://dev.azure.com/{org}/{project}/_git/{repo}/" <PAT> -m 10
 ```
 The `-m 10` tells NuKeeper that it may update 10 packages. For more parameters checkout the [Configuration](/basics/configuration/) page.
+
+#### Setting a custom limit on the number of open pull requests
+
+You can instruct nukeeper to not create more pull requests than allowed by specifying the `--maxopenpullrequests` parameter. The strategy for figuring out how many active pull requests there are is explained in the [configuration page](/basics/configuration/).
+
+```sh
+nukeeper repo "https://dev.azure.com/{org}/{project}/_git/{repo}" <PAT> --maxopenpullrequests 10
+```
+


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature.

### :arrow_heading_down: What is the current behavior?

NuKeeper only creates a single pull request, unless the ordering of selected updates changes due to for example a newer, more important package being released, or some parameter that affects how NuKeeper prioritizes updates changing.

### :new: What is the new behavior (if this is a feature change)?

Now, it is possible to set a limit on the number of open pull requests for Azure Devops/TFS. Nukeeper will now not stop after having tried to apply one set of updates. Instead, it will try to apply updates until it has reached the threshold of the max number of concurrent open pull requests in the repository.

Unfortunately, determining the number of open pull requests is not that straightforward for Azure Devops Server, especially when only having a PAT with `Code (Read & Write)`. The strategies used are explained in the website's configuration page.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

I have only been able to verify the behavior for Azure Devops Server 2019. I cannot make any guarantees for Azure Devops Services (cloud), or older versions of TFS.

### :memo: Links to relevant issues/docs

?

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
