### PR TITLE
add setting for commit message prefix --commitmessageprefix

### DIFF
--- a/NuKeeper.Abstractions/CollaborationPlatform/ICommitWorder.cs
+++ b/NuKeeper.Abstractions/CollaborationPlatform/ICommitWorder.cs
@@ -7,7 +7,7 @@ namespace NuKeeper.Abstractions.CollaborationPlatform
     {
         string MakePullRequestTitle(IReadOnlyCollection<PackageUpdateSet> updates);
 
-        string MakeCommitMessage(PackageUpdateSet updates);
+        string MakeCommitMessage(PackageUpdateSet updates, string commitMessagePrefix);
 
         string MakeCommitDetails(IReadOnlyCollection<PackageUpdateSet> updates);
     }

--- a/NuKeeper.Abstractions/Configuration/CommitSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/CommitSettings.cs
@@ -1,0 +1,7 @@
+namespace NuKeeper.Abstractions.Configuration
+{
+    public class CommitSettings
+    {
+        public string CommitMessagePrefix { get; set; }
+    }
+}

--- a/NuKeeper.Abstractions/Configuration/FileSettings.cs
+++ b/NuKeeper.Abstractions/Configuration/FileSettings.cs
@@ -42,6 +42,8 @@ namespace NuKeeper.Abstractions.Configuration
         public string BranchNameTemplate { get; set; }
         public bool? DeleteBranchAfterMerge { get; set; }
 
+        public string CommitMessagePrefix { get; set; }
+
         public string GitCliPath { get; set; }
         public int? MaxOpenPullRequests { get; set; }
 

--- a/NuKeeper.Abstractions/Configuration/SettingsContainer.cs
+++ b/NuKeeper.Abstractions/Configuration/SettingsContainer.cs
@@ -12,6 +12,8 @@ namespace NuKeeper.Abstractions.Configuration
 
         public BranchSettings BranchSettings { get; set; }
 
+        public CommitSettings CommitSettings { get; set; }
+
         public IFolder WorkingFolder { get; set; }
     }
 }

--- a/NuKeeper.AzureDevOps/AzureDevOpsCommitWorder.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsCommitWorder.cs
@@ -38,14 +38,14 @@ namespace NuKeeper.AzureDevOps
             return $"{CommitEmoji} Automatic update of {updates.SelectedId} to {updates.SelectedVersion}";
         }
 
-        public string MakeCommitMessage(PackageUpdateSet updates)
+        public string MakeCommitMessage(PackageUpdateSet updates, string commitMessagePrefix)
         {
             if (updates == null)
             {
                 throw new ArgumentNullException(nameof(updates));
             }
 
-            return $"{PackageTitle(updates)}";
+            return $"{commitMessagePrefix}{PackageTitle(updates)}";
         }
 
         public string MakeCommitDetails(IReadOnlyCollection<PackageUpdateSet> updates)

--- a/NuKeeper.BitBucket/BitbucketCommitWorder.cs
+++ b/NuKeeper.BitBucket/BitbucketCommitWorder.cs
@@ -34,14 +34,14 @@ namespace NuKeeper.BitBucket
             return $"Automatic update of {updates.SelectedId} to {updates.SelectedVersion}";
         }
 
-        public string MakeCommitMessage(PackageUpdateSet updates)
+        public string MakeCommitMessage(PackageUpdateSet updates, string commitMessagePrefix)
         {
             if (updates == null)
             {
                 throw new ArgumentNullException(nameof(updates));
             }
 
-            return $":{CommitEmoji}: {PackageTitle(updates)}";
+            return $"{commitMessagePrefix}:{CommitEmoji}: {PackageTitle(updates)}";
         }
 
         public string MakeCommitDetails(IReadOnlyCollection<PackageUpdateSet> updates)

--- a/NuKeeper.Integration.Tests/Engine/ExistingCommitFilterTest.cs
+++ b/NuKeeper.Integration.Tests/Engine/ExistingCommitFilterTest.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.Integration.Tests.Engine
 
             var subject = MakeExistingCommitFilter();
 
-            var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head");
+            var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head", string.Empty);
 
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual("First.Nuget", result.FirstOrDefault()?.SelectedId);
@@ -64,7 +64,7 @@ namespace NuKeeper.Integration.Tests.Engine
 
             var subject = MakeExistingCommitFilter();
 
-            var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head");
+            var result = await subject.Filter(git, updates.AsReadOnly(), "base", "head", string.Empty);
 
             Assert.AreEqual(2, result.Count);
         }
@@ -77,7 +77,7 @@ namespace NuKeeper.Integration.Tests.Engine
             collaborationFactory.CollaborationPlatform.Returns(gitClient);
 
             var commitWorder = Substitute.For<ICommitWorder>();
-            commitWorder.MakeCommitMessage(Arg.Any<PackageUpdateSet>()).Returns(p => $"Automatic update of {((PackageUpdateSet)p[0]).SelectedId} to {((PackageUpdateSet)p[0]).SelectedVersion}");
+            commitWorder.MakeCommitMessage(Arg.Any<PackageUpdateSet>(), Arg.Any<string>()).Returns(p => $"Automatic update of {((PackageUpdateSet)p[0]).SelectedId} to {((PackageUpdateSet)p[0]).SelectedVersion}");
             collaborationFactory.CommitWorder.Returns(commitWorder);
 
             return new ExistingCommitFilter(collaborationFactory, NukeeperLogger);

--- a/NuKeeper.Tests/Engine/DefaultCommitWorderTests.cs
+++ b/NuKeeper.Tests/Engine/DefaultCommitWorderTests.cs
@@ -39,11 +39,11 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = PackageUpdates.For(MakePackageForV110());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo(":package: Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo("someprefix: :package: Automatic update of foo.bar to 1.2.3"));
         }
 
         [Test]
@@ -51,11 +51,11 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo(":package: Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo("someprefix: :package: Automatic update of foo.bar to 1.2.3"));
         }
 
         [Test]
@@ -63,11 +63,11 @@ namespace NuKeeper.Tests.Engine
         {
             var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo(":package: Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo("someprefix: :package: Automatic update of foo.bar to 1.2.3"));
         }
 
 

--- a/NuKeeper.Tests/Engine/Packages/PackageUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/Packages/PackageUpdaterTests.cs
@@ -39,6 +39,7 @@ namespace NuKeeper.Tests.Engine.Packages
                     Arg.Any<IGitDriver>(),
                     Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
                     Arg.Any<string>(),
+                    Arg.Any<string>(),
                     Arg.Any<string>()
                 )
                 .Returns(ci => ((IReadOnlyCollection<PackageUpdateSet>)ci[1]));
@@ -114,6 +115,7 @@ namespace NuKeeper.Tests.Engine.Packages
                 .Filter(
                     Arg.Any<IGitDriver>(),
                     Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(),
+                    Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string>()
                 )
@@ -245,6 +247,10 @@ namespace NuKeeper.Tests.Engine.Packages
                 {
                     MaxPackageUpdates = 3,
                     MinimumAge = new TimeSpan(7, 0, 0, 0),
+                },
+                CommitSettings = new CommitSettings
+                {
+                    CommitMessagePrefix = string.Empty
                 }
             };
         }

--- a/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
+++ b/NuKeeper.Tests/Engine/RepositoryUpdaterTests.cs
@@ -152,7 +152,7 @@ namespace NuKeeper.Tests.Engine
 
             var filteredUpdates = updates.Skip(existingCommitsPerBranch).ToList().AsReadOnly();
 
-            existingCommitFilder.Filter(Arg.Any<IGitDriver>(), Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(), Arg.Any<string>(), Arg.Any<string>()).Returns(filteredUpdates);
+            existingCommitFilder.Filter(Arg.Any<IGitDriver>(), Arg.Any<IReadOnlyCollection<PackageUpdateSet>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(filteredUpdates);
 
             var settings = MakeSettings(consolidateUpdates);
 
@@ -358,6 +358,10 @@ namespace NuKeeper.Tests.Engine
                 {
                     MaxPackageUpdates = 3,
                     MinimumAge = new TimeSpan(7, 0, 0, 0),
+                },
+                CommitSettings = new CommitSettings
+                {
+                    CommitMessagePrefix = string.Empty
                 }
             };
         }

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -81,6 +81,10 @@ namespace NuKeeper.Commands
             Description = "Template used for creating the branch name.")]
         public string BranchNameTemplate { get; set; }
 
+        [Option(CommandOptionType.SingleValue, ShortName = "", LongName = "commitmessageprefix",
+            Description = "Prefix used for the package update commit messages, e. g. an issue number")]
+        public string CommitMessagePrefix { get; set; }
+
         [Option(CommandOptionType.SingleValue, ShortName = "git", LongName = "gitclipath",
             Description = "Path to git to use instead of lib2gitsharp implementation")]
         public string GitCliPath { get; set; }
@@ -131,6 +135,7 @@ namespace NuKeeper.Commands
             var allowedChange = Concat.FirstValue(AllowedChange, fileSettings.Change, VersionChange.Major);
             var usePrerelease = Concat.FirstValue(UsePrerelease, fileSettings.UsePrerelease, Abstractions.Configuration.UsePrerelease.FromPrerelease);
             var branchNameTemplate = Concat.FirstValue(BranchNameTemplate, fileSettings.BranchNameTemplate);
+            var commitMessagePrefix = Concat.FirstValue(CommitMessagePrefix, fileSettings.CommitMessagePrefix);
             var gitpath = Concat.FirstValue(GitCliPath, fileSettings.GitCliPath);
 
             var settings = new SettingsContainer
@@ -147,6 +152,10 @@ namespace NuKeeper.Commands
                 BranchSettings = new BranchSettings
                 {
                     BranchNameTemplate = branchNameTemplate
+                },
+                CommitSettings = new CommitSettings
+                {
+                    CommitMessagePrefix = commitMessagePrefix
                 }
             };
 

--- a/NuKeeper/Engine/DefaultCommitWorder.cs
+++ b/NuKeeper/Engine/DefaultCommitWorder.cs
@@ -34,14 +34,14 @@ namespace NuKeeper.Engine
             return $"Automatic update of {updates.SelectedId} to {updates.SelectedVersion}";
         }
 
-        public string MakeCommitMessage(PackageUpdateSet updates)
+        public string MakeCommitMessage(PackageUpdateSet updates, string commitMessagePrefix)
         {
             if (updates == null)
             {
                 throw new ArgumentNullException(nameof(updates));
             }
 
-            return $":{CommitEmoji}: {PackageTitle(updates)}";
+            return $"{commitMessagePrefix}:{CommitEmoji}: {PackageTitle(updates)}";
         }
 
         public string MakeCommitDetails(IReadOnlyCollection<PackageUpdateSet> updates)

--- a/NuKeeper/Engine/Packages/ExistingCommitFilter.cs
+++ b/NuKeeper/Engine/Packages/ExistingCommitFilter.cs
@@ -20,7 +20,7 @@ namespace NuKeeper.Engine.Packages
             _logger = logger;
         }
 
-        public async Task<IReadOnlyCollection<PackageUpdateSet>> Filter(IGitDriver git, IReadOnlyCollection<PackageUpdateSet> updates, string baseBranch, string headBranch)
+        public async Task<IReadOnlyCollection<PackageUpdateSet>> Filter(IGitDriver git, IReadOnlyCollection<PackageUpdateSet> updates, string baseBranch, string headBranch, string commitMessagePrefix)
         {
             if (git == null)
             {
@@ -41,7 +41,7 @@ namespace NuKeeper.Engine.Packages
 
                 foreach (var update in updates)
                 {
-                    var updateCommitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(update);
+                    var updateCommitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(update, commitMessagePrefix);
                     var compactUpdateCommitMessage = new string(updateCommitMessage.Where(c => !char.IsWhiteSpace(c)).ToArray());
 
                     if (!compactCommitMessages.Contains(compactUpdateCommitMessage))

--- a/NuKeeper/Engine/Packages/IExistingCommitFilter.cs
+++ b/NuKeeper/Engine/Packages/IExistingCommitFilter.cs
@@ -11,6 +11,7 @@ namespace NuKeeper.Engine.Packages
             IGitDriver git,
             IReadOnlyCollection<PackageUpdateSet> updates,
             string baseBranch,
-            string headBranch);
+            string headBranch,
+            string commitMessagePrefix);
     }
 }

--- a/NuKeeper/Engine/Packages/PackageUpdater.cs
+++ b/NuKeeper/Engine/Packages/PackageUpdater.cs
@@ -112,18 +112,18 @@ namespace NuKeeper.Engine.Packages
                 await git.CheckoutRemoteToLocal(branchWithChanges);
             }
 
-            var filteredUpdates = await _existingCommitFilter.Filter(git, updates, repository.DefaultBranch, branchWithChanges);
+            var filteredUpdates = await _existingCommitFilter.Filter(git, updates, repository.DefaultBranch, branchWithChanges, settings.CommitSettings.CommitMessagePrefix);
 
             foreach (var filtered in updates.Where(u => !filteredUpdates.Contains(u)))
             {
-                var commitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(filtered);
+                var commitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(filtered, settings.CommitSettings.CommitMessagePrefix);
                 _logger.Normal($"Commit '{commitMessage}' already in branch '{branchWithChanges}'");
             }
 
             var haveUpdates = filteredUpdates.Any();
             foreach (var updateSet in filteredUpdates)
             {
-                var commitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(updateSet);
+                var commitMessage = _collaborationFactory.CommitWorder.MakeCommitMessage(updateSet, settings.CommitSettings.CommitMessagePrefix);
 
                 await _updateRunner.Update(updateSet, sources);
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsCommitWorderTests.cs
@@ -45,11 +45,11 @@ namespace NuKeeper.AzureDevOps.Tests
         {
             var updates = PackageUpdates.For(MakePackageForV110());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo($"{CommitEmoji} Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo($"someprefix: {CommitEmoji} Automatic update of foo.bar to 1.2.3"));
         }
 
         [Test]
@@ -57,11 +57,11 @@ namespace NuKeeper.AzureDevOps.Tests
         {
             var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV100());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo($"{CommitEmoji} Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo($"someprefix: {CommitEmoji} Automatic update of foo.bar to 1.2.3"));
         }
 
         [Test]
@@ -69,11 +69,11 @@ namespace NuKeeper.AzureDevOps.Tests
         {
             var updates = PackageUpdates.For(MakePackageForV110(), MakePackageForV110InProject3());
 
-            var report = _sut.MakeCommitMessage(updates);
+            var report = _sut.MakeCommitMessage(updates, "someprefix: ");
 
             Assert.That(report, Is.Not.Null);
             Assert.That(report, Is.Not.Empty);
-            Assert.That(report, Is.EqualTo($"{CommitEmoji} Automatic update of foo.bar to 1.2.3"));
+            Assert.That(report, Is.EqualTo($"someprefix: {CommitEmoji} Automatic update of foo.bar to 1.2.3"));
         }
 
         [Test]


### PR DESCRIPTION
adds feature #1146 
documentation needs to be added.

### :memo: Links to relevant issues/docs
#1146 

### :thinking: Checklist before submitting

- [ x ] All projects build
- [ ] Relevant documentation was updated 
