### PR TITLE
fix(logging): Prevent IO ex concurrent writes

### DIFF
--- a/NuKeeper.Inspection/Logging/FileLogger.cs
+++ b/NuKeeper.Inspection/Logging/FileLogger.cs
@@ -1,11 +1,12 @@
+using NuKeeper.Abstractions.Logging;
 using System;
 using System.IO;
-using NuKeeper.Abstractions.Logging;
 
 namespace NuKeeper.Inspection.Logging
 {
     public class FileLogger : IInternalLogger
     {
+        private readonly object _fileLocker = new object();
         private readonly string _filePath;
         private readonly LogLevel _logLevel;
 
@@ -46,8 +47,9 @@ namespace NuKeeper.Inspection.Logging
 
         private void WriteMessageToFile(string message)
         {
-            using (var w = File.AppendText(_filePath))
+            lock (_fileLocker)
             {
+                using var w = File.AppendText(_filePath);
                 w.WriteLine(message);
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix. 

### :arrow_heading_down: What is the current behavior?

`File.AppendText` takes an exclusive write lock on a file. This means
that when multiple writes are occurring at the same time, an
`IOException` is thrown saying: "The process cannot access the file X
because it is being used by another process".

### :boom: Does this PR introduce a breaking change?

No. 

This fix will only work as long as the logger is used as a "singleton" throughout the application as the lock is not a static property. I decided against making it static because the constructor has file path as a parameter.

### :bug: Recommendations for testing

Use `--logfile`. This caused issues especially in the package update lookup process as it's parallelized.
