### PR TITLE
Fix issue when project filenames contains whitespaces

### DIFF
--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -109,6 +109,13 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await ExecuteValidUpdateTest(_testDotNetClassicProject, PackageReferenceType.ProjectFileOldStyle);
         }
 
+        [Test]
+        public async Task ShouldUpdateProjectFilenameWithSpaces()
+        {
+            await ExecuteValidUpdateTest(_testDotNetClassicProject, PackageReferenceType.ProjectFileOldStyle, "Project With Spaces.csproj");
+        }
+
+
         private async Task ExecuteValidUpdateTest(
             string testProjectContents,
             PackageReferenceType packageReferenceType,

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -37,20 +37,20 @@ namespace NuKeeper.Update.Process
             }
 
             var projectPath = currentPackage.Path.Info.DirectoryName;
-            var projectFileName = currentPackage.Path.Info.Name;
+            var projectFileNameCommandLine = ArgumentEscaper.EscapeAndConcatenate(new string[] { currentPackage.Path.Info.Name });
             var sourceUrl = UriEscapedForArgument(packageSource.SourceUri);
             var sources = allSources.CommandLine("-s");
 
-            var restoreCommand = $"restore {projectFileName} {sources}";
+            var restoreCommand = $"restore {projectFileNameCommandLine} {sources}";
             await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {
-                var removeCommand = $"remove {projectFileName} package {currentPackage.Id}";
+                var removeCommand = $"remove {projectFileNameCommandLine} package {currentPackage.Id}";
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When the project file name contains whitespaces then NuKeeper fail to restore/remove & add nuget packages.

### :new: What is the new behavior (if this is a feature change)?
NuKeeper will execute dotnet restore/remove & add commands with quotations around project file names

### :boom: Does this PR introduce a breaking change?
nop

### :bug: Recommendations for testing
* Added unittests
* Add a project file name with whitespaces.

### :memo: Links to relevant issues/docs
see #1091

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
