### PR TITLE
fix: Use PackageIcon for dotnet pack

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -6,6 +6,7 @@
     <PackageId>nukeeper</PackageId>
     <ToolCommandName>nukeeper</ToolCommandName>
     <Description>Automagically update nuget packages in .NET projects</Description>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
@@ -38,6 +39,7 @@
     <None Update="config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="..\assets\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <TfmSpecificPackageFile Include="$(NuGetPackageRoot)\nuget.commandline\5.7.0\tools\NuGet.exe">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

"build fix".

### :arrow_heading_down: What is the current behavior?

`dotnet pack` throws error NU5048 related to deprecated `PackageIconUrl`.
It refuses to create a nupkg unless I use `PackageIcon`.

See https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048
 for more information.