### PR TITLE
Automatic update of NuGet.Credentials to 5.8.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Credentials" Version="5.7.0" />
+    <PackageReference Include="NuGet.Credentials" Version="5.8.0" />
     <PackageReference Include="SimpleInjector" Version="5.1.0" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Credentials` to `5.8.0` from `5.7.0`
`NuGet.Credentials 5.8.0` was published at `2020-11-09T20:44:41Z`, 11 days ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `NuGet.Credentials` `5.8.0` from `5.7.0`

[NuGet.Credentials 5.8.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Credentials/5.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
