### PR TITLE
Dotnet 5 support + ContainsDotNetProjects() method fix for Octokit

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -15,9 +15,9 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 steps:
 - task: DotNetCoreInstaller@1
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 5.0.x'
   inputs:
-    version: 3.1.x
+    version: 5.0.x
 
 - bash: echo NugetVersion is $NugetVersion; export NugetVersion
   displayName: 'export NugetVersion into env vars'

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
@@ -17,6 +17,12 @@ namespace NuKeeper.Abstractions.CollaborationModels
 
     public class SearchCodeRequest
     {
+        public SearchCodeRequest(IEnumerable<string> extensions, IEnumerable<SearchRepo> repos)
+        {
+            Extensions = extensions;
+            Repos = repos.ToList();
+        }
+
         public SearchCodeRequest(string term, IEnumerable<SearchRepo> repos)
         {
             Term = term;
@@ -24,6 +30,7 @@ namespace NuKeeper.Abstractions.CollaborationModels
         }
 
         public string Term { get; }
+        public IEnumerable<string> Extensions { get; }
         public IReadOnlyCollection<SearchRepo> Repos { get; }
         public int PerPage { get; set; }
     }

--- a/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
@@ -17,15 +17,10 @@ namespace NuKeeper.Abstractions.CollaborationModels
 
     public class SearchCodeRequest
     {
-        public SearchCodeRequest(IEnumerable<string> extensions, IEnumerable<SearchRepo> repos)
-        {
-            Extensions = extensions;
-            Repos = repos.ToList();
-        }
-
-        public SearchCodeRequest(string term, IEnumerable<SearchRepo> repos)
+        public SearchCodeRequest(IEnumerable<SearchRepo> repos, string term, IEnumerable<string> extensions)
         {
             Term = term;
+            Extensions = extensions;
             Repos = repos.ToList();
         }
 

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -208,9 +208,10 @@ namespace NuKeeper.GitHub
                 }
 
                 var result = await _client.Search.SearchCode(
-                    new Octokit.SearchCodeRequest(search.Term)
+                    new Octokit.SearchCodeRequest()
                     {
                         Repos = repos,
+                        Extensions = search.Extensions,
                         In = new[] { CodeInQualifier.Path },
                         PerPage = search.PerPage
                     });

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
+++ b/NuKeeper.Integration.Tests/RepositoryInspection/RepositoryScannerTests.cs
@@ -244,7 +244,7 @@ namespace NuKeeper.Integration.Tests.RepositoryInspection
             // then the app root directory to scan is "C:\Code\NuKeeper\"
             // So go up four dir levels to the root
             // Self is a convenient source of a valid project to scan
-            var fullPath = new Uri(typeof(RepositoryScanner).GetTypeInfo().Assembly.CodeBase).LocalPath;
+            var fullPath = new Uri(typeof(RepositoryScanner).GetTypeInfo().Assembly.Location).LocalPath;
             var runDir = Path.GetDirectoryName(fullPath);
 
             var projectRootDir = Directory.GetParent(runDir).Parent.Parent.Parent;

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
 	</PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -3,6 +3,7 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
 
@@ -26,7 +27,7 @@ namespace NuKeeper.Engine
                 throw new ArgumentNullException(nameof(repository));
             }
 
-            const string dotNetCodeFiles = "\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"";
+            IEnumerable<string> dotNetCodeFiles = new ReadOnlyCollection<string>(new List<string>(){ ".sln", ".csproj", ".fsproj", ".vbproj" });
 
             var repos = new List<SearchRepo>
             {

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -27,14 +27,15 @@ namespace NuKeeper.Engine
                 throw new ArgumentNullException(nameof(repository));
             }
 
-            IEnumerable<string> dotNetCodeFiles = new ReadOnlyCollection<string>(new List<string>(){ ".sln", ".csproj", ".fsproj", ".vbproj" });
+            IEnumerable<string> dotNetCodeExtensions = new ReadOnlyCollection<string>(new List<string>(){ ".sln", ".csproj", ".fsproj", ".vbproj" });
+            const string dotNetCodeTerms = "\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"";
 
             var repos = new List<SearchRepo>
             {
                 new SearchRepo(repository.RepositoryOwner, repository.RepositoryName)
             };
 
-            var searchCodeRequest = new SearchCodeRequest(dotNetCodeFiles, repos)
+            var searchCodeRequest = new SearchCodeRequest(repos, dotNetCodeTerms, dotNetCodeExtensions)
             {
                 PerPage = 1
             };

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR adds support for dotnet 5 and fixes the `ContainsDotNetProjects()` repo check method when using OctoKit

### :arrow_heading_down: What is the current behavior?
Doesn't run on dotnet 5. Also `ContainsDotNetProjects()` doesn't work as expected when using OctoKit for querying GitHub

### :new: What is the new behavior (if this is a feature change)?
Added support for target framework net5.0. `ContainsDotNetProjects()` works correctly with OctoKit using IEnumerable<string> Extensions instead of string Term

### :boom: Does this PR introduce a breaking change?
It shouldn't 

### :bug: Recommendations for testing
Just run the normal suite of tests on the current master

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated (no updates)
