### PR TITLE
Respect the target branch on a local DevOps pipeline

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsSettingsReader.cs
@@ -97,7 +97,10 @@ namespace NuKeeper.AzureDevOps
 
         private async Task<RepositorySettings> CreateSettingsFromLocal(Uri repositoryUri, string targetBranch)
         {
-            var remoteInfo = new RemoteInfo();
+            var remoteInfo = new RemoteInfo()
+            {
+                BranchName = targetBranch,
+            };
 
             var localCopy = repositoryUri;
             if (await _gitDriver.IsGitRepo(repositoryUri))
@@ -138,7 +141,8 @@ namespace NuKeeper.AzureDevOps
                     pathParts[0],  //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[1]),  // project
-                    Uri.UnescapeDataString(pathParts[3])   // reponame
+                    Uri.UnescapeDataString(pathParts[3]),  // reponame
+                    remoteInfo
                     );
             }
             else if (indexOfGit == 1 && pathParts.Length == 3)
@@ -147,7 +151,8 @@ namespace NuKeeper.AzureDevOps
                     null,          //org
                     repositoryUri, //uri
                     Uri.UnescapeDataString(pathParts[0]),  // project
-                    Uri.UnescapeDataString(pathParts[2])   // reponame
+                    Uri.UnescapeDataString(pathParts[2]),   // reponame
+                    remoteInfo
                     );
             }
             return null;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes Bug #1102 

### :arrow_heading_down: What is the current behavior?

Currently the targetBranch parameter isn't used when running in a Azure DevOps Pipeline.

### :new: What is the new behavior (if this is a feature change)?

Now the parameter is used.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
