### PR TITLE
Automatic update of SimpleInjector.Integration.ServiceCollection to 5.3.0

### DIFF
--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.8.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
-    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
+    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `SimpleInjector.Integration.ServiceCollection` to `5.3.0` from `5.0.1`
`SimpleInjector.Integration.ServiceCollection 5.3.0` was published at `2021-03-07T15:45:32Z`, 6 months ago

1 project update:
Updated `NuKeeper\NuKeeper.csproj` to `SimpleInjector.Integration.ServiceCollection` `5.3.0` from `5.0.1`

[SimpleInjector.Integration.ServiceCollection 5.3.0 on NuGet.org](https://www.nuget.org/packages/SimpleInjector.Integration.ServiceCollection/5.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
