### PR TITLE
Automatic update of LibGit2Sharp to 0.27.0-preview-0119

### DIFF
--- a/NuKeeper.Git/NuKeeper.Git.csproj
+++ b/NuKeeper.Git/NuKeeper.Git.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0119" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a  update of `LibGit2Sharp` to `0.27.0-preview-0119` from `0.27.0-preview-0034`
`LibGit2Sharp 0.27.0-preview-0119` was published at `2021-08-24T15:30:19Z`, 27 days ago

1 project update:
Updated `NuKeeper.Git\NuKeeper.Git.csproj` to `LibGit2Sharp` `0.27.0-preview-0119` from `0.27.0-preview-0034`

[LibGit2Sharp 0.27.0-preview-0119 on NuGet.org](https://www.nuget.org/packages/LibGit2Sharp/0.27.0-preview-0119)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
