### PR TITLE
Add support for Gitlab organisations

### DIFF
--- a/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
+++ b/NuKeeper.Gitlab.Tests/GitlabSettingsReaderTests.cs
@@ -52,6 +52,14 @@ namespace NuKeeper.Gitlab.Tests
             Assert.AreEqual(true, canRead);
         }
 
+        [Test]
+        public async Task AssumesItCanReadGitLabOrganisationUrls()
+        {
+            var canRead = await _gitlabSettingsReader.CanRead(new Uri("https://gitlab.com/org/user/projectname.git"));
+
+            Assert.AreEqual(true, canRead);
+        }
+
         [TestCase(null)]
         [TestCase("master")]
         public async Task GetsCorrectSettingsFromTheUrl(string targetBranch)
@@ -63,6 +71,22 @@ namespace NuKeeper.Gitlab.Tests
             Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
             Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
             Assert.AreEqual("user", repositorySettings.RepositoryOwner);
+            Assert.AreEqual("projectname", repositorySettings.RepositoryName);
+            Assert.AreEqual(targetBranch, repositorySettings.RemoteInfo?.BranchName);
+            Assert.AreEqual(false, repositorySettings.SetAutoMerge);
+        }
+
+        [TestCase(null)]
+        [TestCase("master")]
+        public async Task GetsCorrectSettingsFromTheOrganisationUrl(string targetBranch)
+        {
+            var repositoryUri = new Uri("https://gitlab.com/org/user/projectname.git");
+            var repositorySettings = await _gitlabSettingsReader.RepositorySettings(repositoryUri, true, targetBranch);
+
+            Assert.IsNotNull(repositorySettings);
+            Assert.AreEqual(new Uri("https://gitlab.com/api/v4/"), repositorySettings.ApiUri);
+            Assert.AreEqual(repositoryUri, repositorySettings.RepositoryUri);
+            Assert.AreEqual("org/user", repositorySettings.RepositoryOwner);
             Assert.AreEqual("projectname", repositorySettings.RepositoryName);
             Assert.AreEqual(targetBranch, repositorySettings.RemoteInfo?.BranchName);
             Assert.AreEqual(false, repositorySettings.SetAutoMerge);

--- a/NuKeeper.Gitlab/GitlabSettingsReader.cs
+++ b/NuKeeper.Gitlab/GitlabSettingsReader.cs
@@ -55,14 +55,14 @@ namespace NuKeeper.Gitlab
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();
 
-            if (pathParts.Count != 2)
+            if (pathParts.Count < 2)
             {
                 throw new NuKeeperException(
                     $"The provided uri was is not in the correct format. Provided {repositoryUri} and format should be {UrlPattern}");
             }
 
-            var repoOwner = pathParts[0];
-            var repoName = pathParts[1].Replace(".git", string.Empty);
+            var repoOwner = string.Join("/", pathParts.Take(pathParts.Count - 1));
+            var repoName = pathParts.Last().Replace(".git", string.Empty);
 
             var uriBuilder = new UriBuilder(repositoryUri) { Path = "/api/v4/" };
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix: gitlab.com organisations couldn't be handled as the format is different

### :arrow_heading_down: What is the current behavior?
Gives this error:
NuKeeper.Abstractions.NuKeeperException: The provided uri was is not in the correct format.

### :new: What is the new behavior (if this is a feature change)?
Runs successfully

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Create a gitlab organisation, with a folder structure in it, run against that

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Relevant documentation was updated 
