### PR TITLE
Automatic update of Newtonsoft.Json to 13.0.1

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,7 +12,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="5.8.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `13.0.1` from `12.0.3`
`Newtonsoft.Json 13.0.1` was published at `2021-03-22T20:10:49Z`, 6 months ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `Newtonsoft.Json` `13.0.1` from `12.0.3`

[Newtonsoft.Json 13.0.1 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/13.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
