### PR TITLE
Automatic update of Microsoft.Extensions.Http to 5.0.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
   </ItemGroup>
 

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,6 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.CommandLine" Version="5.7.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Http` to `5.0.0` from `3.1.8`
`Microsoft.Extensions.Http 5.0.0` was published at `2020-11-09T23:40:35Z`, 11 days ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `Microsoft.Extensions.Http` `5.0.0` from `3.1.8`

[Microsoft.Extensions.Http 5.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/5.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
