### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection to 3.1.9

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.CommandLine" Version="5.7.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection` to `3.1.9` from `3.1.8`
`Microsoft.Extensions.DependencyInjection 3.1.9` was published at `2020-09-24T21:10:05Z`, 15 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Microsoft.Extensions.DependencyInjection` `3.1.9` from `3.1.8`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
