### PR TITLE
Bump our linux build agent to ubuntu-latest as suggested

### DIFF
--- a/.azure-build.yml
+++ b/.azure-build.yml
@@ -1,7 +1,7 @@
 strategy:
   matrix:
     Linux:
-      imageName: 'ubuntu-16.04'
+      imageName: 'ubuntu-latest'
     Windows:
       imageName: 'windows-2019'
     Mac:


### PR DESCRIPTION
Azure Pipelines currently print out:

`##[warning]Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/3287.`
