### PR TITLE
Prevent external processes from hanging forever

### DIFF
--- a/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
+++ b/NuKeeper.Update/ProcessRunner/ExternalProcess.cs
@@ -1,8 +1,8 @@
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.Logging;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using NuKeeper.Abstractions;
-using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Update.ProcessRunner
 {
@@ -44,8 +44,13 @@ namespace NuKeeper.Update.ProcessRunner
                 throw new NuKeeperException($"Could not start external process for {command}");
             }
 
-            var textOut = await process.StandardOutput.ReadToEndAsync();
-            var errorOut = await process.StandardError.ReadToEndAsync();
+            var outputs = await Task.WhenAll(
+                process.StandardOutput.ReadToEndAsync(),
+                process.StandardError.ReadToEndAsync()
+            );
+
+            var textOut = outputs[0];
+            var errorOut = outputs[1];
 
             process.WaitForExit();
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

In certain cases, invoking an external process will result in NuKeeper hanging forever waiting for it to terminate. This can reliably be reproduced (in my case), when debugging NuKeeper. When invoking NuKeeper from the command line (without a debugger attached?), this does not happen.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Try debugging NuKeeper. For me this consistently hangs on the first restore solution command. This also happens when running it from bash. It does not happen when I run from the windows cmd console (perhaps after invoking VsDevCmd.bat, since I've been doing that to prevent other problems).

### :memo: Links to relevant issues/docs

+ #1004 

### :thinking: Checklist before submitting

No relevant documentation, I think.

- [X] All projects build
- [X] Relevant documentation was updated 
