### PR TITLE
Support `--targetBranch` for Azure Devops Server/TFS for remote repositories

### DIFF
--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.AzureDevOps
 
             var settings = repositoryUri.IsFile
                 ? await CreateSettingsFromLocal(repositoryUri, targetBranch)
-                : CreateSettingsFromRemote(repositoryUri);
+                : CreateSettingsFromRemote(repositoryUri, targetBranch);
             if (settings == null)
             {
                 throw new NuKeeperException($"The provided uri was is not in the correct format. Provided {repositoryUri.ToString()} and format should be {UrlPattern}");
@@ -64,9 +64,9 @@ namespace NuKeeper.AzureDevOps
             return settings;
         }
 
-        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
         {
-            return RepositorySettings(repositoryUri);
+            return RepositorySettings(repositoryUri, new RemoteInfo { BranchName = targetBranch });
         }
 
         private async Task<RepositorySettings> CreateSettingsFromLocal(Uri repositoryUri, string targetBranch)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -32,7 +32,7 @@ namespace NuKeeper.Commands
         public string RepositoryUri { get; set; }
 
         [Option(CommandOptionType.SingleValue, LongName = "targetBranch",
-            Description = "If the target branch is another branch than that you are currently on, set this to the target")]
+            Description = "Use another target branch than the currently active HEAD branch of the remote or local repository")]
         public string TargetBranch { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "cdir", Description = "If you want NuKeeper to check out the repository to an alternate path, set it here (by default, a temporary directory is used).")]

--- a/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/TfsSettingsReaderTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using NSubstitute;
 using NuKeeper.Abstractions;
 using NuKeeper.Abstractions.CollaborationPlatform;
@@ -7,6 +5,8 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.AzureDevOps;
 using NuKeeper.Tests;
 using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
 
 namespace Nukeeper.AzureDevOps.Tests
 {
@@ -120,5 +120,15 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual("project name", settings.RepositoryOwner);
         }
 
+        [Test]
+        public async Task RepositorySettings_WithRemoteUrlAndTargetBranch_ReturnsRemoteInfoWithSpecifiedBranchName()
+        {
+            var uri = new Uri("https://internalserver/tfs/project%20name/_git/repo%20name");
+            var targetBranch = "myTargetBranch";
+
+            var settings = await _azureSettingsReader.RepositorySettings(uri, false, targetBranch);
+
+            Assert.AreEqual("myTargetBranch", settings.RemoteInfo.BranchName);
+        }
     }
 }

--- a/site/content/commands/repository.md
+++ b/site/content/commands/repository.md
@@ -50,7 +50,7 @@ This is only available for azure devops and vsts
 ### Using a targetBranch
 
 {{% notice info %}}
-This is only available for azure devops, vsts and github right now
+This is only available for azure devops, azure devops server, vsts, tfs, and github right now
 {{% /notice %}}
 
 In some cases you want NuKeeper not to run on the default branch but on a specific (feature-)branch 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature. This PR ensures that specifying `--targetBranch` option works for repositories hosted in on-premise Azure Devops Server (or TFS), when providing a non-file URI.

### :arrow_heading_down: What is the current behavior?

Currently specifying `--targetBranch` for Azure Devops Server (or TFS) has no effect if the URI is not for a local repository.

### :new: What is the new behavior (if this is a feature change)?

Specifying `--targetBranch` for a remote repository will now correctly apply updates to the target branch.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

?

### :memo: Links to relevant issues/docs

+ No linked issue.
+ [repository command](site/content/commands/repository.md)

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
