### PR TITLE
Add failongiterror as parameter to report any git error as NuKeeper e…

### DIFF
--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -44,6 +44,7 @@ namespace NuKeeper.Abstractions.Configuration
 
         public string GitCliPath { get; set; }
         public int? MaxOpenPullRequests { get; set; }
+        public bool? ThrowOnGitError { get; set; }
 
         public static FileSettings Empty()
         {

--- a/NuKeeper.Abstractions/Configuration/UserSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/UserSettings.cs
@@ -16,6 +16,8 @@ namespace NuKeeper.Abstractions.Configuration
 
         public UsePrerelease UsePrerelease { get; set; }
 
+        public bool ThrowOnGitError { get; set; }
+
 
         public OutputFormat OutputFormat { get; set; }
         public OutputDestination OutputDestination { get; set; }

--- a/NuKeeper.Git/LibGit2SharpDriver.cs
+++ b/NuKeeper.Git/LibGit2SharpDriver.cs
@@ -180,12 +180,19 @@ namespace NuKeeper.Git
         {
             return Task.Run(() =>
             {
-                _logger.Detailed($"Git commit with message '{message}'");
-                using (var repo = MakeRepo())
+                try
                 {
-                    var signature = GetSignature(repo);
-                    GitCommands.Stage(repo, "*");
-                    repo.Commit(message, signature, signature);
+                    _logger.Detailed($"Git commit with message '{message}'");
+                    using (var repo = MakeRepo())
+                    {
+                        var signature = GetSignature(repo);
+                        GitCommands.Stage(repo, "*");
+                        repo.Commit(message, signature, signature);
+                    }
+                }
+                catch (EmptyCommitException)
+                {
+                    _logger.Normal($"Empty commit with message '{message}' is ignored");
                 }
             });
         }

--- a/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/ApiPackageLookupTests.cs
@@ -25,7 +25,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(updates, Is.Not.Null);
             Assert.That(updates.Major, Is.Null);
@@ -48,7 +49,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(updates, Is.Not.Null);
 
@@ -74,7 +76,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -98,7 +101,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Minor,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -122,7 +126,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Patch,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -132,7 +137,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMetadata> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();
-            allVersions.Lookup(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<NuGetSources>())
+            allVersions.Lookup(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<NuGetSources>())
                 .Returns(actualResults);
             return allVersions;
         }

--- a/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/BulkPackageLookupTests.cs
@@ -28,13 +28,14 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 Enumerable.Empty<PackageIdentity>(),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
 
             await apiLookup.DidNotReceive().FindVersionUpdate(
-                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>());
         }
 
         [Test]
@@ -54,7 +55,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var results = await bulkLookup.FindVersionUpdates(queries,
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Not.Empty);
@@ -79,10 +81,11 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             await bulkLookup.FindVersionUpdates(queries,
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             await apiLookup.Received(1).FindVersionUpdate(
-                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>());
         }
 
         [Test]
@@ -104,7 +107,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var results = await bulkLookup.FindVersionUpdates(queries,
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             var packages = results.Select(kvp => kvp.Key);
             Assert.That(results.Count, Is.EqualTo(2));
@@ -132,10 +136,11 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             await bulkLookup.FindVersionUpdates(queries,
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             await apiLookup.Received(2).FindVersionUpdate(
-                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>());
         }
 
         [Test]
@@ -156,13 +161,14 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
             var results = await bulkLookup.FindVersionUpdates(queries,
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             await apiLookup.Received(1).FindVersionUpdate(
-                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
+                Arg.Any<PackageIdentity>(), Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>());
             await apiLookup.Received(1).FindVersionUpdate(Arg.Is<PackageIdentity>(
                 pi => pi.Id == "foo" && pi.Version == new NuGetVersion(1, 3, 4)),
-                Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>());
+                Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>());
 
             var packages = results.Select(kvp => kvp.Key);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -177,7 +183,7 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 DateTimeOffset.Now, null);
 
             lookup.FindVersionUpdate(Arg.Is<PackageIdentity>(pm => pm.Id == packageName),
-                    Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>())
+                    Arg.Any<NuGetSources>(), Arg.Any<VersionChange>(), Arg.Any<UsePrerelease>(), Arg.Any<bool>())
                 .Returns(new PackageLookupResult(VersionChange.Major, responseMetaData, responseMetaData, responseMetaData));
         }
 

--- a/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/PackageUpdatesLookupTests.cs
@@ -30,7 +30,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                     Arg.Any<PackageIdentity>(),
                     Arg.Any<NuGetSources>(),
                     VersionChange.Minor,
-                    Arg.Any<UsePrerelease>()
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>()
                 )
                 .Returns(ci =>
                     GetPackageLookupResult(
@@ -54,7 +55,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 packagesInProjects,
                 new NuGetSources("https://api.nuget.com/"),
                 VersionChange.Minor,
-                UsePrerelease.Never
+                UsePrerelease.Never,
+                true
             );
 
             var versionUpdates = result.Select(p => p.SelectedVersion.ToNormalizedString()).ToList();

--- a/NuKeeper.Inspection.Tests/NuGetApi/UsePrereleaseLookupTests.cs
+++ b/NuKeeper.Inspection.Tests/NuGetApi/UsePrereleaseLookupTests.cs
@@ -43,7 +43,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123Prerelease("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -67,7 +68,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -102,7 +104,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123Prerelease("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.Always);
+                UsePrerelease.Always,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -137,7 +140,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.Always);
+                UsePrerelease.Always,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -162,7 +166,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123Prerelease("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.Never);
+                UsePrerelease.Never,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -187,7 +192,8 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
                 CurrentVersion123("TestPackage"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.Never);
+                UsePrerelease.Never,
+                true);
 
             AssertPackagesIdentityIs(updates, "TestPackage");
             Assert.That(updates.Selected().Identity.Version, Is.EqualTo(expectedUpdate));
@@ -197,9 +203,9 @@ namespace NuKeeper.Inspection.Tests.NuGetApi
         private static IPackageVersionsLookup MockVersionLookup(List<PackageSearchMetadata> actualResults)
         {
             var allVersions = Substitute.For<IPackageVersionsLookup>();
-            allVersions.Lookup(Arg.Any<string>(), false, Arg.Any<NuGetSources>())
+            allVersions.Lookup(Arg.Any<string>(), false, Arg.Any<bool>(), Arg.Any<NuGetSources>())
                 .Returns(actualResults.Where(x => !x.Identity.Version.IsPrerelease).ToList());
-            allVersions.Lookup(Arg.Any<string>(), true, Arg.Any<NuGetSources>())
+            allVersions.Lookup(Arg.Any<string>(), true, Arg.Any<bool>(), Arg.Any<NuGetSources>())
                 .Returns(actualResults);
             return allVersions;
         }

--- a/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
+++ b/NuKeeper.Inspection.Tests/UpdateFinderTests.cs
@@ -35,7 +35,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease);
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(0));
@@ -63,7 +63,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease);
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -93,7 +93,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, new Regex("^somePackage"), null);
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true, new Regex("^somePackage"), null);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -124,7 +124,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, new Regex("^andAnotherPackage"), new Regex("^anotherPackage"));
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true, new Regex("^andAnotherPackage"), new Regex("^anotherPackage"));
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -154,7 +154,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, null, new Regex("^anotherPackage"));
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true, null, new Regex("^anotherPackage"));
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -184,7 +184,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease);
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -216,7 +216,7 @@ namespace NuKeeper.Inspection.Tests
             var finder = new UpdateFinder(scanner, updater, logger);
 
             var results = await finder.FindPackageUpdateSets(
-                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease);
+                folder, NuGetSources.GlobalFeed, VersionChange.Major, UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -236,7 +236,8 @@ namespace NuKeeper.Inspection.Tests
                     Arg.Any<IReadOnlyCollection<PackageInProject>>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
-                    Arg.Any<UsePrerelease>())
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>())
                 .Returns(a => a.ArgAt<IReadOnlyCollection<PackageInProject>>(0)
                     .Select(BuildPackageUpdateSet)
                     .ToList());

--- a/NuKeeper.Inspection/IUpdateFinder.cs
+++ b/NuKeeper.Inspection/IUpdateFinder.cs
@@ -25,6 +25,7 @@ namespace NuKeeper.Inspection
             NuGetSources sources,
             VersionChange allowedChange,
             UsePrerelease usePrerelease,
+            bool throwOnGitError,
             Regex include = null,
             Regex exclude = null);
     }

--- a/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/ApiPackageLookup.cs
@@ -21,7 +21,8 @@ namespace NuKeeper.Inspection.NuGetApi
             PackageIdentity package,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease)
+            UsePrerelease usePrerelease,
+            bool throwOnGitError)
         {
             if (package == null)
             {
@@ -30,7 +31,7 @@ namespace NuKeeper.Inspection.NuGetApi
 
             var includePrerelease = ShouldAllowPrerelease(package, usePrerelease);
 
-            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, includePrerelease, sources);
+            var foundVersions = await _packageVersionsLookup.Lookup(package.Id, includePrerelease, throwOnGitError, sources);
             return VersionChanges.MakeVersions(package.Version, foundVersions, allowedChange);
         }
 

--- a/NuKeeper.Inspection/NuGetApi/IApiPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IApiPackageLookup.cs
@@ -12,6 +12,7 @@ namespace NuKeeper.Inspection.NuGetApi
             PackageIdentity package,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease);
+            UsePrerelease usePrerelease,
+            bool throwOnGitError);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IBulkPackageLookup.cs
@@ -13,6 +13,7 @@ namespace NuKeeper.Inspection.NuGetApi
             IEnumerable<PackageIdentity> packages,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease);
+            UsePrerelease usePrerelease,
+            bool throwOnGitError);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageUpdatesLookup.cs
@@ -12,6 +12,7 @@ namespace NuKeeper.Inspection.NuGetApi
             IReadOnlyCollection<PackageInProject> packages,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease);
+            UsePrerelease usePrerelease,
+            bool throwOnGitError);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/IPackageVersionsLookup.cs
@@ -8,7 +8,7 @@ namespace NuKeeper.Inspection.NuGetApi
     public interface IPackageVersionsLookup
     {
         Task<IReadOnlyCollection<PackageSearchMetadata>> Lookup(
-            string packageName, bool includePrerelease,
+            string packageName, bool includePrerelease, bool throwOnGitError,
             NuGetSources sources);
     }
 }

--- a/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
+++ b/NuKeeper.Inspection/NuGetApi/PackageUpdatesLookup.cs
@@ -21,14 +21,15 @@ namespace NuKeeper.Inspection.NuGetApi
             IReadOnlyCollection<PackageInProject> packages,
             NuGetSources sources,
             VersionChange allowedChange,
-            UsePrerelease usePrerelease)
+            UsePrerelease usePrerelease,
+            bool throwOnGitError)
         {
             var packageIds = packages
                 .Select(p => p.Identity)
                 .Distinct();
 
             var latestVersions = await _bulkPackageLookup.FindVersionUpdates(
-                packageIds, sources, allowedChange, usePrerelease);
+                packageIds, sources, allowedChange, usePrerelease, throwOnGitError);
 
             var results = new List<PackageUpdateSet>();
 

--- a/NuKeeper.Inspection/UpdateFinder.cs
+++ b/NuKeeper.Inspection/UpdateFinder.cs
@@ -44,6 +44,7 @@ namespace NuKeeper.Inspection
             NuGetSources sources,
             VersionChange allowedChange,
             UsePrerelease usePrerelease,
+            bool throwOnGitError,
             Regex includes = null,
             Regex excludes = null)
         {
@@ -57,7 +58,7 @@ namespace NuKeeper.Inspection
 
             // look for updates to these packages
             var updates = await _packageUpdatesLookup.FindUpdatesForPackages(
-                filtered, sources, allowedChange, usePrerelease);
+                filtered, sources, allowedChange, usePrerelease, throwOnGitError);
 
             _logger.Log(UpdatesLogger.Log(updates));
             return updates;

--- a/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/ApiPackageLookupTests.cs
@@ -20,7 +20,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
             var package = await lookup.FindVersionUpdate(Current("AWSSDK"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Major, Is.Not.Null);
@@ -41,7 +42,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 Current(Guid.NewGuid().ToString()),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Major, Is.Null);
@@ -57,7 +59,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 Current("Newtonsoft.Json"),
                 NuGetSources.GlobalFeed,
                 VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Major, Is.Not.Null);
@@ -81,7 +84,8 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
                 new PackageIdentity("Newtonsoft.Json", new NuGetVersion(8, 0, 1)),
                 NuGetSources.GlobalFeed,
                 VersionChange.Minor,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease,
+                true);
 
             Assert.That(package, Is.Not.Null);
             Assert.That(package.Major, Is.Not.Null);

--- a/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/BulkPackageLookupTests.cs
@@ -23,7 +23,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);
@@ -44,7 +44,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);
@@ -66,7 +66,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results.Count, Is.EqualTo(1));
@@ -84,7 +84,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -97,7 +97,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 Enumerable.Empty<PackageIdentity>(), NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             Assert.That(results, Is.Not.Null);
             Assert.That(results, Is.Empty);
@@ -118,7 +118,7 @@ namespace NuKeeper.Integration.Tests.NuGet.Api
 
             var results = await lookup.FindVersionUpdates(
                 packages, NuGetSources.GlobalFeed, VersionChange.Major,
-                UsePrerelease.FromPrerelease);
+                UsePrerelease.FromPrerelease, true);
 
             var updatedPackages = results.Select(p => p.Key);
             Assert.That(results, Is.Not.Null);

--- a/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
+++ b/NuKeeper.Integration.Tests/NuGet/Api/PackageVersionsLookupTests.cs
@@ -16,7 +16,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Newtonsoft.Json", false, true, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -30,7 +30,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Newtonsoft.Json", false, true, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -54,7 +54,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Moq", true, NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Moq", true, true, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -81,7 +81,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         {
             var lookup = BuildPackageLookup();
 
-            var packages = await lookup.Lookup("Moq", false, NuGetSources.GlobalFeed);
+            var packages = await lookup.Lookup("Moq", false, true, NuGetSources.GlobalFeed);
 
             Assert.That(packages, Is.Not.Null);
 
@@ -99,10 +99,10 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
         public async Task CanBeCalledTwice()
         {
             var lookup = BuildPackageLookup();
-            var packages1 = await lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
+            var packages1 = await lookup.Lookup("Newtonsoft.Json", false, true, NuGetSources.GlobalFeed);
             Assert.That(packages1, Is.Not.Null);
 
-            var packages2 = await lookup.Lookup("Moq", false, NuGetSources.GlobalFeed);
+            var packages2 = await lookup.Lookup("Moq", false, true, NuGetSources.GlobalFeed);
             Assert.That(packages2, Is.Not.Null);
         }
 
@@ -115,7 +115,7 @@ namespace NuKeeper.Integration.Tests.Nuget.Api
 
             for (int i = 0; i < 10; i++)
             {
-                var task = lookup.Lookup("Newtonsoft.Json", false, NuGetSources.GlobalFeed);
+                var task = lookup.Lookup("Newtonsoft.Json", false, true, NuGetSources.GlobalFeed);
                 tasks.Add(task);
             }
 

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -54,6 +54,7 @@ namespace NuKeeper.Tests.Engine
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
                     Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>(),
                     Arg.Any<Regex>()
                 )
                 .Returns(_packagesToReturn);
@@ -379,7 +380,8 @@ namespace NuKeeper.Tests.Engine
                     Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
-                    Arg.Any<UsePrerelease>())
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>())
                 .Returns(updates);
 
             if (packageUpdater == null)

--- a/NuKeeper.Tests/Local/LocalEngineTests.cs
+++ b/NuKeeper.Tests/Local/LocalEngineTests.cs
@@ -36,7 +36,8 @@ namespace NuKeeper.Tests.Local
                 .FindPackageUpdateSets(Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
-                    Arg.Any<UsePrerelease>());
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>());
 
             await updater.Received(0)
                 .ApplyUpdates(
@@ -64,7 +65,8 @@ namespace NuKeeper.Tests.Local
                 .FindPackageUpdateSets(Arg.Any<IFolder>(),
                     Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
-                    Arg.Any<UsePrerelease>());
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>());
 
             await updater
                 .Received(1)
@@ -81,7 +83,8 @@ namespace NuKeeper.Tests.Local
             finder.FindPackageUpdateSets(
                     Arg.Any<IFolder>(), Arg.Any<NuGetSources>(),
                     Arg.Any<VersionChange>(),
-                    Arg.Any<UsePrerelease>())
+                    Arg.Any<UsePrerelease>(),
+                    Arg.Any<bool>())
                 .Returns(new List<PackageUpdateSet>());
 
             var sorter = Substitute.For<IPackageUpdateSetSort>();

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -85,6 +85,10 @@ namespace NuKeeper.Commands
             Description = "Path to git to use instead of lib2gitsharp implementation")]
         public string GitCliPath { get; set; }
 
+        [Option(CommandOptionType.NoValue, ShortName = "", LongName = "failongiterror",
+            Description = "Should this call fail on a GIT error? Defaults to false.")]
+        public bool? FailOnGitError { get; set; }
+
         protected CommandBase(IConfigureLogger logger, IFileSettingsCache fileSettingsCache)
         {
             _configureLogger = logger;
@@ -132,6 +136,7 @@ namespace NuKeeper.Commands
             var usePrerelease = Concat.FirstValue(UsePrerelease, fileSettings.UsePrerelease, Abstractions.Configuration.UsePrerelease.FromPrerelease);
             var branchNameTemplate = Concat.FirstValue(BranchNameTemplate, fileSettings.BranchNameTemplate);
             var gitpath = Concat.FirstValue(GitCliPath, fileSettings.GitCliPath);
+            var throwOnGitError = Concat.FirstValue(FailOnGitError, fileSettings.ThrowOnGitError, false);
 
             var settings = new SettingsContainer
             {
@@ -142,7 +147,8 @@ namespace NuKeeper.Commands
                     AllowedChange = allowedChange,
                     UsePrerelease = usePrerelease,
                     NuGetSources = NuGetSources,
-                    GitPath = gitpath
+                    GitPath = gitpath,
+                    ThrowOnGitError = throwOnGitError,
                 },
                 BranchSettings = new BranchSettings
                 {
@@ -199,7 +205,7 @@ namespace NuKeeper.Commands
                 return branchNameTemplateValid;
             }
 
-            return await Task.FromResult(ValidationResult.Success);
+            return ValidationResult.Success;
         }
 
         private TimeSpan? ReadMinPackageAge()

--- a/NuKeeper/Engine/RepositoryUpdater.cs
+++ b/NuKeeper/Engine/RepositoryUpdater.cs
@@ -79,6 +79,7 @@ namespace NuKeeper.Engine
                 sources,
                 userSettings.AllowedChange,
                 userSettings.UsePrerelease,
+                userSettings.ThrowOnGitError,
                 settings.PackageFilters?.Includes,
                 settings.PackageFilters?.Excludes);
 

--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -65,6 +65,7 @@ namespace NuKeeper.Local
                 sources,
                 settings.UserSettings.AllowedChange,
                 settings.UserSettings.UsePrerelease,
+                settings.UserSettings.ThrowOnGitError,
                 settings.PackageFilters?.Includes,
                 settings.PackageFilters?.Excludes);
 
@@ -81,11 +82,12 @@ namespace NuKeeper.Local
             NuGetSources sources,
             VersionChange allowedChange,
             UsePrerelease usePrerelease,
+            bool throwOnGitError,
             Regex includes,
             Regex excludes)
         {
             var updates = await _updateFinder.FindPackageUpdateSets(
-                folder, sources, allowedChange, usePrerelease, includes, excludes);
+                folder, sources, allowedChange, usePrerelease, throwOnGitError, includes, excludes);
 
             return _sorter.Sort(updates)
                 .ToList();

--- a/site/content/basics/configuration.md
+++ b/site/content/basics/configuration.md
@@ -27,7 +27,7 @@ title: "Configuration"
 | fork             | f         | `repo`, `org`, `global`   | PreferFork              |
 | label            | l         | `repo`, `org`, `global`   | 'nukeeper'              |
 | maxpackageupdates| m         | `repo`, `org`, `global`, `update`| 3, or when the command is `update`, 1 |
-| maxopenpullrequests |           | `repo`, `org`, `global`| 1 if `consolidate`, else `maxpackageupdates` |
+| maxopenpullrequests |        | `repo`, `org`, `global`| 1 if `consolidate`, else `maxpackageupdates` |
 | consolidate      | n         | `repo`, `org`, `global`   | false                   |
 | platform         |           | `repo`, `org`, `global`   | _null_                  |
 | gitclipath       | git       | `repo`, `org`, `global`   | _null_ (use default Lib2Git-Implementation)                  |
@@ -36,9 +36,10 @@ title: "Configuration"
 | includerepos     |           | `org`, `global`           | _null_                  |
 | excluderepos     |           | `org`, `global`           | _null_                  |
 |                  |           |                           |                         |
-| branchnametemplate |           | `repo`, `org`, `global`, `update`| _null_           |
+| branchnametemplate |         | `repo`, `org`, `global`, `update`| _null_           |
 | deletebranchaftermerge | d   | _all_                     | true                    |
-| setautomerge |    | `repo`                     | false                    |
+| setautomerge     |           | `repo`                    | false                    |
+| failongiterror   |           | _all_                     | false                    |
 
 * *age* The minimum package age. In order to not consume packages immediately after they are released, exclude updates that do not meet a minimum age.  The default is 7 days. This age is the duration between the published date of the selected package update and now.
  A value can be expressed in command options as an integer and a unit suffix,
@@ -109,3 +110,4 @@ Examples: `0` = zero, `12h` = 12 hours, `3d` = 3 days, `2w` = two weeks.
   
 * *deletebranchaftermerge* Specifies whether a branch should be automatically deleted or not once the branch has been merged. Currently only works with `Platform` equal to `AzureDevOps`, `Gitlab` or `Bitbucket`.
 * *setautomerge* Specifies whether a pull request should be merged automatically after passing all checks. Currently only works with `Platform` equal to `AzureDevOps`.
+* *failongiterror* Specified that NuKeeper should fail if git reports an error.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

 A new option is added. When the option FailOnGitError is set the run failes when the call to get the available versions failes.

This is only the first part of a fix for #930 


### :arrow_heading_down: What is the current behavior?

On most of git calls the error is ignored and NuKeeper notifies success.

### :new: What is the new behavior (if this is a feature change)?

A new option `--failongiterror` is introduced and when this option is set an error in a git call results in an error of NuKeeper.

In the current process the option is only used when searching for the available package versions.

### :boom: Does this PR introduce a breaking change?

No, the default behaviour is unchanged.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
