### PR TITLE
Automatic update of SimpleInjector.Integration.ServiceCollection to 5.0.2

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.7.0" />
     <PackageReference Include="SimpleInjector" Version="5.1.0" />
-    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
+    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `SimpleInjector.Integration.ServiceCollection` to `5.0.2` from `5.0.1`
`SimpleInjector.Integration.ServiceCollection 5.0.2` was published at `2020-10-25T10:52:04Z`, 27 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector.Integration.ServiceCollection` `5.0.2` from `5.0.1`

[SimpleInjector.Integration.ServiceCollection 5.0.2 on NuGet.org](https://www.nuget.org/packages/SimpleInjector.Integration.ServiceCollection/5.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
