### PR TITLE
Automatic update of Microsoft.CodeAnalysis.FxCopAnalyzers to 3.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -17,6 +17,6 @@
     <RepositoryUrl>https://github.com/NuKeeperDotNet/NuKeeper.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.2` from `3.3.1`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.2` was published at `2020-12-04T00:17:15Z`, 9 months ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.2` from `3.3.1`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
