### PR TITLE
Added support for GitPullRequestMergeStrategy for Azure DevOps

### DIFF
--- a/NuKeeper.Abstractions.Tests/CollaborationModels/PullRequestRequestTests.cs
+++ b/NuKeeper.Abstractions.Tests/CollaborationModels/PullRequestRequestTests.cs
@@ -1,4 +1,5 @@
 using NuKeeper.Abstractions.CollaborationModels;
+using NuKeeper.Abstractions.Configuration;
 using NUnit.Framework;
 
 namespace NuKeeper.Abstractions.Tests.CollaborationModels
@@ -9,8 +10,8 @@ namespace NuKeeper.Abstractions.Tests.CollaborationModels
         [Test]
         public void ReplacesRemotesWhenCreatingPullRequestRequestObject()
         {
-            var pr = new PullRequestRequest("head", "title", "origin/master", true, true);
-            var pr2 = new PullRequestRequest("head", "title", "master", true, true);
+            var pr = new PullRequestRequest("head", "title", "origin/master", true, true, GitPullRequestMergeStrategy.noFastForward);
+            var pr2 = new PullRequestRequest("head", "title", "master", true, true, GitPullRequestMergeStrategy.noFastForward);
 
             Assert.That(pr.BaseRef, Is.EqualTo("master"));
             Assert.That(pr2.BaseRef, Is.EqualTo("master"));

--- a/NuKeeper.Abstractions.Tests/CollaborationModels/PullRequestRequestTests.cs
+++ b/NuKeeper.Abstractions.Tests/CollaborationModels/PullRequestRequestTests.cs
@@ -10,8 +10,8 @@ namespace NuKeeper.Abstractions.Tests.CollaborationModels
         [Test]
         public void ReplacesRemotesWhenCreatingPullRequestRequestObject()
         {
-            var pr = new PullRequestRequest("head", "title", "origin/master", true, true, GitPullRequestMergeStrategy.noFastForward);
-            var pr2 = new PullRequestRequest("head", "title", "master", true, true, GitPullRequestMergeStrategy.noFastForward);
+            var pr = new PullRequestRequest("head", "title", "origin/master", true, true, GitPullRequestMergeStrategy.NoFastForward);
+            var pr2 = new PullRequestRequest("head", "title", "master", true, true, GitPullRequestMergeStrategy.NoFastForward);
 
             Assert.That(pr.BaseRef, Is.EqualTo("master"));
             Assert.That(pr2.BaseRef, Is.EqualTo("master"));

--- a/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/PullRequestRequest.cs
@@ -1,13 +1,16 @@
+using NuKeeper.Abstractions.Configuration;
+
 namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class PullRequestRequest
     {
-        public PullRequestRequest(string head, string title, string baseRef, bool deleteBranchAfterMerge, bool setAutoMerge)
+        public PullRequestRequest(string head, string title, string baseRef, bool deleteBranchAfterMerge, bool setAutoMerge, GitPullRequestMergeStrategy mergeStrategy)
         {
             Head = head;
             Title = title;
             DeleteBranchAfterMerge = deleteBranchAfterMerge;
             SetAutoMerge = setAutoMerge;
+            MergeStrategy = mergeStrategy;
 
             //This can be a remote that has been passed in, this happens when run locally against a targetbranch that is remote
             BaseRef = baseRef?.Replace("origin/", string.Empty);
@@ -19,5 +22,6 @@ namespace NuKeeper.Abstractions.CollaborationModels
         public string Body { get; set; }
         public bool DeleteBranchAfterMerge { get; set; }
         public bool SetAutoMerge { get; }
+        public GitPullRequestMergeStrategy MergeStrategy { get; set; }
     }
 }

--- a/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/SearchCodeRequest.cs
@@ -17,13 +17,15 @@ namespace NuKeeper.Abstractions.CollaborationModels
 
     public class SearchCodeRequest
     {
-        public SearchCodeRequest(string term, IEnumerable<SearchRepo> repos)
+        public SearchCodeRequest(IEnumerable<SearchRepo> repos, string term, IEnumerable<string> extensions)
         {
             Term = term;
+            Extensions = extensions;
             Repos = repos.ToList();
         }
 
         public string Term { get; }
+        public IEnumerable<string> Extensions { get; }
         public IReadOnlyCollection<SearchRepo> Repos { get; }
         public int PerPage { get; set; }
     }

--- a/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
@@ -10,7 +10,7 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
 
         Task<bool> CanRead(Uri repositoryUri);
 
-        Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward);
+        Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward);
 
         void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings);
     }

--- a/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ISettingsReader.cs
@@ -10,7 +10,7 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
 
         Task<bool> CanRead(Uri repositoryUri);
 
-        Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null);
+        Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward);
 
         void UpdateCollaborationPlatformSettings(CollaborationPlatformSettings settings);
     }

--- a/NuKeeper.Abstractions/Configuration/GitPullRequestMergeStrategy.cs
+++ b/NuKeeper.Abstractions/Configuration/GitPullRequestMergeStrategy.cs
@@ -2,9 +2,9 @@ namespace NuKeeper.Abstractions.Configuration
 {
     public enum GitPullRequestMergeStrategy
     {
-        noFastForward,
-        rebase,
-        rebaseMerge,
-        squash
+        NoFastForward = 0,
+        Rebase = 1,
+        RebaseMerge = 2,
+        Squash = 3
     }
 }

--- a/NuKeeper.Abstractions/Configuration/GitPullRequestMergeStrategy.cs
+++ b/NuKeeper.Abstractions/Configuration/GitPullRequestMergeStrategy.cs
@@ -1,0 +1,10 @@
+namespace NuKeeper.Abstractions.Configuration
+{
+    public enum GitPullRequestMergeStrategy
+    {
+        noFastForward,
+        rebase,
+        rebaseMerge,
+        squash
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
+++ b/NuKeeper.Abstractions/Configuration/RepositorySettings.cs
@@ -34,5 +34,7 @@ namespace NuKeeper.Abstractions.Configuration
         public RemoteInfo RemoteInfo { get; set; }
 
         public bool SetAutoMerge { get; set; }
+
+        public GitPullRequestMergeStrategy MergeStrategy { get; set; }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -160,7 +160,7 @@ namespace NuKeeper.AzureDevOps
             return await PostResource<LabelResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}/labels", labelContent, true);
         }
 
-        public async Task<PullRequest> SetAutoComplete(PRRequest request, string projectName, string azureRepositoryId, int pullRequestId)
+        public async Task<PullRequest> PatchPullRequest(PRRequest request, string projectName, string azureRepositoryId, int pullRequestId)
         {
             var autoCompleteContent = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PatchResource<PullRequest>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}", autoCompleteContent);

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.AzureDevOps
             return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.AzureDevOps
             return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {
@@ -55,6 +55,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             settings.SetAutoMerge = setAutoMerge;
+            settings.MergeStrategy = gitPullRequestMergeStrategy;
 
             return settings;
         }

--- a/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsPlatform.cs
@@ -82,23 +82,24 @@ namespace NuKeeper.AzureDevOps
                 sourceRefName = $"refs/heads/{request.Head}",
                 description = request.Body,
                 targetRefName = $"refs/heads/{request.BaseRef}",
-                completionOptions = new GitPullRequestCompletionOptions
-                {
-                    deleteSourceBranch = request.DeleteBranchAfterMerge
-                }
             };
 
             var pullRequest = await _client.CreatePullRequest(req, target.Owner, repo.id);
 
             if (request.SetAutoMerge)
             {
-                await _client.SetAutoComplete(new PRRequest()
+                await _client.PatchPullRequest(new PRRequest()
+                {
+                    autoCompleteSetBy = new Creator()
                     {
-                        autoCompleteSetBy = new Creator()
-                        {
-                            id = pullRequest.CreatedBy.id
-                        }
-                    }, target.Owner,
+                        id = pullRequest.CreatedBy.id
+                    },
+                    completionOptions = new GitPullRequestCompletionOptions
+                    {
+                        deleteSourceBranch = request.DeleteBranchAfterMerge,
+                        mergeStrategy = request.MergeStrategy.ToString(),
+                    },
+                }, target.Owner,
                     repo.id,
                     pullRequest.PullRequestId);
             }

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -109,6 +109,7 @@ namespace NuKeeper.AzureDevOps
     public class GitPullRequestCompletionOptions
     {
         public bool deleteSourceBranch { get; set; }
+        public string mergeStrategy { get; set; }
     }
 
     public class AzureRepository

--- a/NuKeeper.AzureDevOps/BaseSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/BaseSettingsReader.cs
@@ -32,6 +32,6 @@ namespace NuKeeper.AzureDevOps
             settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
-        public abstract Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null);
+        public abstract Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward);
     }
 }

--- a/NuKeeper.AzureDevOps/BaseSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/BaseSettingsReader.cs
@@ -32,6 +32,6 @@ namespace NuKeeper.AzureDevOps
             settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
-        public abstract Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward);
+        public abstract Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.NoFastForward);
     }
 }

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.AzureDevOps
             return tfsInPath || tfsInHost;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {
@@ -60,6 +60,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             settings.SetAutoMerge = setAutoMerge;
+            settings.MergeStrategy = gitPullRequestMergeStrategy;
 
             return settings;
         }

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -44,7 +44,7 @@ namespace NuKeeper.AzureDevOps
             return tfsInPath || tfsInHost;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.AzureDevOps
             return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/VSTSSettingsReader.cs
@@ -37,7 +37,7 @@ namespace NuKeeper.AzureDevOps
             return repositoryUri?.Host.Contains(PlatformHost, StringComparison.OrdinalIgnoreCase) == true;
         }
 
-        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public override async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, Abstractions.Configuration.GitPullRequestMergeStrategy gitPullRequestMergeStrategy = Abstractions.Configuration.GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {
@@ -53,6 +53,7 @@ namespace NuKeeper.AzureDevOps
             }
 
             settings.SetAutoMerge = setAutoMerge;
+            settings.MergeStrategy = gitPullRequestMergeStrategy;
 
             return settings;
         }

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.BitBucket
             settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.BitBucket/BitbucketSettingsReader.cs
+++ b/NuKeeper.BitBucket/BitbucketSettingsReader.cs
@@ -39,7 +39,7 @@ namespace NuKeeper.BitBucket
             settings.ForkMode = settings.ForkMode ?? ForkMode.SingleRepositoryOnly;
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.GitHub
             settings.ForkMode ??= ForkMode.PreferFork;
         }
 
-        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
+        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.GitHub/GitHubSettingsReader.cs
+++ b/NuKeeper.GitHub/GitHubSettingsReader.cs
@@ -53,7 +53,7 @@ namespace NuKeeper.GitHub
             settings.ForkMode ??= ForkMode.PreferFork;
         }
 
-        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -208,9 +208,10 @@ namespace NuKeeper.GitHub
                 }
 
                 var result = await _client.Search.SearchCode(
-                    new Octokit.SearchCodeRequest(search.Term)
+                    new Octokit.SearchCodeRequest
                     {
                         Repos = repos,
+                        Extensions = search.Extensions,
                         In = new[] { CodeInQualifier.Path },
                         PerPage = search.PerPage
                     });

--- a/NuKeeper.Gitea/GiteaSettingsReader.cs
+++ b/NuKeeper.Gitea/GiteaSettingsReader.cs
@@ -68,7 +68,7 @@ namespace NuKeeper.Gitea
             settings.Token = Concat.FirstValue(envToken, settings.Token);
         }
 
-        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
+        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.Gitea/GiteaSettingsReader.cs
+++ b/NuKeeper.Gitea/GiteaSettingsReader.cs
@@ -68,7 +68,7 @@ namespace NuKeeper.Gitea
             settings.Token = Concat.FirstValue(envToken, settings.Token);
         }
 
-        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public async Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Gitlab
             settings.Token = Concat.FirstValue(envToken, settings.Token);
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -41,7 +41,7 @@ namespace NuKeeper.Gitlab
             settings.Token = Concat.FirstValue(envToken, settings.Token);
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -21,7 +21,7 @@ namespace NuKeeper.Commands
         public bool? SetAutoMerge { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "ms", LongName = "mergestrategy",
-            Description = "Sets the merge strategy. Works only for Azure Devops. Only effective in combination with 'setautomerge'. Allowed strategies: noFastForward, rebase, rebaseMerge, squash. Defaults to noFastForward.")]
+            Description = "Sets the merge strategy. Works only for Azure Devops. Only effective in combination with 'setautomerge'. Allowed strategies: NoFastForward, Rebase, RebaseMerge, Squash. Defaults to NoFastForward.")]
         public GitPullRequestMergeStrategy? MergeStrategy { get; set; }
 
         private readonly IEnumerable<ISettingsReader> _settingsReaders;
@@ -67,7 +67,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Unable to work out which platform to use {RepositoryUri} could not be matched");
             }
 
-            settings.SourceControlServerSettings.Repository = await reader.RepositorySettings(repoUri, SetAutoMerge ?? false, TargetBranch, MergeStrategy ?? GitPullRequestMergeStrategy.noFastForward);
+            settings.SourceControlServerSettings.Repository = await reader.RepositorySettings(repoUri, SetAutoMerge ?? false, TargetBranch, MergeStrategy ?? GitPullRequestMergeStrategy.NoFastForward);
 
             var baseResult = await base.PopulateSettings(settings);
             if (!baseResult.IsSuccess)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -20,6 +20,10 @@ namespace NuKeeper.Commands
             Description = "Set automatically auto merge for created pull request. Works only for Azure Devops. Defaults to false.")]
         public bool? SetAutoMerge { get; set; }
 
+        [Option(CommandOptionType.SingleValue, ShortName = "mg", LongName = "mergestrategy",
+            Description = "Sets the merge strategy. Works only for Azure Devops. Only effective in combination with 'setautomerge'. Allowed strategies: noFastForward, rebase, rebaseMerge, squash. Defaults to noFastForward.")]
+        public GitPullRequestMergeStrategy? MergeStrategy { get; set; }
+
         private readonly IEnumerable<ISettingsReader> _settingsReaders;
 
         public RepositoryCommand(ICollaborationEngine engine, IConfigureLogger logger, IFileSettingsCache fileSettingsCache, ICollaborationFactory collaborationFactory, IEnumerable<ISettingsReader> settingsReaders)
@@ -63,7 +67,7 @@ namespace NuKeeper.Commands
                 return ValidationResult.Failure($"Unable to work out which platform to use {RepositoryUri} could not be matched");
             }
 
-            settings.SourceControlServerSettings.Repository = await reader.RepositorySettings(repoUri, SetAutoMerge ?? false, TargetBranch);
+            settings.SourceControlServerSettings.Repository = await reader.RepositorySettings(repoUri, SetAutoMerge ?? false, TargetBranch, MergeStrategy ?? GitPullRequestMergeStrategy.noFastForward);
 
             var baseResult = await base.PopulateSettings(settings);
             if (!baseResult.IsSuccess)

--- a/NuKeeper/Commands/RepositoryCommand.cs
+++ b/NuKeeper/Commands/RepositoryCommand.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Commands
             Description = "Set automatically auto merge for created pull request. Works only for Azure Devops. Defaults to false.")]
         public bool? SetAutoMerge { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "mg", LongName = "mergestrategy",
+        [Option(CommandOptionType.SingleValue, ShortName = "ms", LongName = "mergestrategy",
             Description = "Sets the merge strategy. Works only for Azure Devops. Only effective in combination with 'setautomerge'. Allowed strategies: noFastForward, rebase, rebaseMerge, squash. Defaults to noFastForward.")]
         public GitPullRequestMergeStrategy? MergeStrategy { get; set; }
 

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -129,7 +129,8 @@ namespace NuKeeper.Engine.Packages
                     var title = _collaborationFactory.CommitWorder.MakePullRequestTitle(updates);
                     var body = _collaborationFactory.CommitWorder.MakeCommitDetails(updates);
 
-                    var pullRequestRequest = new PullRequestRequest(qualifiedBranch, title, repository.DefaultBranch, settings.BranchSettings.DeleteBranchAfterMerge, settings.SourceControlServerSettings.Repository.SetAutoMerge) { Body = body };
+                    var repositorySettings = settings.SourceControlServerSettings.Repository;
+                    var pullRequestRequest = new PullRequestRequest(qualifiedBranch, title, repository.DefaultBranch, settings.BranchSettings.DeleteBranchAfterMerge, repositorySettings.SetAutoMerge, repositorySettings.MergeStrategy) { Body = body };
 
                     await _collaborationFactory.CollaborationPlatform.OpenPullRequest(repository.Pull, pullRequestRequest, settings.SourceControlServerSettings.Labels);
                 }

--- a/NuKeeper/Engine/RepositoryFilter.cs
+++ b/NuKeeper/Engine/RepositoryFilter.cs
@@ -3,6 +3,7 @@ using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.CollaborationModels;
 
@@ -26,14 +27,14 @@ namespace NuKeeper.Engine
                 throw new ArgumentNullException(nameof(repository));
             }
 
-            const string dotNetCodeFiles = "\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"";
-
+            IEnumerable<string> dotNetCodeExtensions = new ReadOnlyCollection<string>(new List<string>(){ ".sln", ".csproj", ".fsproj", ".vbproj" });
+            const string dotNetCodeTerms = "\"packages.config\" OR \".csproj\" OR \".fsproj\" OR \".vbproj\"";
             var repos = new List<SearchRepo>
             {
                 new SearchRepo(repository.RepositoryOwner, repository.RepositoryName)
             };
 
-            var searchCodeRequest = new SearchCodeRequest(dotNetCodeFiles, repos)
+            var searchCodeRequest = new SearchCodeRequest(repos, dotNetCodeTerms, dotNetCodeExtensions)
             {
                 PerPage = 1
             };

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsRestClientTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsRestClientTests.cs
@@ -392,7 +392,7 @@ namespace Nukeeper.AzureDevOps.Tests
                 }
             };
 
-            var pullRequestResponse = await restClient.SetAutoComplete(prRequest, "ProjectName", "RepoId", 100);
+            var pullRequestResponse = await restClient.PatchPullRequest(prRequest, "ProjectName", "RepoId", 100);
             Assert.IsNotNull(pullRequestResponse);
         }
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
@@ -108,9 +108,9 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public async Task RepositorySettings_SetsCorrectPullRequestMergeStrategy()
         {
-            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true, gitPullRequestMergeStrategy: GitPullRequestMergeStrategy.rebase);
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true, gitPullRequestMergeStrategy: GitPullRequestMergeStrategy.Rebase);
 
-            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.rebase);
+            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.Rebase);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace Nukeeper.AzureDevOps.Tests
         {
             var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true);
 
-            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.noFastForward);
+            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.NoFastForward);
         }
 
         [Test]

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
@@ -106,6 +106,22 @@ namespace Nukeeper.AzureDevOps.Tests
         }
 
         [Test]
+        public async Task RepositorySettings_SetsCorrectPullRequestMergeStrategy()
+        {
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true, gitPullRequestMergeStrategy: GitPullRequestMergeStrategy.rebase);
+
+            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.rebase);
+        }
+
+        [Test]
+        public async Task RepositorySettings_MergeStrategyDefaultNoFastForward()
+        {
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true);
+
+            Assert.AreEqual(settings.MergeStrategy, GitPullRequestMergeStrategy.noFastForward);
+        }
+
+        [Test]
         public async Task RepositorySettings_ReturnsNull()
         {
             var settings = await _azureSettingsReader.RepositorySettings(null, true);

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.BitBucketLocal
                    repositoryUri.Host.Contains("bitbucket.org", StringComparison.OrdinalIgnoreCase) == false);
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.NoFastForward)
         {
             if (repositoryUri == null)
             {

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.BitBucketLocal
                    repositoryUri.Host.Contains("bitbucket.org", StringComparison.OrdinalIgnoreCase) == false);
         }
 
-        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null)
+        public Task<RepositorySettings> RepositorySettings(Uri repositoryUri, bool setAutoMerge, string targetBranch = null, GitPullRequestMergeStrategy gitPullRequestMergeStrategy = GitPullRequestMergeStrategy.noFastForward)
         {
             if (repositoryUri == null)
             {

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -38,6 +38,7 @@ title: "Configuration"
 | branchnametemplate |           | `repo`, `org`, `global`, `update`| _null_           |
 | deletebranchaftermerge | d   | _all_                     | true                    |
 | setautomerge |    | `repo`                     | false                    |
+| mergestrategy | ms   | `repo`                     | noFastForward                    |
 
 * *age* The minimum package age. In order to not consume packages immediately after they are released, exclude updates that do not meet a minimum age.  The default is 7 days. This age is the duration between the published date of the selected package update and now.
  A value can be expressed in command options as an integer and a unit suffix,
@@ -73,14 +74,14 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
 * *maxrepo* The maximum number of repositories to change. Used in Organisation and Global mode.
 * *consolidate* Consolidate updates into a single pull request, instead of the default of 1 pull request per package update applied.
 * *platform* One of `GitHub`, `AzureDevOps`, `Bitbucket`, `BitbucketLocal`, `Gitlab`, `Gitea`. Determines which kind of source control api will be used. This is typicaly infered from the api url structure, but since this does not always work, it can be specified here if neccessary.
-* *gitclipath* Path to `git` command line. Alternative use native git via cli instead of the default lib2gitsharp implementation. In special cases lib2gitsharp is not enough. E.g. in enviroments with company-proxies or self hosted git services signed certificates. For Windows it is typically `C:\Program Files\Git\bin\git.exe`. For Linux it is typically `/usr/bin/git`. 
+* *gitclipath* Path to `git` command line. Alternative use native git via cli instead of the default lib2gitsharp implementation. In special cases lib2gitsharp is not enough. E.g. in enviroments with company-proxies or self hosted git services signed certificates. For Windows it is typically `C:\Program Files\Git\bin\git.exe`. For Linux it is typically `/usr/bin/git`.
 
 * *includerepos* A regex to filter repositories by name. Only consider repositories where the name matches this regex pattern. Used in Organisation and Global mode.
 * *excluderepos* A regex to filter repositories by name. Do not consider repositories where the name matches this regex pattern. Used in Organisation and Global mode.
 
 * *branchnametemplate* A template that can be used to set the name of the branch NuKeeper creates. Allows you to put those branches in a hierarchy or set your own naming strategy.
   It accepts the following tokens:
-  
+
   |Token       |Replacement                                                                      |
   |------------|---------------------------------------------------------------------------------|
   |`{Default}` |The default Nukeeper Branch Naming                                               |
@@ -88,15 +89,16 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
   |`{Version}` |The version of the updated Nuget or `Multiple-Versions` if more than one version |
   |`{Count}`   |The number of updated Nugets                                                     |
   |`{Hash}`    |An Unique hash over the updated nugets.                                          |
-  
+
   The default nukeeper branch naming is:
-  
+
   | | |
   |-|-|
   |Single Nuget   |`nukeeper-update-{Name}-to-{Version}`
   |Multiple Nugets|`nukeeper-update-{Count}-packages-{Hash}`
-  
+
   Note: The old and replaced option `branchnameprefix` can be simulated with `--branchnametemplate "YourBranchPrefix/{Default}"`
-  
+
 * *deletebranchaftermerge* Specifies whether a branch should be automatically deleted or not once the branch has been merged. Currently only works with `Platform` equal to `AzureDevOps`, `Gitlab` or `Bitbucket`.
 * *setautomerge* Specifies whether a pull request should be merged automatically after passing all checks. Currently only works with `Platform` equal to `AzureDevOps`.
+* *mergestrategy* Sets the merge strategy. Only effective in combination with `setautomerge`. Allowed strategies: `noFastForward`, `rebase`, `rebaseMerge`, `squash`. Defaults to `noFastForward`. Currently only works with `Platform` equal to `AzureDevOps`.

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -101,4 +101,4 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
 
 * *deletebranchaftermerge* Specifies whether a branch should be automatically deleted or not once the branch has been merged. Currently only works with `Platform` equal to `AzureDevOps`, `Gitlab` or `Bitbucket`.
 * *setautomerge* Specifies whether a pull request should be merged automatically after passing all checks. Currently only works with `Platform` equal to `AzureDevOps`.
-* *mergestrategy* Sets the merge strategy. Only effective in combination with `setautomerge`. Allowed strategies: `noFastForward`, `rebase`, `rebaseMerge`, `squash`. Defaults to `noFastForward`. Currently only works with `Platform` equal to `AzureDevOps`.
+* *mergestrategy* Sets the merge strategy. Only effective in combination with `setautomerge`. Allowed strategies: `NoFastForward`, `Rebase`, `RebaseMerge`, `Squash`. Defaults to `noFastForward`. Currently only works with `Platform` equal to `AzureDevOps`.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added support for GitPullRequestMergeStrategy for Azure DevOps

### :arrow_heading_down: What is the current behavior?
By default the merge behaviour is noFastForward, if this is disabled by policies, then it will not auto-merge

### :new: What is the new behavior (if this is a feature change)?
Repo command expanded with option MergeStrategy, with the following options:
- noFastForward,
- rebase,
- rebaseMerge,
- squash

### :boom: Does this PR introduce a breaking change?
no, it's been made an optional parameter with default noFastForward, which was its original default

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
