### PR TITLE
Automatic update of McMaster.Extensions.CommandLineUtils to 3.1.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `McMaster.Extensions.CommandLineUtils` to `3.1.0` from `3.0.0`
`McMaster.Extensions.CommandLineUtils 3.1.0` was published at `2021-01-10T00:17:53Z`, 8 months ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `McMaster.Extensions.CommandLineUtils` `3.1.0` from `3.0.0`

[McMaster.Extensions.CommandLineUtils 3.1.0 on NuGet.org](https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils/3.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
