### PR TITLE
Revert "Support `--targetBranch` for Azure Devops Server/TFS for remote repositories"

### DIFF
--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.AzureDevOps
 
             var settings = repositoryUri.IsFile
                 ? await CreateSettingsFromLocal(repositoryUri, targetBranch)
-                : CreateSettingsFromRemote(repositoryUri, targetBranch);
+                : CreateSettingsFromRemote(repositoryUri);
             if (settings == null)
             {
                 throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
@@ -64,9 +64,9 @@ namespace NuKeeper.AzureDevOps
             return settings;
         }
 
-        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
         {
-            return RepositorySettings(repositoryUri, new RemoteInfo { BranchName = targetBranch });
+            return RepositorySettings(repositoryUri);
         }
 
         private async Task<RepositorySettings> CreateSettingsFromLocal(Uri repositoryUri, string targetBranch)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.Commands
         public string RepositoryUri { get; set; }
 
         [Option(CommandOptionType.SingleValue, LongName = "targetBranch",
-            Description = "Use another target branch than the currently active HEAD branch of the remote or local repository")]
+            Description = "If the target branch is another branch than that you are currently on, set this to the target")]
         public string TargetBranch { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "cdir", Description = "If you want NuKeeper to check out the repository to an alternate path, set it here (by default, a temporary directory is used).")]

--- a/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
@@ -120,15 +120,5 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual("project name", settings.RepositoryOwner);
         }
 
-        [Test]
-        public async Task RepositorySettings_WithRemoteUrlAndTargetBranch_ReturnsRemoteInfoWithSpecifiedBranchName()
-        {
-            var uri = new Uri("https://internalserver/tfs/project%20name/_git/repo%20name");
-            var targetBranch = "myTargetBranch";
-
-            var settings = await _azureSettingsReader.RepositorySettings(uri, targetBranch);
-
-            Assert.AreEqual("myTargetBranch", settings.RemoteInfo.BranchName);
-        }
     }
 }

--- a/site/content/commands/repository.md
+++ b/site/content/commands/repository.md
@@ -50,7 +50,7 @@ This is only available for azure devops and vsts
 ### Using a targetBranch
 
 {{% notice info %}}
-This is only available for azure devops, azure devops server, vsts, tfs, and github right now
+This is only available for azure devops, vsts and github right now
 {{% /notice %}}
 
 In some cases you want NuKeeper not to run on the default branch but on a specific (feature-)branch 


### PR DESCRIPTION
Reverts NuKeeperDotNet/NuKeeper#1008

The branch was out of date and caused build failures.