### PR TITLE
Use targetBranch when running in a Azure DevOps Pipeline

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -1,7 +1,7 @@
 strategy:
   matrix:
     Linux:
-      imageName: 'ubuntu-16.04'
+      imageName: 'ubuntu-latest'
     Windows:
       imageName: 'windows-2019'
     Mac:

--- a/Docker/SDK5.0/Dockerfile
+++ b/Docker/SDK5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal
 ARG NUKEEPER_VERSION=0.34.0
 RUN dotnet tool install --global NuKeeper --version $NUKEEPER_VERSION
 ENV PATH="${PATH}:/root/.dotnet/tools"

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Abstractions/Configuration/AuthSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/AuthSettings.cs
@@ -4,6 +4,13 @@ namespace NuKeeper.Abstractions.Configuration
 {
     public class AuthSettings
     {
+        /// <summary>
+        /// Provide the credentials required to authenticate against a different repository providers.
+        /// </summary>
+        /// <param name="apiBase">Repository URLs e.g. https://dev.azure.com/ or https://api.github.com/ or https://developer.atlassian.com/bitbucket/api/2/reference/</param>
+        /// <param name="token">Personal Access Tokens or Client Secret. The GitHub client with use anonymous authentication it the token is blank. I.e. public repositories</param>
+        /// <param name="username"></param>
+        /// <remarks>See <seealso cref="NuKeeper.Abstractions.CollaborationPlatform.CollaborationPlatformSettings"/> for a similar model.</remarks>
         public AuthSettings(Uri apiBase, string token, string username = null)
         {
             ApiBase = apiBase;

--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
   </ItemGroup>

--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.11.0" />
   </ItemGroup>
 
 </Project>

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -98,6 +98,7 @@ namespace NuKeeper.AzureDevOps
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);
+                _logger.Detailed(responseBody);
                 throw new NuKeeperException($"Failed to parse json to {typeof(T)}", ex);
             }
         }

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -98,7 +98,6 @@ namespace NuKeeper.AzureDevOps
             {
                 msg = $"{caller} failed to parse json to {typeof(T)}: {ex.Message}";
                 _logger.Error(msg);
-                _logger.Detailed(responseBody);
                 throw new NuKeeperException($"Failed to parse json to {typeof(T)}", ex);
             }
         }

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -97,7 +97,10 @@ namespace NuKeeper.AzureDevOps
 
         private async Task<RepositorySettings> CreateSettingsFromLocal(Uri repositoryUri, string targetBranch)
         {
-            var remoteInfo = new RemoteInfo();
+            var remoteInfo = new RemoteInfo()
+            {
+                BranchName = targetBranch,
+            };
 
             var localCopy = repositoryUri;
             if (await _gitDriver.IsGitRepo(repositoryUri))
@@ -138,7 +141,8 @@ namespace NuKeeper.AzureDevOps
                     pathParts[0],  //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[1]),  // project
-                    Uri.UnescapeDataString(pathParts[3])   // reponame
+                    Uri.UnescapeDataString(pathParts[3]),   // reponame
+                    remoteInfo
                     );
             }
             else if (indexOfGit == 1 && pathParts.Length == 3)
@@ -147,7 +151,8 @@ namespace NuKeeper.AzureDevOps
                     null,          //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[0]),  // project
-                    Uri.UnescapeDataString(pathParts[2])   // reponame
+                    Uri.UnescapeDataString(pathParts[2]),   // reponame
+                    remoteInfo
                     );
             }
             return null;

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -47,7 +47,7 @@ namespace NuKeeper.AzureDevOps
 
             var settings = repositoryUri.IsFile
                 ? await CreateSettingsFromLocal(repositoryUri, targetBranch)
-                : CreateSettingsFromRemote(repositoryUri);
+                : CreateSettingsFromRemote(repositoryUri, targetBranch);
 
             if (settings == null)
             {
@@ -59,7 +59,7 @@ namespace NuKeeper.AzureDevOps
             return settings;
         }
 
-        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri)
+        private static RepositorySettings CreateSettingsFromRemote(Uri repositoryUri, string targetBranch)
         {
             // URL pattern is
             // https://dev.azure.com/{org}/{project}/_git/{repo}/
@@ -80,8 +80,8 @@ namespace NuKeeper.AzureDevOps
                     pathParts[0],  //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[1]),  // project
-                    Uri.UnescapeDataString(pathParts[3])   // reponame
-                    );
+                    Uri.UnescapeDataString(pathParts[3]),   // reponame
+                    new RemoteInfo { BranchName = targetBranch });
             }
             else if (indexOfGit == 1 && pathParts.Length == 3)
             {
@@ -89,8 +89,8 @@ namespace NuKeeper.AzureDevOps
                     null,          //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[0]),  // project
-                    Uri.UnescapeDataString(pathParts[2])   // reponame
-                    );
+                    Uri.UnescapeDataString(pathParts[2]),   // reponame
+                    new RemoteInfo { BranchName = targetBranch });
             }
             return null;
         }

--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -141,7 +141,7 @@ namespace NuKeeper.AzureDevOps
                     pathParts[0],  //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[1]),  // project
-                    Uri.UnescapeDataString(pathParts[3]),   // reponame
+                    Uri.UnescapeDataString(pathParts[3]),  // reponame
                     remoteInfo
                     );
             }
@@ -151,7 +151,7 @@ namespace NuKeeper.AzureDevOps
                     null,          //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[0]),  // project
-                    Uri.UnescapeDataString(pathParts[2]),   // reponame
+                    Uri.UnescapeDataString(pathParts[2]),  // reponame
                     remoteInfo
                     );
             }

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -50,7 +50,6 @@ namespace NuKeeper.Git
 
         public Task Clone(Uri pullEndpoint, string branchName)
         {
-            _logger.Detailed("LibGit2ShaprDriver.Clone(Uri, branchName)");
             return Task.Run(() =>
             {
                 _logger.Normal($"Git clone {pullEndpoint}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -44,7 +44,6 @@ namespace NuKeeper.Git
 
         public async Task Clone(Uri pullEndpoint)
         {
-            _logger.Detailed("LibGit2ShaprDriver.Clone(Uri)");
             await Clone(pullEndpoint, null);
         }
 

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -44,11 +44,13 @@ namespace NuKeeper.Git
 
         public async Task Clone(Uri pullEndpoint)
         {
+            _logger.Detailed("LibGit2ShaprDriver.Clone(Uri)");
             await Clone(pullEndpoint, null);
         }
 
         public Task Clone(Uri pullEndpoint, string branchName)
         {
+            _logger.Detailed("LibGit2ShaprDriver.Clone(Uri, branchName)");
             return Task.Run(() =>
             {
                 _logger.Normal($"Git clone {pullEndpoint}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.GitHub/NuKeeper.GitHub.csproj
+++ b/NuKeeper.GitHub/NuKeeper.GitHub.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.48.0" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -40,12 +40,20 @@ namespace NuKeeper.GitHub
             }
 
             _apiBase = settings.ApiBase;
+            Credentials creds;
+            if (string.IsNullOrWhiteSpace(settings.Token))
+            {
+                creds = Credentials.Anonymous;
+            }
+            else
+            {
+                creds = new Credentials(settings.Token, AuthenticationType.Oauth);
+            }
 
             _client = new GitHubClient(new ProductHeaderValue("NuKeeper"), _apiBase)
             {
-                Credentials = new Credentials(settings.Token)
+                Credentials = creds
             };
-
             _initialised = true;
         }
 
@@ -206,7 +214,6 @@ namespace NuKeeper.GitHub
                 {
                     repos.Add(repo.Owner, repo.Name);
                 }
-
                 var result = await _client.Search.SearchCode(
                     new Octokit.SearchCodeRequest()
                     {

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
    <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -37,12 +37,10 @@ namespace NuKeeper.Integration.Tests.Engine
         }
 
         private RepositoryFilter MakeRepositoryFilter()
-        {
-            const string testKeyWithOnlyPublicAccess = "c13d2ce7774d39ae99ddaad46bd69c3d459b9992";
-
+        {            
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             var gitHubClient = new OctokitClient(NukeeperLogger);
-            gitHubClient.Initialise(new AuthSettings(new Uri("https://api.github.com"), testKeyWithOnlyPublicAccess));
+            gitHubClient.Initialise(new AuthSettings(new Uri("https://api.github.com"), ""));
             collaborationFactory.CollaborationPlatform.Returns(gitHubClient);
 
             return new RepositoryFilter(collaborationFactory, NukeeperLogger);

--- a/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Process/DotNetUpdatePackageCommandTests.cs
@@ -109,6 +109,13 @@ namespace NuKeeper.Integration.Tests.NuGet.Process
             await ExecuteValidUpdateTest(_testDotNetClassicProject, PackageReferenceType.ProjectFileOldStyle);
         }
 
+        [Test]
+        public async Task ShouldUpdateProjectFilenameWithSpaces()
+        {
+            await ExecuteValidUpdateTest(_testDotNetClassicProject, PackageReferenceType.ProjectFileOldStyle, "Project With Spaces.csproj");
+        }
+
+
         private async Task ExecuteValidUpdateTest(
             string testProjectContents,
             PackageReferenceType packageReferenceType,

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -10,7 +10,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="0.48.0" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Inspection\NuKeeper.Inspection.csproj" />

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -4,7 +4,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Tests/Engine/NugetRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/NugetRestoreTests.cs
@@ -1,0 +1,51 @@
+using NSubstitute;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Update.Process;
+using NuKeeper.Update.ProcessRunner;
+using NUnit.Framework;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class NugetRestoreTests
+    {
+        [Test]
+        public async Task WhenNugetRestoreIsCalledThenArgsIncludePackageDirectory()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var nuGetPath = Substitute.For<INuGetPath>();
+            var monoExecuter = Substitute.For<IMonoExecutor>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+            var file = new FileInfo("packages.config");
+            nuGetPath.Executable.Returns(@"c:\DoesNotExist\nuget.exe");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                externalProcess.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("", "", 0));
+            }
+            else
+            {
+                monoExecuter.CanRun().Returns(true);
+                monoExecuter.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("", "", 0));
+            }
+            var cmd = new NuGetFileRestoreCommand(logger, nuGetPath, monoExecuter, externalProcess);
+
+            await cmd.Invoke(file, NuGetSources.GlobalFeed);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                await externalProcess.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+                await externalProcess.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+            }
+            else
+            {
+                logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>(), Arg.Any<System.Exception>());
+                await monoExecuter.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+                await monoExecuter.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+            }
+        }
+    }
+}

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="5.1.0" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -10,7 +10,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -4,7 +4,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -37,20 +37,20 @@ namespace NuKeeper.Update.Process
             }
 
             var projectPath = currentPackage.Path.Info.DirectoryName;
-            var projectFileName = currentPackage.Path.Info.Name;
+            var projectFileNameCommandLine = ArgumentEscaper.EscapeAndConcatenate(new string[] { currentPackage.Path.Info.Name });
             var sourceUrl = UriEscapedForArgument(packageSource.SourceUri);
             var sources = allSources.CommandLine("-s");
 
-            var restoreCommand = $"restore {projectFileName} {sources}";
+            var restoreCommand = $"restore {projectFileNameCommandLine} {sources}";
             await _externalProcess.Run(projectPath, "dotnet", restoreCommand, true);
 
             if (currentPackage.Path.PackageReferenceType == PackageReferenceType.ProjectFileOldStyle)
             {
-                var removeCommand = $"remove {projectFileName} package {currentPackage.Id}";
+                var removeCommand = $"remove {projectFileNameCommandLine} package {currentPackage.Id}";
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = $"add {projectFileName} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
 

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -50,7 +50,7 @@ namespace NuKeeper.Update.Process
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
+            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl} -n";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
 

--- a/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
+++ b/NuKeeper.Update/Process/DotNetUpdatePackageCommand.cs
@@ -50,7 +50,7 @@ namespace NuKeeper.Update.Process
                 await _externalProcess.Run(projectPath, "dotnet", removeCommand, true);
             }
 
-            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl} -n";
+            var addCommand = $"add {projectFileNameCommandLine} package {currentPackage.Id} -v {newVersion} -s {sourceUrl}";
             await _externalProcess.Run(projectPath, "dotnet", addCommand, true);
         }
 

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -55,8 +55,13 @@ namespace NuKeeper.Update.Process
 
             var fileNameCommandLine = ArgumentEscaper.EscapeAndConcatenate(new[] { file.Name });
             var sourcesCommandLine = sources.CommandLine("-Source");
+            string restoreCommand = $"restore {fileNameCommandLine} {sourcesCommandLine} -NonInteractive";
 
-            var restoreCommand = $"restore {fileNameCommandLine} {sourcesCommandLine}  -NonInteractive";
+            // see: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-restore
+            if (string.Equals(file.Name, "packages.config", StringComparison.OrdinalIgnoreCase))
+            {
+                restoreCommand = $"{restoreCommand} -PackagesDirectory ..\\packages";
+            }
 
             ProcessOutput processOutput;
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -67,6 +67,7 @@ namespace NuKeeper.Engine
 
             if (!repository.IsLocalRepo)
             {
+                _logger.Detailed("RepositoryUpdater.Run(git, repository)");
                 await GitInit(git, repository);
             }
 

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -67,7 +67,6 @@ namespace NuKeeper.Engine
 
             if (!repository.IsLocalRepo)
             {
-                _logger.Detailed("RepositoryUpdater.Run(git, repository)");
                 await GitInit(git, repository);
             }
 

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="5.8.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Credentials" Version="5.8.0" />
+    <PackageReference Include="NuGet.Credentials" Version="5.11.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
   </ItemGroup>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.8.0" />
-    <PackageReference Include="SimpleInjector" Version="5.1.0" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.8.0">
+    <PackageReference Include="NuGet.CommandLine" Version="5.11.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -41,7 +41,7 @@
     <None Include="..\assets\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <TfmSpecificPackageFile Include="$(NuGetPackageRoot)\nuget.commandline\5.8.0\tools\NuGet.exe">
+    <TfmSpecificPackageFile Include="$(NuGetPackageRoot)\nuget.commandline\5.11.0\tools\NuGet.exe">
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\NuGet.exe</PackagePath>
     </TfmSpecificPackageFile>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.11.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
-    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
+    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsSettingsReaderTests.cs
@@ -82,7 +82,7 @@ namespace Nukeeper.AzureDevOps.Tests
         [Test]
         public async Task RepositorySettings_GetsCorrectSettingsOrganisation()
         {
-            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/org/project/_git/reponame"), true);
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/org/project/_git/reponame"), true, "develop");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiUri, "https://dev.azure.com/org/");
@@ -90,12 +90,13 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual(settings.RepositoryName, "reponame");
             Assert.AreEqual(settings.RepositoryOwner, "project");
             Assert.AreEqual(settings.SetAutoMerge, true);
+            Assert.AreEqual(settings.RemoteInfo.BranchName, "develop");
         }
 
         [Test]
         public async Task RepositorySettings_GetsCorrectSettingsPrivate()
         {
-            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true);
+            var settings = await _azureSettingsReader.RepositorySettings(new Uri("https://dev.azure.com/owner/_git/reponame"), true, "main");
 
             Assert.IsNotNull(settings);
             Assert.AreEqual(settings.ApiUri, "https://dev.azure.com/");
@@ -103,6 +104,7 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual(settings.RepositoryName, "reponame");
             Assert.AreEqual(settings.RepositoryOwner, "owner");
             Assert.AreEqual(settings.SetAutoMerge, true);
+            Assert.AreEqual(settings.RemoteInfo.BranchName, "main");
         }
 
         [Test]
@@ -129,6 +131,5 @@ namespace Nukeeper.AzureDevOps.Tests
             Assert.AreEqual("repo name", settings.RepositoryName);
             Assert.AreEqual("project name", settings.RepositoryOwner);
         }
-
     }
 }

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalPlatform.cs
@@ -66,7 +66,7 @@ namespace NuKeeper.BitBucketLocal
             var repositories = await _client.GetGitRepositories(target.Owner);
             var targetRepository = repositories.FirstOrDefault(x => x.Name.Equals(target.Name, StringComparison.InvariantCultureIgnoreCase));
 
-            var reviewers = await _client.GetBitBucketReviewers(target.Owner, targetRepository.Name);
+            var reviewers = await _client.GetBitBucketReviewers(target.Owner, targetRepository.Name, targetRepository.Id, request.Head, request.BaseRef);
 
             var pullReq = new PullRequest
             {

--- a/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
+++ b/Nukeeper.BitBucketLocal/BitBucketLocalSettingsReader.cs
@@ -55,7 +55,8 @@ namespace NuKeeper.BitBucketLocal
                 ApiUri = new Uri($"{repositoryUri.Scheme}://{repositoryUri.Authority}"),
                 RepositoryUri = repositoryUri,
                 RepositoryName = repoName,
-                RepositoryOwner = project
+                RepositoryOwner = project,
+                RemoteInfo = targetBranch != null ? new RemoteInfo { BranchName = targetBranch } : null
             });
         }
 

--- a/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
+++ b/Nukeeper.BitBucketLocal/BitbucketLocalRestClient.cs
@@ -138,10 +138,11 @@ namespace NuKeeper.BitBucketLocal
             return await HandleResponse<PullRequest>(response, caller);
         }
 
-        public async Task<IEnumerable<PullRequestReviewer>> GetBitBucketReviewers(string projectName, string repositoryName, [CallerMemberName] string caller = null)
+        public async Task<IEnumerable<PullRequestReviewer>> GetBitBucketReviewers(string projectName, string repositoryName, int repositoryId, string head, string baseRef, [CallerMemberName] string caller = null)
         {
-            var response = await GetResourceOrEmpty<List<Conditions>>($@"{ApiReviewersPath}/projects/{projectName}/repos/{repositoryName}/conditions", caller);
-            return response.SelectMany(c => c.Reviewers).Select(usr => new PullRequestReviewer() { User = usr });
+            var response = await GetResourceOrEmpty<List<Reviewer>>($@"{ApiReviewersPath}/projects/{projectName}/repos/{repositoryName}/reviewers?sourceRepoId={repositoryId}&targetRepoId={repositoryId}&sourceRefId={head}&targetRefId={baseRef}", caller);
+
+            return response.Where(r => r.Active).Select(user => new PullRequestReviewer { User = user });
         }
     }
 }

--- a/Nukeeper.BitBucketLocal/Models/Reviewer.cs
+++ b/Nukeeper.BitBucketLocal/Models/Reviewer.cs
@@ -6,5 +6,8 @@ namespace NuKeeper.BitBucketLocal.Models
     {
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonProperty("active")]
+        public bool Active { get; set; }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes Bug #1102 

### :arrow_heading_down: What is the current behavior?

Currently the targetBranch parameter isn't used when running in a Azure DevOps Pipeline.

### :new: What is the new behavior (if this is a feature change)?

Now the parameter is used.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
