### PR TITLE
Drop netcoreapp2.1 target, it's no longer supported

### DIFF
--- a/Docker/SDK5.0/Dockerfile
+++ b/Docker/SDK5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal
 ARG NUKEEPER_VERSION=0.34.0
 RUN dotnet tool install --global NuKeeper --version $NUKEEPER_VERSION
 ENV PATH="${PATH}:/root/.dotnet/tools"

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>


### PR DESCRIPTION
Adds a .NET SDK 5.0 target to the Docker images published (after this is merged, I'll update Docker Hub configuration).