### PR TITLE
Automatic update of Microsoft.CodeAnalysis.FxCopAnalyzers to 3.3.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NSubstitute;
 using NUnit.Framework;
 using NuGet.Configuration;
@@ -56,11 +57,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 UsePrerelease.Never
             );
 
-            var versionUpdates = result.Select(p => p.SelectedVersion.ToNormalizedString());
-#pragma warning disable CA1307 // Specify StringComparison
-            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("6.")));
-            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("10.")));
-#pragma warning restore CA1307 // Specify StringComparison
+            var versionUpdates = result.Select(p => p.SelectedVersion.ToNormalizedString()).ToList();
+            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("6.", StringComparison.OrdinalIgnoreCase)));
+            Assert.That(versionUpdates, Has.Some.Matches<string>(version => version.StartsWith("10.", StringComparison.OrdinalIgnoreCase)));
         }
 
         private static PackageLookupResult GetPackageLookupResult(


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.1` from `3.3.0`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.1` was published at `2020-10-28T20:56:21Z`, 23 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.1` from `3.3.0`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
