### PR TITLE
Update NuKeeper.csproj to enable .NET 5.0 environments to use the tool

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net50</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>


### PR DESCRIPTION
Update to support .NET 5.0 based environments

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds support in the NuKeeper project for usage of the dotnet global tool in a pure .NET 5.0 environment.

### :arrow_heading_down: What is the current behavior?
Running in a docker container with only .NET 5.0 installed, this is the current output:

```
Tool 'nukeeper' (version '0.34.0') was successfully installed.
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.1.0' was not found.
  - The following frameworks were found:
      5.0.0 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```
So we cannot use NuKeeper without also installing .NET Core 3.1

### :new: What is the new behavior (if this is a feature change)?
With this new target framework version `dotnet tool install` will recognize the correct TFM to use and fix the issue.

### :boom: Does this PR introduce a breaking change?
I don't think so :-)

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
