### PR TITLE
Add nuget restore CLI PackagesDirectory for package.config

### DIFF
--- a/NuKeeper.Abstractions/Configuration/AuthSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/AuthSettings.cs
@@ -4,6 +4,13 @@ namespace NuKeeper.Abstractions.Configuration
 {
     public class AuthSettings
     {
+        /// <summary>
+        /// Provide the credentials required to authenticate against a different repository providers.
+        /// </summary>
+        /// <param name="apiBase">Repository URLs e.g. https://dev.azure.com/ or https://api.github.com/ or https://developer.atlassian.com/bitbucket/api/2/reference/</param>
+        /// <param name="token">Personal Access Tokens or Client Secret. The GitHub client with use anonymous authentication it the token is blank. I.e. public repositories</param>
+        /// <param name="username"></param>
+        /// <remarks>See <seealso cref="NuKeeper.Abstractions.CollaborationPlatform.CollaborationPlatformSettings"/> for a similar model.</remarks>
         public AuthSettings(Uri apiBase, string token, string username = null)
         {
             ApiBase = apiBase;

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -40,12 +40,20 @@ namespace NuKeeper.GitHub
             }
 
             _apiBase = settings.ApiBase;
+            Credentials creds;
+            if (string.IsNullOrWhiteSpace(settings.Token))
+            {
+                creds = new Credentials(settings.Token, AuthenticationType.Anonymous);
+            }
+            else
+            {
+                creds = new Credentials(settings.Token, AuthenticationType.Oauth);
+            }
 
             _client = new GitHubClient(new ProductHeaderValue("NuKeeper"), _apiBase)
             {
-                Credentials = new Credentials(settings.Token)
+                Credentials = creds
             };
-
             _initialised = true;
         }
 
@@ -206,7 +214,6 @@ namespace NuKeeper.GitHub
                 {
                     repos.Add(repo.Owner, repo.Name);
                 }
-
                 var result = await _client.Search.SearchCode(
                     new Octokit.SearchCodeRequest()
                     {

--- a/NuKeeper.GitHub/OctokitClient.cs
+++ b/NuKeeper.GitHub/OctokitClient.cs
@@ -43,7 +43,7 @@ namespace NuKeeper.GitHub
             Credentials creds;
             if (string.IsNullOrWhiteSpace(settings.Token))
             {
-                creds = new Credentials(settings.Token, AuthenticationType.Anonymous);
+                creds = Credentials.Anonymous;
             }
             else
             {

--- a/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
+++ b/NuKeeper.Integration.Tests/Engine/RepositoryFilterTests.cs
@@ -37,12 +37,10 @@ namespace NuKeeper.Integration.Tests.Engine
         }
 
         private RepositoryFilter MakeRepositoryFilter()
-        {
-            const string testKeyWithOnlyPublicAccess = "c13d2ce7774d39ae99ddaad46bd69c3d459b9992";
-
+        {            
             var collaborationFactory = Substitute.For<ICollaborationFactory>();
             var gitHubClient = new OctokitClient(NukeeperLogger);
-            gitHubClient.Initialise(new AuthSettings(new Uri("https://api.github.com"), testKeyWithOnlyPublicAccess));
+            gitHubClient.Initialise(new AuthSettings(new Uri("https://api.github.com"), ""));
             collaborationFactory.CollaborationPlatform.Returns(gitHubClient);
 
             return new RepositoryFilter(collaborationFactory, NukeeperLogger);

--- a/NuKeeper.Tests/Engine/NugetRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/NugetRestoreTests.cs
@@ -28,6 +28,7 @@ namespace NuKeeper.Tests.Engine
             }
             else
             {
+                monoExecuter.CanRun().Returns(true);
                 monoExecuter.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("", "", 0));
             }
             var cmd = new NuGetFileRestoreCommand(logger, nuGetPath, monoExecuter, externalProcess);
@@ -41,10 +42,10 @@ namespace NuKeeper.Tests.Engine
             }
             else
             {
+                logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>(), Arg.Any<System.Exception>());
                 await monoExecuter.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
                 await monoExecuter.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
             }
-
         }
     }
 }

--- a/NuKeeper.Tests/Engine/NugetRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/NugetRestoreTests.cs
@@ -1,0 +1,32 @@
+using NSubstitute;
+using NuKeeper.Abstractions.Logging;
+using NuKeeper.Abstractions.NuGet;
+using NuKeeper.Update.Process;
+using NuKeeper.Update.ProcessRunner;
+using NUnit.Framework;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace NuKeeper.Tests.Engine
+{
+    [TestFixture]
+    public class NugetRestoreTests
+    {
+        [Test]
+        public async Task WhenNugetRestoreIsCalledThenArgsIncludePackageDirectory()
+        {
+            var logger = Substitute.For<INuKeeperLogger>();
+            var nuGetPath = Substitute.For<INuGetPath>();           
+            var monoExecuter = Substitute.For<IMonoExecutor>();
+            var externalProcess = Substitute.For<IExternalProcess>();
+            var file = new FileInfo("packages.config");           
+            nuGetPath.Executable.Returns(@"c:\DoesNotExist\nuget.exe");
+            externalProcess.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("","",0));
+            var cmd = new NuGetFileRestoreCommand(logger, nuGetPath, monoExecuter, externalProcess);
+            await cmd.Invoke(file, NuGetSources.GlobalFeed);
+
+            await externalProcess.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+            await externalProcess.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+        }
+    }
+}

--- a/NuKeeper.Tests/Engine/NugetRestoreTests.cs
+++ b/NuKeeper.Tests/Engine/NugetRestoreTests.cs
@@ -5,6 +5,7 @@ using NuKeeper.Update.Process;
 using NuKeeper.Update.ProcessRunner;
 using NUnit.Framework;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace NuKeeper.Tests.Engine
@@ -16,17 +17,34 @@ namespace NuKeeper.Tests.Engine
         public async Task WhenNugetRestoreIsCalledThenArgsIncludePackageDirectory()
         {
             var logger = Substitute.For<INuKeeperLogger>();
-            var nuGetPath = Substitute.For<INuGetPath>();           
+            var nuGetPath = Substitute.For<INuGetPath>();
             var monoExecuter = Substitute.For<IMonoExecutor>();
             var externalProcess = Substitute.For<IExternalProcess>();
-            var file = new FileInfo("packages.config");           
+            var file = new FileInfo("packages.config");
             nuGetPath.Executable.Returns(@"c:\DoesNotExist\nuget.exe");
-            externalProcess.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("","",0));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                externalProcess.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("", "", 0));
+            }
+            else
+            {
+                monoExecuter.Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(new ProcessOutput("", "", 0));
+            }
             var cmd = new NuGetFileRestoreCommand(logger, nuGetPath, monoExecuter, externalProcess);
+
             await cmd.Invoke(file, NuGetSources.GlobalFeed);
 
-            await externalProcess.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-            await externalProcess.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                await externalProcess.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+                await externalProcess.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+            }
+            else
+            {
+                await monoExecuter.Received(1).Run(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+                await monoExecuter.ReceivedWithAnyArgs().Run(Arg.Any<string>(), Arg.Any<string>(), $"restore {file.Name} - Source ${NuGetSources.GlobalFeed} -NonInteractive -PackagesDirectory ..\\packages", Arg.Any<bool>());
+            }
+
         }
     }
 }

--- a/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
+++ b/NuKeeper.Update/Process/NuGetFileRestoreCommand.cs
@@ -55,8 +55,13 @@ namespace NuKeeper.Update.Process
 
             var fileNameCommandLine = ArgumentEscaper.EscapeAndConcatenate(new[] { file.Name });
             var sourcesCommandLine = sources.CommandLine("-Source");
+            string restoreCommand = $"restore {fileNameCommandLine} {sourcesCommandLine} -NonInteractive";
 
-            var restoreCommand = $"restore {fileNameCommandLine} {sourcesCommandLine}  -NonInteractive";
+            // see: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-restore
+            if (string.Equals(file.Name, "packages.config", StringComparison.OrdinalIgnoreCase))
+            {
+                restoreCommand = $"{restoreCommand} -PackagesDirectory ..\\packages";
+            }
 
             ProcessOutput processOutput;
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
* Add required option when restoring via package.config
* Add unit tests to ensure we include the CLI option

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for nuget restore CLI.

### :arrow_heading_down: What is the current behavior?
Nukeeper fails to restore nuget packages for older project types with package.config entries.

### :new: What is the new behavior (if this is a feature change)?
Includes the missing nuget CLI option required for the restoring of packages.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Tested against 24 Azure DevOps private repositories with multiple private NuGet sources.

### :memo: Links to relevant issues/docs
See - https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-restore. 
The resent nuget versions include the required option "-PackagesDirectory" when restoring via package.config files.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Relevant documentation was updated 
- [x] Unit test added 