### PR TITLE
Nukeeper/fix/return non zero code when updates fail

### DIFF
--- a/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
+++ b/NuKeeper.Tests/Commands/RepositoryCommandTests.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Threading.Tasks;
-
 using NSubstitute;
-
 using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
@@ -18,8 +12,11 @@ using NuKeeper.Engine;
 using NuKeeper.GitHub;
 using NuKeeper.Inspection.Files;
 using NuKeeper.Inspection.Logging;
-
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Tests.Commands
 {
@@ -341,7 +338,7 @@ namespace NuKeeper.Tests.Commands
             collaborationFactorySubstitute.ForkFinder.FindPushFork(Arg.Any<string>(), Arg.Any<ForkData>()).Returns(Task.FromResult(new ForkData(testUri, "nukeeper", "nukeeper")));
             var folderFactorySubstitute = Substitute.For<IFolderFactory>();
             folderFactorySubstitute.FolderFromPath(Arg.Any<string>())
-                .Returns(ci => new Folder(null, new System.IO.DirectoryInfo(ci.Arg<string>())));
+                .Returns(ci => new Folder(Substitute.For<INuKeeperLogger>(), new System.IO.DirectoryInfo(ci.Arg<string>())));
 
             var updater = Substitute.For<IRepositoryUpdater>();
             var gitEngine = new GitRepositoryEngine(updater, collaborationFactorySubstitute, folderFactorySubstitute,

--- a/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
+++ b/NuKeeper.Tests/Engine/CollaborationEngineTests.cs
@@ -1,20 +1,148 @@
 using NSubstitute;
+using NuKeeper.Abstractions;
+using NuKeeper.Abstractions.CollaborationModels;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
+using NuKeeper.Abstractions.Git;
 using NuKeeper.Abstractions.Logging;
+using NuKeeper.Collaboration;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.Files;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuKeeper.Abstractions.CollaborationModels;
-using NuKeeper.Collaboration;
 
 namespace NuKeeper.Tests.Engine
 {
     [TestFixture]
     public class CollaborationEngineTests
     {
+        private IGitRepositoryEngine _repoEngine;
+        private ICollaborationFactory _collaborationFactory;
+        private IFolderFactory _folderFactory;
+        private INuKeeperLogger _logger;
+        private List<RepositorySettings> _disoverableRepositories;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _repoEngine = Substitute.For<IGitRepositoryEngine>();
+            _collaborationFactory = Substitute.For<ICollaborationFactory>();
+            _folderFactory = Substitute.For<IFolderFactory>();
+            _logger = Substitute.For<INuKeeperLogger>();
+            _disoverableRepositories = new List<RepositorySettings>();
+
+            _collaborationFactory.CollaborationPlatform.GetCurrentUser().Returns(new User("", "", ""));
+            _collaborationFactory.Settings.Returns(new CollaborationPlatformSettings());
+            _collaborationFactory
+                .RepositoryDiscovery
+                .GetRepositories(Arg.Any<SourceControlServerSettings>())
+                .Returns(_disoverableRepositories);
+        }
+
+        [Test]
+        public async Task Run_ExceptionWhenUpdatingRepository_StillTreatsOtherRepositories()
+        {
+            var settings = MakeSettings();
+            var repoSettingsOne = MakeRepositorySettingsAndAddAsDiscoverable();
+            var repoSettingsTwo = MakeRepositorySettingsAndAddAsDiscoverable();
+            _repoEngine
+                .When(
+                    r => r.Run(
+                        repoSettingsOne,
+                        Arg.Any<GitUsernamePasswordCredentials>(),
+                        Arg.Any<SettingsContainer>(),
+                        Arg.Any<User>()
+                    )
+                )
+                .Do(r => throw new Exception());
+            var engine = MakeCollaborationEngine();
+
+            try
+            {
+                await engine.Run(settings);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception) { }
+#pragma warning restore CA1031 // Do not catch general exception types
+
+            await _repoEngine
+                .Received()
+                .Run(
+                    repoSettingsTwo,
+                    Arg.Any<GitUsernamePasswordCredentials>(),
+                    Arg.Any<SettingsContainer>(),
+                    Arg.Any<User>()
+                );
+        }
+
+        [Test]
+        public void Run_ExceptionWhenUpdatingRepository_RethrowsException()
+        {
+            var exceptionMessage = "Try again later";
+            var settings = MakeSettings();
+            var repoSettingsOne = MakeRepositorySettingsAndAddAsDiscoverable();
+            var repoSettingsTwo = MakeRepositorySettingsAndAddAsDiscoverable();
+            _repoEngine
+                .When(
+                    r => r.Run(
+                        repoSettingsOne,
+                        Arg.Any<GitUsernamePasswordCredentials>(),
+                        Arg.Any<SettingsContainer>(),
+                        Arg.Any<User>()
+                    )
+                )
+                .Do(r => throw new NuKeeperException(exceptionMessage));
+            var engine = MakeCollaborationEngine();
+
+            var ex = Assert.ThrowsAsync<NuKeeperException>(() => engine.Run(settings));
+
+            var innerEx = ex.InnerException as NuKeeperException;
+            Assert.IsNotNull(innerEx);
+            Assert.AreEqual(exceptionMessage, innerEx.Message);
+        }
+
+        [Test]
+        public void Run_MultipleExceptionsWhenUpdatingRepositories_AreFlattened()
+        {
+            var settings = MakeSettings();
+            var repoSettingsOne = MakeRepositorySettingsAndAddAsDiscoverable();
+            var repoSettingsTwo = MakeRepositorySettingsAndAddAsDiscoverable();
+            var repoSettingsThree = MakeRepositorySettingsAndAddAsDiscoverable();
+            _repoEngine
+                .When(
+                    r => r.Run(
+                        repoSettingsOne,
+                        Arg.Any<GitUsernamePasswordCredentials>(),
+                        Arg.Any<SettingsContainer>(),
+                        Arg.Any<User>()
+                    )
+                )
+                .Do(r => throw new InvalidOperationException("Repo 1 failed!"));
+            _repoEngine
+                .When(
+                    r => r.Run(
+                        repoSettingsThree,
+                        Arg.Any<GitUsernamePasswordCredentials>(),
+                        Arg.Any<SettingsContainer>(),
+                        Arg.Any<User>()
+                    )
+                )
+                .Do(r => throw new TaskCanceledException("Repo 3 failed!"));
+            var engine = MakeCollaborationEngine();
+
+            var ex = Assert.ThrowsAsync<NuKeeperException>(() => engine.Run(settings));
+
+            var aggregateEx = ex.InnerException as AggregateException;
+            var exceptions = aggregateEx?.InnerExceptions;
+            Assert.IsNotNull(aggregateEx);
+            Assert.IsNotNull(exceptions);
+            Assert.AreEqual(2, exceptions.Count);
+            Assert.That(exceptions, Has.One.InstanceOf(typeof(InvalidOperationException)));
+            Assert.That(exceptions, Has.One.InstanceOf(typeof(TaskCanceledException)));
+        }
+
         [Test]
         public async Task SuccessCaseWithNoRepos()
         {
@@ -110,6 +238,23 @@ namespace NuKeeper.Tests.Engine
             var count = await engine.Run(settings);
 
             Assert.That(count, Is.EqualTo(1));
+        }
+
+        private ICollaborationEngine MakeCollaborationEngine()
+        {
+            return new CollaborationEngine(
+                _collaborationFactory,
+                _repoEngine,
+                _folderFactory,
+                _logger
+            );
+        }
+
+        private RepositorySettings MakeRepositorySettingsAndAddAsDiscoverable()
+        {
+            var repositorySettings = new RepositorySettings();
+            _disoverableRepositories.Add(repositorySettings);
+            return repositorySettings;
         }
 
         private static CollaborationEngine MakeCollaborationEngine(

--- a/NuKeeper/Collaboration/CollaborationEngine.cs
+++ b/NuKeeper/Collaboration/CollaborationEngine.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Threading.Tasks;
+using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Formats;
@@ -7,6 +6,8 @@ using NuKeeper.Abstractions.Git;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Engine;
 using NuKeeper.Inspection.Files;
+using System;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Collaboration
 {
@@ -49,6 +50,7 @@ namespace NuKeeper.Collaboration
             var repositories = await _collaborationFactory.RepositoryDiscovery.GetRepositories(settings.SourceControlServerSettings);
 
             var reposUpdated = 0;
+            (bool Happened, Exception Value) unhandledEx = (false, null);
 
             foreach (var repository in repositories)
             {
@@ -57,13 +59,23 @@ namespace NuKeeper.Collaboration
                     _logger.Detailed($"Reached max of {reposUpdated} repositories changed");
                     break;
                 }
-
-                var updatesInThisRepo = await _repositoryEngine.Run(repository,
-                    credentials, settings, user);
-
-                if (updatesInThisRepo > 0)
+                try
                 {
-                    reposUpdated++;
+
+                    var updatesInThisRepo = await _repositoryEngine.Run(repository,
+                        credentials, settings, user);
+
+                    if (updatesInThisRepo > 0)
+                    {
+                        reposUpdated++;
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _logger.Error($"Failed on repo {repository.RepositoryName}", ex);
+                    SetOrUpdateUnhandledException(ref unhandledEx, ex);
                 }
             }
 
@@ -73,12 +85,46 @@ namespace NuKeeper.Collaboration
             }
 
             _logger.Detailed($"Done at {Now()}");
+
+            ThrowIfUnhandledException(unhandledEx);
+
             return reposUpdated;
         }
 
         private static string Now()
         {
             return DateFormat.AsUtcIso8601(DateTimeOffset.Now);
+        }
+
+        private static void SetOrUpdateUnhandledException(
+            ref (bool Happened, Exception Value) unhandledEx,
+            Exception ex
+        )
+        {
+            unhandledEx.Happened = true;
+            if (unhandledEx.Value == null)
+            {
+                unhandledEx.Value = ex;
+            }
+            else
+            {
+                unhandledEx.Value = new AggregateException(unhandledEx.Value, ex);
+            }
+        }
+
+        private static void ThrowIfUnhandledException(
+            (bool Happened, Exception Value) unhandledEx
+        )
+        {
+            if (unhandledEx.Happened)
+            {
+                var exception = unhandledEx.Value;
+                if (exception is AggregateException aggregateException)
+                {
+                    exception = aggregateException.Flatten();
+                }
+                throw new NuKeeperException("One or multiple repositories failed to update.", exception);
+            }
         }
     }
 }

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -109,14 +109,17 @@ namespace NuKeeper.Engine
                 new LibGit2SharpDriver(_logger, folder, credentials, user) as IGitDriver :
                 new GitCmdDriver(settings.UserSettings.GitPath, _logger, folder, credentials) as IGitDriver;
 
-            var updatesDone = await _repositoryUpdater.Run(git, repositoryData, settings);
-
-            if (!repository.IsLocalRepo)
+            try
             {
-                folder.TryDelete();
+                return await _repositoryUpdater.Run(git, repositoryData, settings);
             }
-
-            return updatesDone;
+            finally
+            {
+                if (!repository.IsLocalRepo)
+                {
+                    folder.TryDelete();
+                }
+            }
         }
 
         private async Task<RepositoryData> BuildGitRepositorySpec(

--- a/NuKeeper/Engine/GitRepositoryEngine.cs
+++ b/NuKeeper/Engine/GitRepositoryEngine.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Credentials;
 using NuKeeper.Abstractions.CollaborationModels;
@@ -11,6 +8,9 @@ using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
 using NuKeeper.Git;
 using NuKeeper.Inspection.Files;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace NuKeeper.Engine
 {
@@ -60,73 +60,63 @@ namespace NuKeeper.Engine
 
             DefaultCredentialServiceUtility.SetupDefaultCredentialService(_nugetLogger, true);
 
-            try
+            var repositoryData = await BuildGitRepositorySpec(repository, credentials.Username);
+            if (repositoryData == null)
             {
-                var repositoryData = await BuildGitRepositorySpec(repository, credentials.Username);
-                if (repositoryData == null)
+                return 0;
+            }
+
+            // should perform the remote check for "is this a .NET repo"
+            // (and also not a github fork)
+            // only when we have multiple remote repos
+            // otherwise it's ok to work locally, and check there
+            if (!(settings.SourceControlServerSettings.Scope == ServerScope.Repository || repository.IsLocalRepo))
+            {
+                var remoteRepoContainsDotNet = await _repositoryFilter.ContainsDotNetProjects(repository);
+                if (!remoteRepoContainsDotNet)
                 {
                     return 0;
                 }
-
-                // should perform the remote check for "is this a .NET repo"
-                // (and also not a github fork)
-                // only when we have multiple remote repos
-                // otherwise it's ok to work locally, and check there
-                if (!(settings.SourceControlServerSettings.Scope == ServerScope.Repository || repository.IsLocalRepo))
-                {
-                    var remoteRepoContainsDotNet = await _repositoryFilter.ContainsDotNetProjects(repository);
-                    if (!remoteRepoContainsDotNet)
-                    {
-                        return 0;
-                    }
-                }
-
-                IFolder folder;
-                if (repository.IsLocalRepo)
-                {
-                    folder = new Folder(_logger, new DirectoryInfo(Uri.UnescapeDataString(repository.RemoteInfo.LocalRepositoryUri.AbsolutePath)));
-                    settings.WorkingFolder = new Folder(_logger, new DirectoryInfo(Uri.UnescapeDataString(repository.RemoteInfo.WorkingFolder.AbsolutePath)));
-                    repositoryData.IsLocalRepo = repository.IsLocalRepo;
-
-                    if (!repositoryData.IsFork) //check if we are on a fork. If not on a fork we set the remote to the locally found remote
-                    {
-                        repositoryData.Remote = repository.RemoteInfo.RemoteName;
-                    }
-                }
-                else
-                {
-                    folder = !string.IsNullOrWhiteSpace(settings?.UserSettings?.Directory)
-                        ? _folderFactory.FolderFromPath(settings.UserSettings.Directory)
-                        : _folderFactory.UniqueTemporaryFolder();
-                    settings.WorkingFolder = folder;
-                }
-
-                if (!string.IsNullOrEmpty(repository.RemoteInfo?.BranchName))
-                {
-                    repositoryData.DefaultBranch = repository.RemoteInfo.BranchName;
-                }
-
-                repositoryData.IsLocalRepo = repository.IsLocalRepo;
-                IGitDriver git = string.IsNullOrWhiteSpace(settings?.UserSettings?.GitPath) ?
-                    new LibGit2SharpDriver(_logger, folder, credentials, user) as IGitDriver :
-                    new GitCmdDriver(settings.UserSettings.GitPath, _logger, folder, credentials) as IGitDriver;
-
-                var updatesDone = await _repositoryUpdater.Run(git, repositoryData, settings);
-
-                if (!repository.IsLocalRepo)
-                {
-                    folder.TryDelete();
-                }
-
-                return updatesDone;
             }
-#pragma warning disable CA1031
-            catch (Exception ex)
-#pragma warning restore CA1031
+
+            IFolder folder;
+            if (repository.IsLocalRepo)
             {
-                _logger.Error($"Failed on repo {repository.RepositoryName}", ex);
-                return 1;
+                folder = new Folder(_logger, new DirectoryInfo(Uri.UnescapeDataString(repository.RemoteInfo.LocalRepositoryUri.AbsolutePath)));
+                settings.WorkingFolder = new Folder(_logger, new DirectoryInfo(Uri.UnescapeDataString(repository.RemoteInfo.WorkingFolder.AbsolutePath)));
+                repositoryData.IsLocalRepo = repository.IsLocalRepo;
+
+                if (!repositoryData.IsFork) //check if we are on a fork. If not on a fork we set the remote to the locally found remote
+                {
+                    repositoryData.Remote = repository.RemoteInfo.RemoteName;
+                }
             }
+            else
+            {
+                folder = !string.IsNullOrWhiteSpace(settings?.UserSettings?.Directory)
+                    ? _folderFactory.FolderFromPath(settings.UserSettings.Directory)
+                    : _folderFactory.UniqueTemporaryFolder();
+                settings.WorkingFolder = folder;
+            }
+
+            if (!string.IsNullOrEmpty(repository.RemoteInfo?.BranchName))
+            {
+                repositoryData.DefaultBranch = repository.RemoteInfo.BranchName;
+            }
+
+            repositoryData.IsLocalRepo = repository.IsLocalRepo;
+            IGitDriver git = string.IsNullOrWhiteSpace(settings?.UserSettings?.GitPath) ?
+                new LibGit2SharpDriver(_logger, folder, credentials, user) as IGitDriver :
+                new GitCmdDriver(settings.UserSettings.GitPath, _logger, folder, credentials) as IGitDriver;
+
+            var updatesDone = await _repositoryUpdater.Run(git, repositoryData, settings);
+
+            if (!repository.IsLocalRepo)
+            {
+                folder.TryDelete();
+            }
+
+            return updatesDone;
         }
 
         private async Task<RepositoryData> BuildGitRepositorySpec(

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -55,25 +55,17 @@ namespace NuKeeper.Engine.Packages
             }
 
             int totalCount = 0;
-            try
-            {
-                var groups = UpdateConsolidator.Consolidate(updates,
-                    settings.UserSettings.ConsolidateUpdatesInSinglePullRequest);
 
-                foreach (var updateSets in groups)
-                {
-                    var updatesMade = await MakeUpdatePullRequests(
-                        git, repository,
-                        sources, settings, updateSets);
+            var groups = UpdateConsolidator.Consolidate(updates,
+                settings.UserSettings.ConsolidateUpdatesInSinglePullRequest);
 
-                    totalCount += updatesMade;
-                }
-            }
-#pragma warning disable CA1031
-            catch (Exception ex)
-#pragma warning restore CA1031
+            foreach (var updateSets in groups)
             {
-                _logger.Error("Updates failed", ex);
+                var updatesMade = await MakeUpdatePullRequests(
+                    git, repository,
+                    sources, settings, updateSets);
+
+                totalCount += updatesMade;
             }
 
             return totalCount;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

In many locations exceptions were being swallowed inappropriately. 

I've ensured that each separate repository gets a chance to run in case
of a multiple repository update command; single repository commands on
the other hand will now fail as soon as one of its update sets cannot be
applied.

The reasoning for this is the following: an error at the level of an
update set being applied is most likely going to happen for all the
different update sets. It is after all working with the same git
repository, target repository,... For example, if a push fails due to an
authentication issue, it will happen for all update sets.

After all repositories have had their chance and at least one of them
fails, an exception is throw that will result in a non-zero status code
being returned to process that invoked nukeeper.

`ICollaborationEngine` returns an integer, but this represents the
number of updates it has performed, and since there's no easy way to know
what the expected number of updates is at this point, there's no way to
utilize this information to be able to tell whether
`CollaborationPlatformCommand` should return a non-zero status code.

### :boom: Does this PR introduce a breaking change?

Yes. NuKeeper will now return a non-zero exit code in case of failure.

### :bug: Recommendations for testing

Compare behavior of various commands before and after to ensure NuKeeper is return a non-zero status code at the appropriate times.