### PR TITLE
Add support for .NET 6 projects with Docker image

### DIFF
--- a/CodeAnalysisRules.ruleset
+++ b/CodeAnalysisRules.ruleset
@@ -2,6 +2,7 @@
 <RuleSet Name="CodeProjects" Description="Code analysis rules for NuKeeper Code." ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1303" Action="None" />
+	<Rule Id="CA1305" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
   </Rules>

--- a/Docker/SDK6.0/Dockerfile
+++ b/Docker/SDK6.0/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
+ARG NUKEEPER_VERSION=0.35.0
+RUN dotnet tool install --global NuKeeper --version $NUKEEPER_VERSION
+ENV PATH="${PATH}:/root/.dotnet/tools"
+ENTRYPOINT ["nukeeper"]

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
The Docker image does not support .NET 6 projects

### :new: What is the new behavior (if this is a feature change)?
The Docker image now supports .NET 6 projects

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. Create a .NET 6 C# project with an oudated NuGet package.
2. Build a Docker image using the new Dockerfile in Docker/SDK6.0
3. Use the newly built Docker image to update the outdated NuGet package in the .NET 6 C# project created in step 1

### :memo: Links to relevant issues/docs
Resolves #1156 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Relevant documentation was updated 
