### PR TITLE
Enable all *.props and *.targets file patterns, when inspecting or updating directory.

### DIFF
--- a/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/DirectoryBuildTargetsReader.cs
@@ -38,7 +38,7 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
         public IReadOnlyCollection<string> GetFilePatterns()
         {
-            return new[] { "Directory.Build.props", "Directory.Packages.props", "Directory.Build.targets", "Packages.props" };
+            return new[] { "*.props", "*.targets" };
         }
 
         public IReadOnlyCollection<PackageInProject> Read(Stream fileContents, PackagePath path)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
New feature.
All files with extensions "*.props" and "*.targets" are read, when inspecting or updating a directory.

I have a lot of files like "Directory.Build.props" and "Directory.Build.targets" in my repository. These files manage the package references (versions) for different customers. These files are currently not taken into account, because the method "DirectoryBuildTargetsReader.GetFilePatterns()" only provides fixed file names and no file extensions, like "ProjectFileReader.GetFilePatterns()" does.

### :arrow_heading_down: What is the current behavior?
Only "Directory.Build.props", "Directory.Packages.props", "Directory.Build.targets" and "Packages.props" are read, when inspecting or updating a directory.

### :new: What is the new behavior (if this is a feature change)?
Now all files with extensions "*.props" and "*.targets" are read, when inspecting or updating a directory.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Relevant documentation was updated 
