### PR TITLE
Automatic update of NuGet.Protocol to 5.11.0

### DIFF
--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.11.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Protocol` to `5.11.0` from `5.8.0`
`NuGet.Protocol 5.11.0` was published at `2021-08-12T23:42:58Z`, 1 month ago

1 project update:
Updated `NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `NuGet.Protocol` `5.11.0` from `5.8.0`

[NuGet.Protocol 5.11.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Protocol/5.11.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
