### PR TITLE
Automatic update of System.Text.Encoding.CodePages to 5.0.0

### DIFF
--- a/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a major update of `System.Text.Encoding.CodePages` to `5.0.0` from `4.7.1`
`System.Text.Encoding.CodePages 5.0.0` was published at `2020-11-09T23:44:09Z`, 11 days ago

1 project update:
Updated `NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `System.Text.Encoding.CodePages` `5.0.0` from `4.7.1`

[System.Text.Encoding.CodePages 5.0.0 on NuGet.org](https://www.nuget.org/packages/System.Text.Encoding.CodePages/5.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
