### PR TITLE
Automatic update of NuGet.Protocol to 5.8.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Protocol` to `5.8.0` from `5.7.0`
`NuGet.Protocol 5.8.0` was published at `2020-11-09T20:44:56Z`, 11 days ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `NuGet.Protocol` `5.8.0` from `5.7.0`

[NuGet.Protocol 5.8.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Protocol/5.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
