### PR TITLE
Fix target-branch for azure devops client.

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.AzureDevOps
 
             var settings = repositoryUri.IsFile
                 ? await CreateSettingsFromLocal(repositoryUri, targetBranch)
-                : CreateSettingsFromRemote(repositoryUri);
+                : CreateSettingsFromRemote(repositoryUri, targetBranch);
 
             if (settings == null)
             {
@@ -59,7 +59,7 @@ namespace NuKeeper.AzureDevOps
             return settings;
         }
 
-        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
         {
             // URL pattern is
             // https://dev.azure.com/{org}/{project}/_git/{repo}/
@@ -80,8 +80,8 @@ namespace NuKeeper.AzureDevOps
                     pathParts[0],  //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[1]),  // project
-                    Uri.UnescapeDataString(pathParts[3])   // reponame
-                    );
+                    Uri.UnescapeDataString(pathParts[3]),   // reponame
+                    new RemoteInfo { BranchName = targetBranch });
             }
             else if (indexOfGit == 1 && pathParts.Length == 3)
             {
@@ -89,8 +89,8 @@ namespace NuKeeper.AzureDevOps
                     null,          //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[0]),  // project
-                    Uri.UnescapeDataString(pathParts[2])   // reponame
-                    );
+                    Uri.UnescapeDataString(pathParts[2]),   // reponame
+                    new RemoteInfo { BranchName = targetBranch });
             }
             return null;
         }

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
@@ -82,7 +82,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public async Task RepositorySettings_GetsCorrectSettingsOrganisation()
         {
-            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/org/project/_git/reponame"), true);
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/org/project/_git/reponame"), true, "develop");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiUri, "https://dev.azure.com/org/");
@@ -90,12 +90,13 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual(settings.RepositoryName, "reponame");
             Assert.AreEqual(settings.RepositoryOwner, "project");
             Assert.AreEqual(settings.SetAutoMerge, true);
+            Assert.AreEqual(settings.RemoteInfo.BranchName, "develop");
         }
 
         [Test]
         public async Task RepositorySettings_GetsCorrectSettingsPrivate()
         {
-            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true);
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true, "main");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiUri, "https://dev.azure.com/");
@@ -103,6 +104,7 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual(settings.RepositoryName, "reponame");
             Assert.AreEqual(settings.RepositoryOwner, "owner");
             Assert.AreEqual(settings.SetAutoMerge, true);
+            Assert.AreEqual(settings.RemoteInfo.BranchName, "main");
         }
 
         [Test]
@@ -129,6 +131,5 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual("repo name", settings.RepositoryName);
             Assert.AreEqual("project name", settings.RepositoryOwner);
         }
-
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix target-branch for Azure DevOps client. It seems the PR #1074 isn't sufficient enough for Azure DevOps after testing.  @CrispyDrone 

### :arrow_heading_down: What is the current behavior?
After providing the targetbranch argument, NuKeeper keep checking against the default branch of the repo.

### :new: What is the new behavior (if this is a feature change)?
Fix the PR #1074 

### :boom: Does this PR introduce a breaking change?
nop

### :bug: Recommendations for testing
Provide the --targetBranch argument against the Azure DevOps repo and see that NuKeeper will check dependencies against the provided --targetBranch.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Relevant documentation was updated 
- [x] Unit tests added
