### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.8.0

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.8.0` from `16.7.1`
`Microsoft.NET.Test.Sdk 16.8.0` was published at `2020-11-08T13:22:12Z`, 7 days ago

10 project updates:
Updated `NuKeeper.Abstractions.Tests\NuKeeper.Abstractions.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `Nukeeper.AzureDevOps.Tests\Nukeeper.AzureDevOps.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Git.Tests\NuKeeper.Git.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Gitea.Tests\NuKeeper.Gitea.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.GitHub.Tests\NuKeeper.GitHub.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Tests\NuKeeper.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`
Updated `NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.0` from `16.7.1`

[Microsoft.NET.Test.Sdk 16.8.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
