### PR TITLE
Automatic update of Microsoft.Extensions.Http to 5.0.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Http` to `5.0.0` from `3.1.8`
`Microsoft.Extensions.Http 5.0.0` was published at `2020-10-27T05:45:34Z`, 8 days ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `Microsoft.Extensions.Http` `5.0.0` from `3.1.8`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
